### PR TITLE
Add a note that bug bounty only applies to nordsec owned repos

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,5 @@ Once a new minor version comes out, the oldest one is removed from the repositor
 ## Reporting a security vulnerability
 
 See https://hackerone.com/nordsecurity?type=team for how to report a vulnerability.
+Findings apply only to the Nord Security owned repositories.
+Forks are not included.


### PR DESCRIPTION
In a lot of forks now there is a nordsecurity bug bounty links in SECURITY.md file, therefore adding a note for future forks to have that bug bounty is only applicable if the vulnerability being reported is present in code repositories owned by NordSecurity as well.