### PR TITLE
Do not change local obfuscation setting on technology change

### DIFF
--- a/cli/cli_set_technology.go
+++ b/cli/cli_set_technology.go
@@ -69,7 +69,6 @@ func (c *cmd) SetTechnology(ctx *cli.Context) error {
 		flag, _ := strconv.ParseBool(resp.Data[0])
 		color.Green(fmt.Sprintf(MsgSetSuccess, "Technology", strings.Join(resp.Data[1:], " ")))
 		c.config.Technology = tech
-		c.config.Obfuscate = false
 		if flag {
 			color.Yellow(SetReconnect)
 		}

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -118,3 +118,14 @@ def test_technology_set_options(tech, proto, obfuscated):
         assert ovpn_list
     else:
         assert not ovpn_list
+
+
+@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES + lib.OBFUSCATED_TECHNOLOGIES)
+def test_keep_obfuscate_setting_on_technology_switch(tech, proto, obfuscated):
+    lib.set_technology_and_protocol(tech, proto, obfuscated)
+    sh.nordvpn.set.technology('nordlynx')
+    sh.nordvpn.set.technology('openvpn')
+    if obfuscated == 'on':
+        assert "Obfuscate: {}".format('enabled') in sh.nordvpn.settings()
+    else:
+        assert "Obfuscate: {}".format('disabled') in sh.nordvpn.settings()


### PR DESCRIPTION
CLI client sets obfuscate to false on `set technology` in its own config copy, without sending a RPC to daemon to really disable it. This pull request removes changing local obfuscation settings on technology change. This means that obfuscation will remain enabled for OpenVPN when changing a technology to NordLynx. When user will change back to OpenVPN, obfuscation will be enabled.