### PR TITLE
Improve error messages for cities command

### DIFF
--- a/cli/cli_cities.go
+++ b/cli/cli_cities.go
@@ -39,6 +39,12 @@ func (c *cmd) Cities(ctx *cli.Context) error {
 		return formatError(err)
 	}
 
+	if resp.Type != internal.CodeSuccess {
+		err := fmt.Errorf(MsgListIsEmpty, "cities")
+		log.Println(internal.ErrorPrefix, err)
+		return formatError(err)
+	}
+
 	if len(resp.Data) == 0 {
 		return formatError(errors.New(CitiesNotFoundError))
 	}

--- a/cli/cli_cities_test.go
+++ b/cli/cli_cities_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/client/config"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func TestCitiesList(t *testing.T) {
+	category.Set(t, category.Unit)
+	mockClient := mockDaemonClient{}
+	c := cmd{&mockClient, nil, nil, "", nil, config.Config{}, nil}
+
+	tests := []struct {
+		name          string
+		cities        []string
+		country       string
+		expected      string
+		expectedError error
+	}{
+		{
+			name:          "missing country name",
+			expectedError: formatError(fmt.Errorf("The command you entered is not valid. Enter 'cli.test  --help' to see the options.")),
+		},
+		{
+			name:          "no cities data",
+			country:       "France",
+			expectedError: formatError(fmt.Errorf("We couldn’t load the list of cities. Please try again later.")),
+		},
+		{
+			name:     "cities list",
+			country:  "France",
+			expected: "Marseille, Paris",
+			cities:   []string{"Marseille", "Paris"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := cli.NewApp()
+			set := flag.NewFlagSet("test", 0)
+			if test.country != "" {
+				set.Parse([]string{test.country})
+			}
+			mockClient.cities = test.cities
+			ctx := cli.NewContext(app, set, &cli.Context{Context: context.Background()})
+
+			result, err := captureOutput(func() {
+				err := c.Cities(ctx)
+				assert.Equal(t, test.expectedError, err)
+			})
+			assert.Nil(t, err)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
When cities list is empty because nothing is cached or failed to fetch it from API, report to the user the message `We couldn’t load the list of cities. Please try again later.`