### PR TITLE
Fix daemon crash when groups list is empty

### DIFF
--- a/cli/cli_groups.go
+++ b/cli/cli_groups.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -25,7 +24,7 @@ func (c *cmd) Groups(ctx *cli.Context) error {
 	}
 
 	if resp.Type != internal.CodeSuccess {
-		return formatError(errors.New(MsgGroupsListIsEmpty))
+		return formatError(fmt.Errorf(MsgListIsEmpty, "server groups"))
 	}
 
 	groupList, err := internal.Columns(resp.Data)

--- a/cli/cli_groups.go
+++ b/cli/cli_groups.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -21,6 +22,10 @@ func (c *cmd) Groups(ctx *cli.Context) error {
 	})
 	if err != nil {
 		return formatError(err)
+	}
+
+	if resp.Type != internal.CodeSuccess {
+		return formatError(errors.New(MsgGroupsListIsEmpty))
 	}
 
 	groupList, err := internal.Columns(resp.Data)

--- a/cli/messages.go
+++ b/cli/messages.go
@@ -111,7 +111,7 @@ Example: nordvpn set %s on`
 	CheckYourInternetConnMessage = "Please check your internet connection and try again."
 	ExpiredAccountMessage        = "Your account has expired. Renew your subscription now to continue enjoying the ultimate privacy and security with NordVPN."
 	NoSuchCommand                = "Command '%s' doesn't exist."
-	MsgGroupsListIsEmpty         = "TODO: Groups list not available"
+	MsgListIsEmpty               = "We couldn’t load the list of %s. Please try again later."
 
 	// Meshnet
 	MsgSetMeshnetUsage       = "Enables or disables Meshnet on this device."

--- a/cli/messages.go
+++ b/cli/messages.go
@@ -111,6 +111,7 @@ Example: nordvpn set %s on`
 	CheckYourInternetConnMessage = "Please check your internet connection and try again."
 	ExpiredAccountMessage        = "Your account has expired. Renew your subscription now to continue enjoying the ultimate privacy and security with NordVPN."
 	NoSuchCommand                = "Command '%s' doesn't exist."
+	MsgGroupsListIsEmpty         = "TODO: Groups list not available"
 
 	// Meshnet
 	MsgSetMeshnetUsage       = "Enables or disables Meshnet on this device."

--- a/daemon/rpc_groups.go
+++ b/daemon/rpc_groups.go
@@ -13,12 +13,30 @@ import (
 // Groups provides endpoint and autocompletion.
 func (r *RPC) Groups(ctx context.Context, in *pb.GroupsRequest) (*pb.Payload, error) {
 	var cfg config.Config
+	if r.cm == nil || r.dm == nil {
+		log.Println(internal.ErrorPrefix, "configuration Manager or DataManager is nil")
+		return &pb.Payload{
+			Type: internal.CodeEmptyPayloadError,
+		}, nil
+	}
+
 	if err := r.cm.Load(&cfg); err != nil {
 		log.Println(internal.ErrorPrefix, err)
+		return &pb.Payload{
+			Type: internal.CodeConfigError,
+		}, nil
+	}
+
+	groups := r.dm.GetAppData().GroupNames[in.GetObfuscate()][cfg.AutoConnectData.Protocol]
+	if groups == nil {
+		log.Println(internal.ErrorPrefix, "groups list are nil")
+		return &pb.Payload{
+			Type: internal.CodeEmptyPayloadError,
+		}, nil
 	}
 
 	var groupNames []string
-	for group := range r.dm.GetAppData().GroupNames[in.GetObfuscate()][cfg.AutoConnectData.Protocol].Iter() {
+	for group := range groups.Iter() {
 		groupNames = append(groupNames, group.(string))
 	}
 

--- a/daemon/rpc_groups.go
+++ b/daemon/rpc_groups.go
@@ -13,13 +13,6 @@ import (
 // Groups provides endpoint and autocompletion.
 func (r *RPC) Groups(ctx context.Context, in *pb.GroupsRequest) (*pb.Payload, error) {
 	var cfg config.Config
-	if r.cm == nil || r.dm == nil {
-		log.Println(internal.ErrorPrefix, "configuration Manager or DataManager is nil")
-		return &pb.Payload{
-			Type: internal.CodeEmptyPayloadError,
-		}, nil
-	}
-
 	if err := r.cm.Load(&cfg); err != nil {
 		log.Println(internal.ErrorPrefix, err)
 		return &pb.Payload{
@@ -27,22 +20,20 @@ func (r *RPC) Groups(ctx context.Context, in *pb.GroupsRequest) (*pb.Payload, er
 		}, nil
 	}
 
-	groups := r.dm.GetAppData().GroupNames[in.GetObfuscate()][cfg.AutoConnectData.Protocol]
-	if groups == nil {
-		log.Println(internal.ErrorPrefix, "groups list are nil")
+	if groups, ok := r.dm.GetAppData().GroupNames[in.GetObfuscate()][cfg.AutoConnectData.Protocol]; ok {
+		var groupNames []string
+		for group := range groups.Iter() {
+			groupNames = append(groupNames, group.(string))
+		}
+
+		sort.Strings(groupNames)
 		return &pb.Payload{
-			Type: internal.CodeEmptyPayloadError,
+			Type: internal.CodeSuccess,
+			Data: groupNames,
 		}, nil
 	}
-
-	var groupNames []string
-	for group := range groups.Iter() {
-		groupNames = append(groupNames, group.(string))
-	}
-
-	sort.Strings(groupNames)
+	log.Println(internal.ErrorPrefix, "group list is empty")
 	return &pb.Payload{
-		Type: internal.CodeSuccess,
-		Data: groupNames,
+		Type: internal.CodeEmptyPayloadError,
 	}, nil
 }

--- a/daemon/rpc_groups_test.go
+++ b/daemon/rpc_groups_test.go
@@ -26,18 +26,6 @@ func TestRPCGroups(t *testing.T) {
 		statusCode int64
 	}{
 		{
-			name:       "DataManager and config.Manager are nil",
-			dm:         nil,
-			cm:         nil,
-			statusCode: internal.CodeEmptyPayloadError,
-		},
-		{
-			name:       "DataManager is nil",
-			dm:         nil,
-			cm:         newMockConfigManager(),
-			statusCode: internal.CodeEmptyPayloadError,
-		},
-		{
 			name:       "missing configuration file",
 			dm:         testNewDataManager(),
 			cm:         failingConfigManager{},

--- a/daemon/rpc_groups_test.go
+++ b/daemon/rpc_groups_test.go
@@ -15,34 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func configureRPC(dm *DataManager, cm config.Manager) *RPC {
-	return &RPC{
-		ac:        &workingLoginChecker{},
-		cm:        cm,
-		dm:        dm,
-		fileshare: service.NoopFileshare{},
-		netw:      &networker.Mock{},
-		ncClient:  mockNC{},
-		publisher: &subs.Subject[string]{},
-		api:       mockApi{},
-	}
-}
-
-func setupTest(t *testing.T) {
-	category.Set(t, category.Unit)
-}
-
-func tearDown(t *testing.T) {
-	if r := recover(); r != nil {
-		t.Error("The app crashed")
-	}
-
-	testsCleanup()
-}
-
 func TestRPCGroups(t *testing.T) {
-	setupTest(t)
-	defer tearDown(t)
+	category.Set(t, category.Unit)
+	defer testsCleanup()
 
 	tests := []struct {
 		name       string
@@ -78,7 +53,16 @@ func TestRPCGroups(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rpc := configureRPC(test.dm, test.cm)
+			rpc := RPC{
+				ac:        &workingLoginChecker{},
+				cm:        test.cm,
+				dm:        test.dm,
+				fileshare: service.NoopFileshare{},
+				netw:      &networker.Mock{},
+				ncClient:  mockNC{},
+				publisher: &subs.Subject[string]{},
+				api:       mockApi{},
+			}
 			payload, _ := rpc.Groups(context.Background(), &pb.GroupsRequest{})
 
 			assert.Equal(t, test.statusCode, payload.Type)
@@ -87,8 +71,8 @@ func TestRPCGroups(t *testing.T) {
 }
 
 func TestRPCGroups_Successful(t *testing.T) {
-	setupTest(t)
-	defer tearDown(t)
+	category.Set(t, category.Unit)
+	defer testsCleanup()
 
 	dm := testNewDataManager()
 
@@ -103,7 +87,16 @@ func TestRPCGroups_Successful(t *testing.T) {
 	cm := newMockConfigManager()
 	cm.c.AutoConnectData.Protocol = config.Protocol_TCP
 
-	rpc := configureRPC(dm, cm)
+	rpc := RPC{
+		ac:        &workingLoginChecker{},
+		cm:        cm,
+		dm:        dm,
+		fileshare: service.NoopFileshare{},
+		netw:      &networker.Mock{},
+		ncClient:  mockNC{},
+		publisher: &subs.Subject[string]{},
+		api:       mockApi{},
+	}
 
 	groupsRequest := &pb.GroupsRequest{}
 	groupsRequest.Obfuscate = false

--- a/daemon/rpc_groups_test.go
+++ b/daemon/rpc_groups_test.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/events/subs"
+	"github.com/NordSecurity/nordvpn-linux/fileshare/service"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock/networker"
+	mapset "github.com/deckarep/golang-set"
+	"github.com/stretchr/testify/assert"
+)
+
+func configureRPC(dm *DataManager, cm config.Manager) *RPC {
+	return &RPC{
+		ac:        &workingLoginChecker{},
+		cm:        cm,
+		dm:        dm,
+		fileshare: service.NoopFileshare{},
+		netw:      &networker.Mock{},
+		ncClient:  mockNC{},
+		publisher: &subs.Subject[string]{},
+		api:       mockApi{},
+	}
+}
+
+func setupTest(t *testing.T) {
+	category.Set(t, category.Unit)
+}
+
+func tearDown(t *testing.T) {
+	if r := recover(); r != nil {
+		t.Error("The app crashed")
+	}
+
+	testsCleanup()
+}
+
+func TestRPCGroups(t *testing.T) {
+	setupTest(t)
+	defer tearDown(t)
+
+	tests := []struct {
+		name       string
+		dm         *DataManager
+		cm         config.Manager
+		statusCode int64
+	}{
+		{
+			name:       "DataManager and config.Manager are nil",
+			dm:         nil,
+			cm:         nil,
+			statusCode: internal.CodeEmptyPayloadError,
+		},
+		{
+			name:       "DataManager is nil",
+			dm:         nil,
+			cm:         newMockConfigManager(),
+			statusCode: internal.CodeEmptyPayloadError,
+		},
+		{
+			name:       "missing configuration file",
+			dm:         testNewDataManager(),
+			cm:         failingConfigManager{},
+			statusCode: internal.CodeConfigError,
+		},
+		{
+			name:       "app data is empty",
+			dm:         testNewDataManager(),
+			cm:         newMockConfigManager(),
+			statusCode: internal.CodeEmptyPayloadError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rpc := configureRPC(test.dm, test.cm)
+			payload, _ := rpc.Groups(context.Background(), &pb.GroupsRequest{})
+
+			assert.Equal(t, test.statusCode, payload.Type)
+		})
+	}
+}
+
+func TestRPCGroups_Successful(t *testing.T) {
+	setupTest(t)
+	defer tearDown(t)
+
+	dm := testNewDataManager()
+
+	groupNames := map[bool]map[config.Protocol]mapset.Set{
+		false: {
+			config.Protocol_UDP: mapset.NewSet("false_Protocol_UDP"),
+			config.Protocol_TCP: mapset.NewSet("false_Protocol_TCP"),
+		},
+	}
+	dm.SetAppData(nil, nil, groupNames)
+
+	cm := newMockConfigManager()
+	cm.c.AutoConnectData.Protocol = config.Protocol_TCP
+
+	rpc := configureRPC(dm, cm)
+
+	groupsRequest := &pb.GroupsRequest{}
+	groupsRequest.Obfuscate = false
+
+	payload, _ := rpc.Groups(context.Background(), groupsRequest)
+	assert.Equal(t, internal.CodeSuccess, payload.GetType())
+	assert.Equal(t, []string{"false_Protocol_TCP"}, payload.GetData())
+}


### PR DESCRIPTION
When groups list is nil, return an error message to let the use know that the list is being fetched.