### PR TITLE
Notify all platforms for a new file transfer

### DIFF
--- a/core/mesh.go
+++ b/core/mesh.go
@@ -773,6 +773,11 @@ func (api *DefaultAPI) NotifyNewTransfer(
 	}
 
 	resp, err := api.do(req)
+	// 500 Internal Server Error is returned when peer machine have not registered its app_user_uid
+	// Not all platforms implemented it yet, so suppress that error to not clutter logs
+	if errors.Is(err, ErrServerInternal) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/meshnet/server.go
+++ b/meshnet/server.go
@@ -2419,13 +2419,6 @@ func (s *Server) NotifyNewTransfer(
 	ctx context.Context,
 	req *pb.NewTransferNotification,
 ) (*pb.NotifyNewTransferResponse, error) {
-	// This is only needed for iOS platform
-	if req.GetOs() != "ios" {
-		return &pb.NotifyNewTransferResponse{
-			Response: &pb.NotifyNewTransferResponse_Empty{},
-		}, nil
-	}
-
 	if !s.ac.IsLoggedIn() {
 		return &pb.NotifyNewTransferResponse{
 			Response: &pb.NotifyNewTransferResponse_ServiceErrorCode{


### PR DESCRIPTION
A device can send an optional `app_user_uid` field when registering to meshnet. It links the notification center with the meshnet and makes it possible to receive incoming file transfer notifications even if meshnet is disabled. Currently only iOS provide `app_user_uid`, but other platforms started implementing it as well. Therefore, we can remove the iOS check and send the notification to all platforms peers. To not clutter logs with errors in cases when a platform on the other side does not yet support file transfer notifications, suppress 500 Internal Server Error error for that API call.