### PR TITLE
Update message that the device needs to be rebooted after install

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -935,7 +935,7 @@ func (c *cmd) action(err error, f func(*cli.Context) error, daemonURL string, la
 				os.Exit(1)
 			case internal.ErrSocketAccessDenied:
 				color.Red(formatError(internal.ErrSocketAccessDenied).Error())
-				color.Red("Run 'usermod -aG nordvpn $USER' to fix this issue and log out of OS afterwards for this to take an effect.")
+				color.Red("Run 'usermod -aG nordvpn $USER' to fix this issue and reboot your device afterwards for this to take an effect.")
 				os.Exit(1)
 			case internal.ErrDaemonConnectionRefused:
 				color.Red(formatError(internal.ErrDaemonConnectionRefused).Error())

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -935,7 +935,7 @@ func (c *cmd) action(err error, f func(*cli.Context) error, daemonURL string, la
 				os.Exit(1)
 			case internal.ErrSocketAccessDenied:
 				color.Red(formatError(internal.ErrSocketAccessDenied).Error())
-				color.Red("Run 'usermod -aG nordvpn $USER' to fix this issue and reboot your device afterwards for this to take an effect.")
+				color.Red("Run 'sudo usermod -aG nordvpn $USER' to fix this issue and reboot your device afterwards for this to take an effect.")
 				os.Exit(1)
 			case internal.ErrDaemonConnectionRefused:
 				color.Red(formatError(internal.ErrDaemonConnectionRefused).Error())


### PR DESCRIPTION
The device needs to be rebooted after installing nordvpn, otherwise there are problems with `systemd --user`.
Update error message to let the user know that the machine needs to be rebooted instead of just logging out