### PR TITLE
Use cached data for remote config when fetching fails

### DIFF
--- a/config/remote/firebase.go
+++ b/config/remote/firebase.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/coreos/go-semver/semver"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -66,27 +67,16 @@ func (rc *RConfig) fetchRemoteConfigIfTime() error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
+	// don't fetch the remote config too often even if there is nothing cached
 	if time.Now().After(cfg.RCLastUpdate.Add(rc.updatePeriod)) {
-		remoteConfigValue, err := rc.remoteService.FetchRemoteConfig()
-		if err != nil {
-			return err
-		}
-		err = json.Unmarshal(remoteConfigValue, rc.config)
-		if err != nil {
-			return err
-		}
-		if err := rc.configManager.SaveWith(func(c config.Config) config.Config {
-			s, err := json.Marshal(rc.config)
-			if err == nil {
-				c.RemoteConfig = string(s)
-				c.RCLastUpdate = time.Now()
+		if err := rc.fetchAndSaveRemoteConfig(cfg); err != nil {
+			// if there no is cached config return error
+			// otherwise use the cached data
+			if cfg.RemoteConfig == "" {
+				return err
+			} else {
+				log.Println(internal.ErrorPrefix, "use cached config because fetch failed:", err)
 			}
-			return c
-		}); err != nil {
-			return err
-		}
-		if err := rc.configManager.Load(&cfg); err != nil {
-			return fmt.Errorf("reloading config: %w", err)
 		}
 	}
 
@@ -101,18 +91,52 @@ func (rc *RConfig) fetchRemoteConfigIfTime() error {
 	return nil
 }
 
-// GetValue provides value of requested key from remote config
-func (rc *RConfig) GetValue(cfgKey string) (string, error) {
-	if err := rc.fetchRemoteConfigIfTime(); err != nil {
-		return "", err
+func (rc *RConfig) fetchAndSaveRemoteConfig(cfg config.Config) error {
+	remoteConfigValue, err := rc.remoteService.FetchRemoteConfig()
+	if err != nil {
+		return fmt.Errorf("fetching the remote config failed: %w", err)
+	}
+	err = json.Unmarshal(remoteConfigValue, rc.config)
+	if err != nil {
+		return fmt.Errorf("parsing the fetched remote config failed: %w", err)
+	}
+	if err := rc.configManager.SaveWith(func(c config.Config) config.Config {
+		s, err := json.Marshal(rc.config)
+		if err == nil {
+			c.RemoteConfig = string(s)
+			c.RCLastUpdate = time.Now()
+		} else {
+			log.Println(internal.ErrorPrefix, "cannot encode the new remote config:", err)
+		}
+		return c
+	}); err != nil {
+		return fmt.Errorf("failed to save the new remote config: %w", err)
+	}
+	if err := rc.configManager.Load(&cfg); err != nil {
+		return fmt.Errorf("reloading config: %w", err)
 	}
 
+	return nil
+}
+
+// GetValue provides value of requested key from remote config
+func (rc *RConfig) GetValue(cfgKey string) (string, error) {
+	err := rc.fetchRemoteConfigIfTime()
+	if err != nil {
+		log.Println(internal.WarningPrefix, "using cached config:", err)
+	}
+	// if fetching new config fails, use the cached info
 	configParam := rc.config.Parameters
 	for key, val := range configParam {
 		if key == cfgKey {
 			return val.DefaultValue.Value, nil
 		}
 	}
+	if err != nil {
+		// when not found return the original error from fetch
+		return "", err
+	}
+
 	return "", fmt.Errorf("key %s does not exist in remote config", cfgKey)
 }
 
@@ -136,15 +160,16 @@ func stringToSemVersion(stringVersion, prefix string) (*semver.Version, error) {
 // GetTelioConfig try to find remote config field for app version
 // and load json block from that field
 func (rc *RConfig) GetTelioConfig(stringVersion string) (string, error) {
-	cfg := ""
-
 	if err := rc.fetchRemoteConfigIfTime(); err != nil {
-		return cfg, err
+		if len(rc.config.Parameters) == 0 {
+			return "", err
+		}
+		log.Println(internal.WarningPrefix, "using cached config:", err)
 	}
 
 	appVersion, err := stringToSemVersion(stringVersion, "")
 	if err != nil {
-		return cfg, err
+		return "", err
 	}
 
 	// build descending ordered version list
@@ -163,13 +188,13 @@ func (rc *RConfig) GetTelioConfig(stringVersion string) (string, error) {
 	// find exact version match or first older/lower version
 	versionField, err := findVersionField(orderedFields, appVersion)
 	if err != nil {
-		return cfg, err
+		return "", err
 	}
 	log.Println("remote config version field:", versionField)
 
 	jsonString, err := rc.GetValue(versionField)
 	if err != nil {
-		return cfg, err
+		return "", err
 	}
 
 	return jsonString, nil

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -184,7 +184,7 @@ func New(prod bool, eventPath string, fwmark uint32,
 
 		fallbackTelioConfig, err := json.Marshal(defaultTelioConfig)
 		if err != nil {
-			log.Println(internal.ErrorPrefix, "cannot encode config: ", err)
+			log.Println(internal.ErrorPrefix, "couldn't encode default telio config: ", err)
 			fallbackTelioConfig = []byte(`{"direct":{}}`)
 		}
 		cfg = fallbackTelioConfig

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -176,7 +176,18 @@ func New(prod bool, eventPath string, fwmark uint32,
 
 	cfg, err := handleTelioConfig(eventPath, deviceID, appVersion, prod, telioCfg)
 	if err != nil {
-		cfg = []byte("{}")
+		log.Println(internal.ErrorPrefix, "failed to get telio config: ", err)
+
+		defaultTelioConfig := &telioFeatures{}
+		defaultTelioConfig.Lana = &lanaConfig{Prod: prod, EventPath: eventPath}
+		defaultTelioConfig.Direct = &directConfig{}
+
+		fallbackTelioConfig, err := json.Marshal(defaultTelioConfig)
+		if err != nil {
+			log.Println(internal.ErrorPrefix, "cannot encode config: ", err)
+			fallbackTelioConfig = []byte(`{"direct":{}}`)
+		}
+		cfg = fallbackTelioConfig
 	}
 	log.Println(internal.InfoPrefix, "libtelio final config:", string(cfg))
 


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* use cached data as fallback for remote config,when fetching new data fails
* define a default config for telio that also includes direct connections, if fetching fails and there is no cached data