### PR TITLE
Don't recreate tun at network changes

### DIFF
--- a/cmd/daemon/vpn_linux.go
+++ b/cmd/daemon/vpn_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"net/netip"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -44,6 +45,9 @@ func (noopMesh) Refresh(cesh.MachineMap) error   { return nil }
 func (noopMesh) Tun() tunnel.T                   { return &tunnel.Tunnel{} }
 func (noopMesh) StatusMap() (map[string]string, error) {
 	return map[string]string{}, nil
+}
+func (noopMesh) NetworkChanged() error {
+	return fmt.Errorf("not supported")
 }
 
 func meshnetImplementation(fn daemon.FactoryFunc) (meshnet.Mesh, error) {

--- a/daemon/connect_test.go
+++ b/daemon/connect_test.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"errors"
 	"net"
 	"net/netip"
 	"testing"
@@ -14,13 +13,8 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/networker"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	testnetworker "github.com/NordSecurity/nordvpn-linux/test/mock/networker"
-	"github.com/NordSecurity/nordvpn-linux/tunnel"
 
 	"github.com/stretchr/testify/assert"
-)
-
-var (
-	errOnPurpose = errors.New("on purpose")
 )
 
 type workingRouter struct{}
@@ -55,25 +49,6 @@ func (workingFirewall) Delete([]string) error     { return nil }
 func (workingFirewall) Enable() error             { return nil }
 func (workingFirewall) Disable() error            { return nil }
 func (workingFirewall) IsEnabled() bool           { return true }
-
-type workingTunnel struct{}
-
-func (workingTunnel) Interface() net.Interface { return en0Interface }
-func (workingTunnel) IPs() []netip.Addr {
-	return []netip.Addr{netip.MustParseAddr("172.105.90.114")}
-}
-
-func (workingTunnel) TransferRates() (tunnel.Statistics, error) {
-	return tunnel.Statistics{Tx: 1337, Rx: 1337}, nil
-}
-
-type failingTunnel struct{}
-
-func (failingTunnel) Interface() net.Interface { return net.Interface{} }
-func (failingTunnel) IPs() []netip.Addr        { return nil }
-func (failingTunnel) TransferRates() (tunnel.Statistics, error) {
-	return tunnel.Statistics{}, errOnPurpose
-}
 
 type UniqueAddress struct{}
 
@@ -132,14 +107,6 @@ func TestConnect(t *testing.T) {
 			assert.Equal(t, test.expected, <-channel)
 		})
 	}
-}
-
-var en0Interface = net.Interface{
-	Index:        1,
-	MTU:          5,
-	Name:         "en0",
-	HardwareAddr: []byte("00:00:5e:00:53:01"),
-	Flags:        net.FlagMulticast,
 }
 
 func TestMaskIPRouteOutput(t *testing.T) {

--- a/daemon/connect_test.go
+++ b/daemon/connect_test.go
@@ -75,32 +75,6 @@ func (failingTunnel) TransferRates() (tunnel.Statistics, error) {
 	return tunnel.Statistics{}, errOnPurpose
 }
 
-type workingVPN struct{}
-
-func (workingVPN) Start(
-	vpn.Credentials,
-	vpn.ServerData,
-) error {
-	return nil
-}
-func (workingVPN) Stop() error      { return nil }
-func (workingVPN) State() vpn.State { return vpn.ConnectedState }
-func (workingVPN) IsActive() bool   { return true }
-func (workingVPN) Tun() tunnel.T    { return workingTunnel{} }
-
-type failingVPN struct{}
-
-func (failingVPN) Start(
-	vpn.Credentials,
-	vpn.ServerData,
-) error {
-	return errOnPurpose
-}
-func (failingVPN) Stop() error      { return errOnPurpose }
-func (failingVPN) State() vpn.State { return vpn.ExitedState }
-func (failingVPN) IsActive() bool   { return false }
-func (failingVPN) Tun() tunnel.T    { return failingTunnel{} }
-
 type UniqueAddress struct{}
 
 func TestConnect(t *testing.T) {

--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/meshnet"
 	"github.com/NordSecurity/nordvpn-linux/networker"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
 	testnetworker "github.com/NordSecurity/nordvpn-linux/test/mock/networker"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -123,7 +124,7 @@ func TestStartAutoConnect(t *testing.T) {
 					&subs.Subject[int]{},
 				),
 				func(config.Technology) (vpn.VPN, error) {
-					return &workingVPN{}, nil
+					return &mock.WorkingVPN{}, nil
 				},
 				newEndpointResolverMock(netip.MustParseAddr("127.0.0.1")),
 				netw,
@@ -358,7 +359,7 @@ func TestStartAutoMeshnet(t *testing.T) {
 					&subs.Subject[int]{},
 				),
 				func(config.Technology) (vpn.VPN, error) {
-					return &workingVPN{}, nil
+					return &mock.WorkingVPN{}, nil
 				},
 				newEndpointResolverMock(netip.MustParseAddr("127.0.0.1")),
 				test.netw,

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/networker"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
 	testnetworker "github.com/NordSecurity/nordvpn-linux/test/mock/networker"
 
 	"github.com/stretchr/testify/assert"
@@ -117,7 +118,7 @@ func TestRpcConnect(t *testing.T) {
 		{
 			name: "successfull connect",
 			factory: func(config.Technology) (vpn.VPN, error) {
-				return &workingVPN{}, nil
+				return &mock.WorkingVPN{}, nil
 			},
 			netw:      &testnetworker.Mock{},
 			retriever: newGatewayMock(netip.Addr{}),
@@ -128,7 +129,7 @@ func TestRpcConnect(t *testing.T) {
 		{
 			name: "failed connect",
 			factory: func(config.Technology) (vpn.VPN, error) {
-				return &failingVPN{}, nil
+				return &mock.FailingVPN{}, nil
 			},
 			netw:      testnetworker.Failing{},
 			retriever: newGatewayMock(netip.Addr{}),
@@ -139,7 +140,7 @@ func TestRpcConnect(t *testing.T) {
 		{
 			name: "VPN expired",
 			factory: func(config.Technology) (vpn.VPN, error) {
-				return &workingVPN{}, nil
+				return &mock.WorkingVPN{}, nil
 			},
 			netw:      &testnetworker.Mock{},
 			retriever: newGatewayMock(netip.Addr{}),
@@ -150,7 +151,7 @@ func TestRpcConnect(t *testing.T) {
 		{
 			name: "VPN expiration check fails",
 			factory: func(config.Technology) (vpn.VPN, error) {
-				return &workingVPN{}, nil
+				return &mock.WorkingVPN{}, nil
 			},
 			netw:      &testnetworker.Mock{},
 			retriever: newGatewayMock(netip.Addr{}),
@@ -235,10 +236,10 @@ func TestRpcReconnect(t *testing.T) {
 	factory := func(config.Technology) (vpn.VPN, error) {
 		if fail {
 			fail = false
-			return &failingVPN{}, nil
+			return &mock.FailingVPN{}, nil
 		}
 		fail = true
-		return &workingVPN{}, nil
+		return &mock.WorkingVPN{}, nil
 	}
 
 	cm := newMockConfigManager()

--- a/daemon/vpn/nordlynx/kernel_space.go
+++ b/daemon/vpn/nordlynx/kernel_space.go
@@ -149,6 +149,10 @@ func (k *KernelSpace) stop() error {
 	return nil
 }
 
+func (k *KernelSpace) NetworkChanged() error {
+	return fmt.Errorf("not supported")
+}
+
 func pushConfig(iface net.Interface, wgconf string) error {
 	// fill temp file with generated config
 	tmp, err := internal.FileTemp(iface.Name, []byte(wgconf))

--- a/daemon/vpn/openvpn/openvpn.go
+++ b/daemon/vpn/openvpn/openvpn.go
@@ -35,7 +35,7 @@ var (
 	errServerTimeout  = errors.New("server timeout")
 	ErrServerVersion  = errors.New("invalid openvpn server version")
 	errExited         = errors.New("exited")
-	errNotSupported   = errors.New("not supported")
+	errNotImplemented = errors.New("not implemented")
 )
 
 type OpenVPN struct {
@@ -216,7 +216,7 @@ func (ovpn *OpenVPN) NetworkChanged() error {
 	// but because the servers sends different configuration at pull, then the TUN is closed + recreated
 	// https://github.com/OpenVPN/openvpn/blob/a1cb1b47b138b9f654cd0bca5de6d08dbca61888/src/openvpn/init.c#L2421
 
-	return errNotSupported
+	return errNotImplemented
 
 	// the following should be the correct implementation for it
 	// if !ovpn.IsActive() {

--- a/daemon/vpn/openvpn/openvpn.go
+++ b/daemon/vpn/openvpn/openvpn.go
@@ -35,6 +35,7 @@ var (
 	errServerTimeout  = errors.New("server timeout")
 	ErrServerVersion  = errors.New("invalid openvpn server version")
 	errExited         = errors.New("exited")
+	errNotSupported   = errors.New("not supported")
 )
 
 type OpenVPN struct {
@@ -208,6 +209,32 @@ func (ovpn *OpenVPN) stop() error {
 	ovpn.active = false
 	ovpn.state = vpn.ExitedState
 	return nil
+}
+
+func (ovpn *OpenVPN) NetworkChanged() error {
+	// application uses the flag --persist-tun and it should not close the TUN interface at restarts
+	// but because the servers sends different configuration at pull, then the TUN is closed + recreated
+	// https://github.com/OpenVPN/openvpn/blob/a1cb1b47b138b9f654cd0bca5de6d08dbca61888/src/openvpn/init.c#L2421
+
+	return errNotSupported
+
+	// the following should be the correct implementation for it
+	// if !ovpn.IsActive() {
+	// 	return nil
+	// }
+
+	// ovpn.Lock()
+	// defer ovpn.Unlock()
+
+	// if ovpn.manager != nil {
+	// 	if pid, _ := ovpn.manager.Pid(); pid != 0 {
+	// 		err := ovpn.manager.SendSignal("SIGUSR1")
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 	}
+	// }
+	// return nil
 }
 
 // IsActive checks if openvpn process is running
@@ -424,11 +451,10 @@ func vpnMonitor(reader io.ReadCloser, prefix string, inform chan struct{}) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		txt := scanner.Text()
-		fmt.Printf("debug: %s\n", txt)
 		if containsSeveral(txt, []string{cipherErr, tlsErr}) {
 			inform <- struct{}{}
 		}
-		log.Println(fmt.Sprintf("[%s] %s", prefix, txt))
+		log.Println(prefix, txt)
 	}
 }
 

--- a/daemon/vpn/vpn.go
+++ b/daemon/vpn/vpn.go
@@ -15,11 +15,7 @@ type VPN interface {
 	State() State // required because of OpenVPN
 	IsActive() bool
 	Tun() tunnel.T // required because of OpenVPN
-}
-
-// NetworkChanger allows refreshing VPN connection without the need for full start/stop.
-type NetworkChanger interface {
-	NetworkChange() error
+	NetworkChanged() error
 }
 
 // Credentials define a possible set of credentials required to

--- a/meshnet/mesh.go
+++ b/meshnet/mesh.go
@@ -25,7 +25,7 @@ type Mesh interface {
 	// StatusMap retrieves the current status map for the related
 	// meshnet peers
 	StatusMap() (map[string]string, error)
-	// handle network changes
+	// NetworkChanged is called at network changes
 	NetworkChanged() error
 }
 

--- a/meshnet/mesh.go
+++ b/meshnet/mesh.go
@@ -25,6 +25,8 @@ type Mesh interface {
 	// StatusMap retrieves the current status map for the related
 	// meshnet peers
 	StatusMap() (map[string]string, error)
+	// handle network changes
+	NetworkChanged() error
 }
 
 // KeyGenerator for use in meshnet.

--- a/networker/networker_test.go
+++ b/networker/networker_test.go
@@ -208,7 +208,7 @@ func (e *workingExitNode) ResetFirewall(lan bool) error { e.LanAvailable = lan; 
 
 type workingMesh struct {
 	enableErr         error
-	errNetworkChanged error
+	networkChangedErr error
 }
 
 func (w *workingMesh) Enable(netip.Addr, string) error { return w.enableErr }
@@ -219,7 +219,7 @@ func (*workingMesh) Tun() tunnel.T                     { return mock.WorkingT{} 
 func (*workingMesh) StatusMap() (map[string]string, error) {
 	return map[string]string{}, nil
 }
-func (w *workingMesh) NetworkChanged() error { return w.errNetworkChanged }
+func (w *workingMesh) NetworkChanged() error { return w.networkChangedErr }
 
 type workingHostSetter struct {
 	hosts dns.Hosts
@@ -1451,7 +1451,7 @@ func TestCombined_Reconnect(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			meshnet := &workingMesh{}
-			meshnet.errNetworkChanged = mock.ErrOnPurpose
+			meshnet.networkChangedErr = mock.ErrOnPurpose
 			netw := NewCombined(
 				nil,
 				meshnet,

--- a/networker/networker_test.go
+++ b/networker/networker_test.go
@@ -218,6 +218,7 @@ func (*workingMesh) Tun() tunnel.T                     { return mock.WorkingT{} 
 func (*workingMesh) StatusMap() (map[string]string, error) {
 	return map[string]string{}, nil
 }
+func (*workingMesh) NotifyNetworkChange() error { return nil }
 
 type workingHostSetter struct {
 	hosts dns.Hosts

--- a/networker/networker_test.go
+++ b/networker/networker_test.go
@@ -447,12 +447,12 @@ func TestCombined_TransferRates(t *testing.T) {
 	}{
 		{
 			name:     "active vpn",
-			vpn:      activeVPN{},
+			vpn:      mock.ActiveVPN{},
 			expected: tunnel.Statistics{Tx: 1337, Rx: 1337},
 		},
 		{
 			name: "inactive vpn",
-			vpn:  inactiveVPN{},
+			vpn:  mock.WorkingInactiveVPN{},
 			err:  errInactiveVPN,
 		},
 		{

--- a/networker/vpn_test.go
+++ b/networker/vpn_test.go
@@ -89,6 +89,8 @@ func TestRefreshVPN_MeshnetFailure(t *testing.T) {
 	assert.True(t, combined.isMeshnetSet)
 
 	combined.mesh.(*workingMesh).enableErr = fmt.Errorf("test error")
+	combined.mesh.(*workingMesh).errNetworkChanged = fmt.Errorf("test error")
+
 	err := combined.refreshVPN()
 	assert.Error(t, err)
 
@@ -109,10 +111,81 @@ func TestRefreshVPN_VPNFailure(t *testing.T) {
 	assert.True(t, combined.isMeshnetSet)
 
 	combined.vpnet.(*mock.WorkingVPN).StartErr = fmt.Errorf("test error")
+	combined.vpnet.(*mock.WorkingVPN).ErrNetworkChanges = fmt.Errorf("test error")
 	err := combined.refreshVPN()
 	assert.Error(t, err)
 
 	assert.False(t, combined.isConnectedToVPN())
 	assert.True(t, combined.isMeshnetSet)
 	assert.NotEmpty(t, combined.fw.(*workingFirewall).rules) // We want to keep rules to avoid leaking
+}
+
+func TestNetworkChange(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	sharedVPNAndMesh := &mock.MeshnetAndVPN{}
+	tests := []struct {
+		name string
+		vpn  *mock.MeshnetAndVPN
+		mesh *mock.MeshnetAndVPN
+	}{
+		{
+			name: "NetworkChange executes once for VPN only",
+			vpn:  &mock.MeshnetAndVPN{},
+			mesh: nil,
+		},
+		{
+			name: "For VPN+Mesh using same tunnel NetworkChanged executes once",
+			vpn:  sharedVPNAndMesh,
+			mesh: sharedVPNAndMesh,
+		},
+		{
+			name: "VPN+Mesh with different tunnels NetworkChanged executes once",
+			vpn:  &mock.MeshnetAndVPN{},
+			mesh: &mock.MeshnetAndVPN{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			combined := GetTestCombined()
+
+			combined.SetVPN(test.vpn)
+			combined.mesh = test.mesh
+
+			assert.NoError(t, combined.start(vpn.Credentials{}, vpn.ServerData{}, config.Allowlist{}, config.DNS{"1.1.1.1"}))
+			assert.True(t, combined.isNetworkSet)
+
+			if test.mesh != nil {
+				assert.NoError(t, combined.setMesh(mesh.MachineMap{}, netip.IPv4Unspecified(), ""))
+				assert.True(t, combined.isMeshnetSet)
+			}
+
+			assert.NoError(t, combined.refreshVPN())
+			assert.Equal(t, 1, test.vpn.ExecutionStats[mock.StatsNetworkChange])
+			assert.Equal(t, 1, test.vpn.ExecutionStats[mock.StatsStart])
+			assert.True(t, combined.isConnectedToVPN())
+
+			if test.mesh != nil {
+				assert.Equal(t, 1, test.vpn.ExecutionStats[mock.StatsNetworkChange])
+			}
+		})
+	}
+}
+
+func TestFallbackCaseForRefreshVPN(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	combined := GetTestCombined()
+	vpnet := combined.vpnet.(*mock.WorkingVPN)
+	assert.NoError(t, combined.start(vpn.Credentials{}, vpn.ServerData{}, config.Allowlist{}, config.DNS{"1.1.1.1"}))
+	assert.Equal(t, 1, vpnet.ExecutionStats[mock.StatsStart])
+
+	vpnet.ErrNetworkChanges = mock.ErrOnPurpose
+
+	assert.NoError(t, combined.refreshVPN())
+	assert.Equal(t, 1, vpnet.ExecutionStats[mock.StatsNetworkChange])
+	assert.Equal(t, 2, vpnet.ExecutionStats[mock.StatsStart])
+
+	assert.True(t, combined.isConnectedToVPN())
 }

--- a/networker/vpn_test.go
+++ b/networker/vpn_test.go
@@ -89,7 +89,7 @@ func TestRefreshVPN_MeshnetFailure(t *testing.T) {
 	assert.True(t, combined.isMeshnetSet)
 
 	combined.mesh.(*workingMesh).enableErr = fmt.Errorf("test error")
-	combined.mesh.(*workingMesh).errNetworkChanged = fmt.Errorf("test error")
+	combined.mesh.(*workingMesh).networkChangedErr = fmt.Errorf("test error")
 
 	err := combined.refreshVPN()
 	assert.Error(t, err)

--- a/networker/vpn_test.go
+++ b/networker/vpn_test.go
@@ -10,36 +10,9 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/mock"
-	"github.com/NordSecurity/nordvpn-linux/tunnel"
 
 	"github.com/stretchr/testify/assert"
 )
-
-type activeVPN struct{}
-
-func (activeVPN) Start(
-	vpn.Credentials,
-	vpn.ServerData,
-) error {
-	return nil
-}
-func (activeVPN) State() vpn.State { return vpn.UnknownState }
-func (activeVPN) Stop() error      { return nil }
-func (activeVPN) Tun() tunnel.T    { return mock.WorkingT{} }
-func (activeVPN) IsActive() bool   { return true }
-
-type inactiveVPN struct{}
-
-func (inactiveVPN) Start(
-	vpn.Credentials,
-	vpn.ServerData,
-) error {
-	return nil
-}
-func (inactiveVPN) State() vpn.State { return vpn.UnknownState }
-func (inactiveVPN) Stop() error      { return nil }
-func (inactiveVPN) Tun() tunnel.T    { return nil }
-func (inactiveVPN) IsActive() bool   { return false }
 
 func TestVPNNetworker_IsVPNActive(t *testing.T) {
 	tests := []struct {
@@ -49,12 +22,12 @@ func TestVPNNetworker_IsVPNActive(t *testing.T) {
 	}{
 		{
 			name:     "active vpn",
-			vpn:      activeVPN{},
+			vpn:      mock.ActiveVPN{},
 			expected: true,
 		},
 		{
 			name:     "inactive vpn",
-			vpn:      inactiveVPN{},
+			vpn:      mock.WorkingInactiveVPN{},
 			expected: false,
 		},
 		{

--- a/test/mock/vpn.go
+++ b/test/mock/vpn.go
@@ -5,20 +5,45 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/tunnel"
 )
 
+const (
+	StatsStart         = iota
+	StatsStop          = iota
+	StatsNetworkChange = iota
+	statsLastValue     = iota
+)
+
 // WorkingVPN stub of a github.com/NordSecurity/nordvpn-linux/daemon/vpn.VPN interface.
 type WorkingVPN struct {
-	isActive bool
-	StartErr error
+	isActive          bool
+	StartErr          error
+	ErrNetworkChanges error
+	ExecutionStats    [statsLastValue]int
 }
 
 func (w *WorkingVPN) Start(vpn.Credentials, vpn.ServerData) error {
+	w.ExecutionStats[StatsStart]++
+
 	w.isActive = w.StartErr == nil
 	return w.StartErr
 }
-func (w *WorkingVPN) Stop() error    { w.isActive = false; return nil }
-func (*WorkingVPN) State() vpn.State { return vpn.ConnectedState }
-func (w *WorkingVPN) IsActive() bool { return w.isActive }
-func (*WorkingVPN) Tun() tunnel.T    { return WorkingT{} }
+func (w *WorkingVPN) Stop() error {
+	w.ExecutionStats[StatsStop]++
+
+	if !w.isActive {
+		return w.StartErr
+	}
+
+	w.isActive = false
+	return nil
+}
+func (w *WorkingVPN) State() vpn.State { return vpn.ConnectedState }
+func (w *WorkingVPN) IsActive() bool   { return w.isActive }
+func (*WorkingVPN) Tun() tunnel.T      { return WorkingT{} }
+func (w *WorkingVPN) NotifyNetworkChange() error {
+	w.ExecutionStats[StatsNetworkChange]++
+
+	return w.ErrNetworkChanges
+}
 
 type WorkingInactiveVPN struct{}
 
@@ -27,6 +52,7 @@ func (WorkingInactiveVPN) Stop() error                                 { return 
 func (WorkingInactiveVPN) State() vpn.State                            { return vpn.ConnectedState }
 func (WorkingInactiveVPN) IsActive() bool                              { return false }
 func (WorkingInactiveVPN) Tun() tunnel.T                               { return WorkingT{} }
+func (WorkingInactiveVPN) NotifyNetworkChange() error                  { return nil }
 
 // FailingVPN stub of a github.com/NordSecurity/nordvpn-linux/daemon/vpn.VPN interface.
 type FailingVPN struct{}
@@ -36,6 +62,7 @@ func (FailingVPN) Stop() error                                 { return ErrOnPur
 func (FailingVPN) State() vpn.State                            { return vpn.ExitedState }
 func (FailingVPN) IsActive() bool                              { return false }
 func (FailingVPN) Tun() tunnel.T                               { return WorkingT{} }
+func (FailingVPN) NotifyNetworkChange() error                  { return ErrOnPurpose }
 
 // ActiveVPN stub of a github.com/NordSecurity/nordvpn-linux/daemon/vpn.VPN interface.
 type ActiveVPN struct{}
@@ -45,3 +72,4 @@ func (ActiveVPN) Stop() error                                 { return nil }
 func (ActiveVPN) State() vpn.State                            { return vpn.ExitedState }
 func (ActiveVPN) IsActive() bool                              { return true }
 func (ActiveVPN) Tun() tunnel.T                               { return WorkingT{} }
+func (ActiveVPN) NotifyNetworkChange() error                  { return nil }

--- a/test/mock/vpn.go
+++ b/test/mock/vpn.go
@@ -1,6 +1,9 @@
 package mock
 
 import (
+	"net/netip"
+
+	"github.com/NordSecurity/nordvpn-linux/core/mesh"
 	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
 	"github.com/NordSecurity/nordvpn-linux/tunnel"
 )
@@ -39,7 +42,7 @@ func (w *WorkingVPN) Stop() error {
 func (w *WorkingVPN) State() vpn.State { return vpn.ConnectedState }
 func (w *WorkingVPN) IsActive() bool   { return w.isActive }
 func (*WorkingVPN) Tun() tunnel.T      { return WorkingT{} }
-func (w *WorkingVPN) NotifyNetworkChange() error {
+func (w *WorkingVPN) NetworkChanged() error {
 	w.ExecutionStats[StatsNetworkChange]++
 
 	return w.ErrNetworkChanges
@@ -52,7 +55,7 @@ func (WorkingInactiveVPN) Stop() error                                 { return 
 func (WorkingInactiveVPN) State() vpn.State                            { return vpn.ConnectedState }
 func (WorkingInactiveVPN) IsActive() bool                              { return false }
 func (WorkingInactiveVPN) Tun() tunnel.T                               { return WorkingT{} }
-func (WorkingInactiveVPN) NotifyNetworkChange() error                  { return nil }
+func (WorkingInactiveVPN) NetworkChanged() error                       { return nil }
 
 // FailingVPN stub of a github.com/NordSecurity/nordvpn-linux/daemon/vpn.VPN interface.
 type FailingVPN struct{}
@@ -62,7 +65,7 @@ func (FailingVPN) Stop() error                                 { return ErrOnPur
 func (FailingVPN) State() vpn.State                            { return vpn.ExitedState }
 func (FailingVPN) IsActive() bool                              { return false }
 func (FailingVPN) Tun() tunnel.T                               { return WorkingT{} }
-func (FailingVPN) NotifyNetworkChange() error                  { return ErrOnPurpose }
+func (FailingVPN) NetworkChanged() error                       { return ErrOnPurpose }
 
 // ActiveVPN stub of a github.com/NordSecurity/nordvpn-linux/daemon/vpn.VPN interface.
 type ActiveVPN struct{}
@@ -72,4 +75,16 @@ func (ActiveVPN) Stop() error                                 { return nil }
 func (ActiveVPN) State() vpn.State                            { return vpn.ExitedState }
 func (ActiveVPN) IsActive() bool                              { return true }
 func (ActiveVPN) Tun() tunnel.T                               { return WorkingT{} }
-func (ActiveVPN) NotifyNetworkChange() error                  { return nil }
+func (ActiveVPN) NetworkChanged() error                       { return nil }
+
+type MeshnetAndVPN struct {
+	WorkingVPN
+	MeshEnableError error
+}
+
+func (w *MeshnetAndVPN) Enable(netip.Addr, string) error { return w.MeshEnableError }
+func (*MeshnetAndVPN) Disable() error                    { return nil }
+func (*MeshnetAndVPN) Refresh(mesh.MachineMap) error     { return nil }
+func (*MeshnetAndVPN) StatusMap() (map[string]string, error) {
+	return map[string]string{}, nil
+}

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -242,17 +242,13 @@ def test_connect_network_restart_nordlynx(tech, proto, obfuscated):
         links = socket.if_nameindex()
         logging.log(links)
         default_gateway = network.stop()
-
-        list_without_default_gateway = socket.if_nameindex()
         network.start(default_gateway)
         
-        # wait for the default gateway to come back online
-        daemon.wait_for_reconnect(list_without_default_gateway)
+        # wait for internet
+        network.is_available(10)
 
         assert network.is_connected()
-
-        links_after_reconnect = socket.if_nameindex()
-        assert links == links_after_reconnect
+        assert links == socket.if_nameindex()
 
         logging.log(info.collect())
 

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -242,9 +242,10 @@ def test_connect_network_restart_nordlynx(tech, proto, obfuscated):
         links = socket.if_nameindex()
         logging.log(links)
         default_gateway = network.stop()
+
+        list_without_default_gateway = socket.if_nameindex()
         network.start(default_gateway)
         
-        list_without_default_gateway = socket.if_nameindex()
         # wait for the default gateway to come back online
         daemon.wait_for_reconnect(list_without_default_gateway)
 

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -5,7 +5,6 @@ import requests
 import pytest
 import timeout_decorator
 import socket
-import network
 
 ssh_client = ssh.Ssh("qa-peer", "root", "root")
 

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -334,7 +334,6 @@ def test_network_changed_for_meshnet():
     # wait for internet
     network.is_available(10)
 
-    assert not network.is_connected()
     assert links == socket.if_nameindex()
 
     assert "icmp_seq=" in sh.ping("-c", "1", "qa-peer")

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -324,8 +324,7 @@ def test_account_switch():
 def test_network_changed_for_meshnet():
     sh.nordvpn.meshnet.peer.refresh()
 
-    with pytest.raises(sh.ErrorReturnCode_1) as ex:
-        assert "icmp_seq=" in sh.ping("-c", "1", "qa-peer")
+    assert "icmp_seq=" in sh.ping("-c", "1", "qa-peer")
 
     links = socket.if_nameindex()
     logging.log(links)
@@ -338,5 +337,4 @@ def test_network_changed_for_meshnet():
     assert not network.is_connected()
     assert links == socket.if_nameindex()
 
-    with pytest.raises(sh.ErrorReturnCode_1) as ex:
-        assert "icmp_seq=" in sh.ping("-c", "1", "qa-peer")
+    assert "icmp_seq=" in sh.ping("-c", "1", "qa-peer")


### PR DESCRIPTION
For Nordlynx try to reconfigure internally the VPN at network changes, instead of recreating the tunnel.
For OpenVPN is not possible at the moment, because the server config can change between pulls and that internally will trigger the recreation of the tunnel.