### PR TITLE
Don't run gitlab CI on pushes to main

### DIFF
--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [labeled]
   push:
+    branches-ignore: 
+      - 'main'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 permissions: {}
 jobs:
   trigger-gitlab-pipeline:


### PR DESCRIPTION
CI is run on PR's and we do not want it running on pushes to main at the moment.