### PR TITLE
Fix VPN disconnected after set meshnet off

### DIFF
--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -261,6 +261,7 @@ func (*meshNetworker) Refresh(mesh.MachineMap) error                          { 
 func (*meshNetworker) StatusMap() (map[string]string, error) {
 	return map[string]string{}, nil
 }
+func (*meshNetworker) LastServerName() string { return "" }
 
 func TestStartAutoMeshnet(t *testing.T) {
 	category.Set(t, category.Unit)

--- a/meshnet/networker.go
+++ b/meshnet/networker.go
@@ -34,6 +34,7 @@ type Networker interface {
 	// changed, peers is the map of all the machine peers(including the changed peer).
 	ResetRouting(changedPeer mesh.MachinePeer, peers mesh.MachinePeers) error
 	StatusMap() (map[string]string, error)
+	LastServerName() string
 	Start(
 		vpn.Credentials,
 		vpn.ServerData,

--- a/meshnet/server_test.go
+++ b/meshnet/server_test.go
@@ -97,6 +97,7 @@ func (*workingNetworker) Refresh(mesh.MachineMap) error    { return nil }
 func (*workingNetworker) StatusMap() (map[string]string, error) {
 	return map[string]string{}, nil
 }
+func (*workingNetworker) LastServerName() string { return "" }
 
 type invitationsAPI struct{}
 

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -1,4 +1,4 @@
-from lib import daemon, info, logging, login, meshnet, ssh
+from lib import daemon, info, logging, login, meshnet, network, ssh
 import lib
 import sh
 import requests
@@ -275,6 +275,19 @@ def test_lan_discovery_exitnode(lan_discovery: bool, local: bool):
             if result:
                 break
         assert result, message
+
+
+def test_connect_set_mesh_off():
+    output = f"{sh.nordvpn.mesh.peer.list(_tty_out=False)}"
+    peer = meshnet.get_peers(output)[0]
+    sh.nordvpn.mesh.peer.connect(peer)
+    sh.nordvpn.disconnect()
+    sh.nordvpn.connect()
+    sh.nordvpn.set.mesh.off()
+
+    with lib.Defer(sh.nordvpn.set.mesh.on):
+        with lib.Defer(sh.nordvpn.disconnect):
+            assert network.is_connected()
 
 
 def test_remove_peer_firewall_update():


### PR DESCRIPTION
When connecting to a Meshnet peer as an VPN exit, the Meshnet server `s.isPeerConnected` variable was set to `true`. Then this variable was being used during Meshnet disable (`nordvpn set mesh off`) to determine whether we are connected to a Meshnet peer to stop that connection along with Meshnet disable.

However, user can in the meantime connect to a regular VPN server (and thus disconnect from a Meshnet peer). The `s.isPeerConnected` variable was not updated, so Meshnet disabling was resulting in regular VPN disconnect in such case.

The fix is to not use `s.isPeerConnected` variable to remember if we had connected to Meshnet peer, but to check during Meshnet disable the address of currently connected VPN and stop connection only if address indicates that we are connected to a Meshnet peer.