### PR TITLE
BUILD.md typo and formatting fix

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -50,7 +50,7 @@ mage build:binaries
 mage build:binariesDocker
 ```
 ## Building parts of the application manually
-Bellow steps can be used to build the app without mage and build scripts.
+Below steps can be used to build the app without mage and build scripts.
 ### Dependencies
 #### Compile time
 - Go 1.20+
@@ -230,7 +230,7 @@ The pushing can be done with:
 docker push <registry>/<image>[:tag]
 ```
 ### Idempotent docker builds
-By default, mage targets will always pull docker images from the registry. If bellow entry is present in `.env` file, images will be pulled only if they are not present on the host system:
+By default, mage targets will always pull docker images from the registry. If below entry is present in `.env` file, images will be pulled only if they are not present on the host system:
 ```
 IDEMPOTENT_DOCKER=1
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -177,21 +177,26 @@ And to run a single test:
 ### Test credentials for QA tests
 Login credentials are required in order to run the QA tests. They are configured in the `.env` file in the form of authentication tokens and usernames. Tokens can be generated from the [nordvpn account dashboard](https://my.nordaccount.com/dashboard/nordvpn/). Usernames are used only for logging purposes, so in reality they can be configured to anything meaningful.
 
-`.env` file tokens:
+#### `.env` file tokens:
+
 Default account is used as a local peer in login, fileshare and meshnet tests.
 * `DEFAULT_LOGIN_USERNAME`
 * `DEFAULT_LOGIN_TOKEN`
+  
 QA peer is used as a remote peer used in meshnet tests(check out [qa peer README](ci/docker/qa-peer/README.md) for details):
 * `QA_PEER_USERNAME`
 * `QA_PEER_TOKEN`
+  
 Valid account is an account used in login tests. It has to be different than default account.
 * `VALID_LOGIN_USERNAME`
 * `VALID_LOGIN_TOKEN`
-#xpired account is an account whose subscription has expired. Used in login tests. Currently the tests are disabled, so this token does not need to be configured.
+  
+Expired account is an account whose subscription has expired. Used in login tests. Currently the tests are disabled, so this token does not need to be configured.
 * `EXPIRED_LOGIN_USERNAME`
 * `EXPIRED_LOGIN_TOKEN`
+
 ### Note about meshnet tests
-In case of meshnet tests(`test_meshnet.py`), two nordvpn account might be required(`QA_PEER` and `DEFAULT`). Meshnet functionality does not require a subscription, so a secondary free account can be used in this case.
+In case of meshnet tests(`test_meshnet.py`), two NordVPN accounts might be required(`QA_PEER` and `DEFAULT`). Meshnet functionality does not require a subscription, so a secondary free account can be used in this case.
 ## Running unit tests
 You can run unit tests for a single package as you would run uts for any other go project, for example:
 ```


### PR DESCRIPTION
I found a few typos and formatting issues with the BUILD.md documentation file:

- Fixed cases where `bellow` was used instead of `below`
- Fixed formatting for the `.env` file tokens section