### PR TITLE
Always include the last line into the changelog if is not empty

### DIFF
--- a/ci/data.sh
+++ b/ci/data.sh
@@ -38,7 +38,7 @@ for filename in "${files[@]}"; do
   changes:" \
     	"${entry_tag}" "$(date -d@"${entry_date}" +%Y-%m-%dT%H:%M:%SZ)" >> "${WORKDIR}"/dist/changelog.yml
 
-    while read -r line ; do
+    while read -r line || [ -n "$line" ]; do
         printf "\n   - note: |-\n      %s" "${line:1}" >> "${WORKDIR}"/dist/changelog.yml
     done < "${filename}"
 

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -170,9 +170,6 @@ func New(prod bool, eventPath string, fwmark uint32,
 	telioCfg remote.RemoteConfigGetter, deviceID, appVersion string) *Libtelio {
 	events := make(chan state)
 	logLevel := teliogo.TELIOLOGINFO
-	if prod {
-		logLevel = teliogo.TELIOLOGERROR
-	}
 
 	cfg, err := handleTelioConfig(eventPath, deviceID, appVersion, prod, telioCfg)
 	if err != nil {


### PR DESCRIPTION
When the changelog file from the `contrib/changelog/prod/*.md` didn't end with empty new line, the last line was not added to the official release.