### PR TITLE
Fix Python code warnings and add Python linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,16 @@ jobs:
           go-version: '1.20'
       - run: go install github.com/securego/gosec/v2/cmd/gosec@v2.13.0
       - run: gosec -quiet -exclude-dir=third-party ./...
-
+  ruff:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+        with:
+          python-version: '3.11'
+      - name: Install pip and ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff==0.2.1
+      - name: Run ruff
+        run: ruff check --output-format=github test/qa

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -187,10 +187,11 @@ class Defer:
 
 
 def set_technology_and_protocol(tech, proto, obfuscation):
-    """Allows setting technology, protocol and obfuscation regardless
-    of whether it is already set or not.
+    """
+    Allows setting technology, protocol and obfuscation regardless of whether it is already set or not.
 
-    Tests do not break on reordering when using this."""
+    Tests do not break on reordering when using this.
+    """
     if tech:
         try:
             print(sh.nordvpn.set.technology(tech))

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -1,8 +1,9 @@
-from enum import Enum
 import os
-import sh
 import time
+from enum import Enum
+from typing import Callable, Union
 
+import sh
 
 # Used for test parametrization, when the tested functionality does not work with obfuscated.
 STANDARD_TECHNOLOGIES = [
@@ -35,7 +36,6 @@ TECHNOLOGIES_BASIC1 = [
 TECHNOLOGIES_BASIC2 = [
     ("openvpn", "udp", "off"),
 ]
-
 
 # no obfuscated servers with ipv6 2021/05/24
 TECHNOLOGIES_WITH_IPV6 = STANDARD_TECHNOLOGIES
@@ -111,6 +111,7 @@ IPV6_SERVERS = [
     "us9591", "us9592"
 ]
 
+
 class Protocol(Enum):
     UDP = "UDP"
     TCP = "TCP"
@@ -119,10 +120,12 @@ class Protocol(Enum):
     def __str__(self):
         return self.value
 
+
 class Port:
     def __init__(self, value: str, protocol: Protocol):
         self.value = value
         self.protocol = protocol
+
 
 PROTOCOLS = [
     Protocol.UDP,
@@ -157,9 +160,10 @@ ALLOWLIST_ALIAS = [
 # Used for integration test coverage
 os.environ["GOCOVERDIR"] = os.environ["WORKDIR"] + "/" + os.environ["COVERDIR"]
 
+
 # Implements context manager a.k.a. with block and executes command on exit if exception was thrown.
 class ErrorDefer:
-    def __init__(self, command: sh.Command):
+    def __init__(self, command: Union[sh.Command, Callable]):
         self.command = command
 
     def __enter__(self):
@@ -172,7 +176,7 @@ class ErrorDefer:
 
 # Implements context manager a.k.a. with block and executes command on exit.
 class Defer:
-    def __init__(self, command: sh.Command):
+    def __init__(self, command: Union[sh.Command, Callable]):
         self.command = command
 
     def __enter__(self):
@@ -269,8 +273,8 @@ def flush_allowlist():
 def is_connect_successful(output, name="", hostname=""):
     if name and hostname:
         return (
-            f"Connecting to {name} ({hostname})"
-            and f"You are connected to {name} ({hostname})!" in output
+                f"Connecting to {name} ({hostname})"
+                and f"You are connected to {name} ({hostname})!" in output
         )
     return "Connecting to" and "You are connected to" in output
 
@@ -278,15 +282,15 @@ def is_connect_successful(output, name="", hostname=""):
 # returns True when failed to connect
 def is_connect_unsuccessful(exception):
     return (
-        "The specified server does not exist." in str(exception.value)
-        or "The specified server is not available at the moment or does not support your connection settings."
-        in str(exception.value)
-        or "You cannot connect to a group and set the group option at the same time."
-        in str(exception.value)
-        or "Something went wrong. Please try again. If the problem persists, contact our customer support."
-        in str(exception.value)
-        or "The specified group does not exist."
-        in str(exception.value)
+            "The specified server does not exist." in str(exception.value)
+            or "The specified server is not available at the moment or does not support your connection settings."
+            in str(exception.value)
+            or "You cannot connect to a group and set the group option at the same time."
+            in str(exception.value)
+            or "Something went wrong. Please try again. If the problem persists, contact our customer support."
+            in str(exception.value)
+            or "The specified group does not exist."
+            in str(exception.value)
     )
 
 

--- a/test/qa/lib/allowlist.py
+++ b/test/qa/lib/allowlist.py
@@ -109,7 +109,7 @@ def add_subnet_to_allowlist(subnet_list: list[str], allowlist_alias="allowlist")
 
         # If subnet /32 whitelisted, only IP Address is visible in `ip route`
         if "/32" in subnet:
-            subnet = subnet.replace("/32", "")
+            subnet = subnet.replace("/32", "")  # noqa: PLW2901
 
         if daemon.is_connected() and not _is_private_subnet(subnet):
             assert subnet in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE), \
@@ -132,7 +132,7 @@ def remove_subnet_from_allowlist(subnet_list: list[str], allowlist_alias="allowl
 
         # If subnet /32 whitelisted, only IP Address is visible in `ip route`
         if "/32" in subnet:
-            subnet = subnet.replace("/32", "")
+            subnet = subnet.replace("/32", "")  # noqa: PLW2901
 
         if not _is_private_subnet(subnet):
             assert subnet not in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE), \

--- a/test/qa/lib/daemon.py
+++ b/test/qa/lib/daemon.py
@@ -4,7 +4,6 @@ import logging
 import os
 import socket
 import time
-from typing import List, Tuple
 
 import sh
 
@@ -23,7 +22,7 @@ def is_init_systemd():
 
 
 def is_connected() -> bool:
-    """returns True when connected to VPN server"""
+    """Returns True when connected to VPN server."""
     try:
         return "Connected" in sh.nordvpn.status()
     except sh.ErrorReturnCode:
@@ -31,7 +30,7 @@ def is_connected() -> bool:
 
 
 def is_disconnected() -> bool:
-    """returns True when not connected to VPN"""
+    """Returns True when not connected to VPN."""
     try:
         return "Disconnected" in sh.nordvpn.status()
     except sh.ErrorReturnCode:
@@ -39,7 +38,7 @@ def is_disconnected() -> bool:
 
 
 def is_killswitch_on():
-    """return True when Killswitch is activated"""
+    """Return True when Killswitch is activated."""
     try:
         return "Kill Switch: enabled" in sh.nordvpn.settings()
     except sh.ErrorReturnCode:
@@ -55,7 +54,7 @@ def is_ipv6_on():
 
 
 def install_peer(ssh_client: ssh.Ssh):
-    """installs nordvpn in peer"""
+    """Installs nordvpn in peer."""
     project_root = os.environ["WORKDIR"]
     deb_path = glob.glob(f'{project_root}/dist/app/deb/*amd64.deb')[0]
     ssh_client.send_file(deb_path, '/tmp/nordvpn.deb')
@@ -63,12 +62,12 @@ def install_peer(ssh_client: ssh.Ssh):
 
 
 def uninstall_peer(ssh_client: ssh.Ssh):
-    """uninstalls nordvpn in peer"""
+    """Uninstalls nordvpn in peer."""
     ssh_client.exec_command('sudo apt remove -y nordvpn')
 
 
 def start():
-    """starts daemon and blocks until it is actually started"""
+    """Starts daemon and blocks until it is actually started."""
     if is_init_systemd():
         return sh.sudo.systemctl.start.nordvpnd()
     # call to init.d returns before the daemon is actually started
@@ -76,10 +75,11 @@ def start():
     sh.sudo("/etc/init.d/nordvpn", "start")
     while not is_running():
         time.sleep(1)
+    return None
 
 
 def start_peer(ssh_client: ssh.Ssh):
-    """starts daemon in peer and blocks until it is actually started"""
+    """Starts daemon in peer and blocks until it is actually started."""
     ssh_client.exec_command("sudo /etc/init.d/nordvpn start")
     time.sleep(1)
     while not is_peer_running(ssh_client):
@@ -87,17 +87,18 @@ def start_peer(ssh_client: ssh.Ssh):
 
 
 def stop():
-    """stops the daemon and blocks until it is actually stopped"""
+    """Stops the daemon and blocks until it is actually stopped."""
     if is_init_systemd():
         return sh.sudo.systemctl.stop.nordvpnd()
     # call to init.d returns before the daemon is actually stopped
     sh.sudo("/etc/init.d/nordvpn", "stop")
     while is_running():
         time.sleep(1)
+    return None
 
 
 def stop_peer(ssh_client: ssh.Ssh):
-    """stops the daemon in peer and blocks until it is actually stopped"""
+    """Stops the daemon in peer and blocks until it is actually stopped."""
     ssh_client.exec_command("sudo /etc/init.d/nordvpn stop")
     while is_peer_running(ssh_client):
         time.sleep(1)
@@ -115,7 +116,7 @@ def restart():
 
 # retrieving links inside this function creates a race condition,
 # therefore it is safer to provide them as arguments
-def wait_for_reconnect(links: List[Tuple[int, str]]):
+def wait_for_reconnect(links: list[tuple[int, str]]):
     logging.info("waiting for reconnect")
     while True:
         got = socket.if_nameindex()
@@ -146,10 +147,9 @@ def is_running():
 
 
 # returns True when daemon is running in peer
-# noinspection PyBroadException
 def is_peer_running(ssh_client: ssh.Ssh) -> bool:
     try:
         ssh_client.exec_command("nordvpn status")
         return True
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False

--- a/test/qa/lib/daemon.py
+++ b/test/qa/lib/daemon.py
@@ -1,12 +1,14 @@
 """Functions to make it easier to interact with nordvpnd."""
-from lib import ssh
+import glob
 import logging
 import os
-import sh
 import socket
 import time
-import glob
 from typing import List, Tuple
+
+import sh
+
+from . import ssh
 
 
 def _rewrite_log_path():
@@ -37,7 +39,7 @@ def is_disconnected() -> bool:
 
 
 def is_killswitch_on():
-    """ return True when Killswitch is activated """
+    """return True when Killswitch is activated"""
     try:
         return "Kill Switch: enabled" in sh.nordvpn.settings()
     except sh.ErrorReturnCode:
@@ -144,9 +146,10 @@ def is_running():
 
 
 # returns True when daemon is running in peer
+# noinspection PyBroadException
 def is_peer_running(ssh_client: ssh.Ssh) -> bool:
     try:
         ssh_client.exec_command("nordvpn status")
         return True
-    except:
+    except Exception:
         return False

--- a/test/qa/lib/daemon.py
+++ b/test/qa/lib/daemon.py
@@ -69,13 +69,13 @@ def uninstall_peer(ssh_client: ssh.Ssh):
 def start():
     """Starts daemon and blocks until it is actually started."""
     if is_init_systemd():
-        return sh.sudo.systemctl.start.nordvpnd()
+        sh.sudo.systemctl.start.nordvpnd()
+        return
     # call to init.d returns before the daemon is actually started
     _rewrite_log_path()
     sh.sudo("/etc/init.d/nordvpn", "start")
     while not is_running():
         time.sleep(1)
-    return None
 
 
 def start_peer(ssh_client: ssh.Ssh):
@@ -89,12 +89,12 @@ def start_peer(ssh_client: ssh.Ssh):
 def stop():
     """Stops the daemon and blocks until it is actually stopped."""
     if is_init_systemd():
-        return sh.sudo.systemctl.stop.nordvpnd()
+        sh.sudo.systemctl.stop.nordvpnd()
+        return
     # call to init.d returns before the daemon is actually stopped
     sh.sudo("/etc/init.d/nordvpn", "stop")
     while is_running():
         time.sleep(1)
-    return None
 
 
 def stop_peer(ssh_client: ssh.Ssh):

--- a/test/qa/lib/dns.py
+++ b/test/qa/lib/dns.py
@@ -45,14 +45,14 @@ TPL_MSG_WARNING_DISABLING = "Disabling Threat Protection Lite."
 
 
 def is_unset() -> bool:
-    """returns True when NordVPN app has not modified the DNS"""
+    """Returns True when NordVPN app has not modified the DNS."""
     return all(os_address != address
                for os_address in dns.resolver.Resolver().nameservers
                for address in ALL_TEST_DNS_ADDRESSES)
 
 
 def is_set_for(dns_set_in_app: list) -> bool:
-    """returns True, if NordVPN application has successfully set and overriden DNS servers in Resolver"""
+    """Returns True, if NordVPN application has successfully set and overriden DNS servers in Resolver."""
 
     # DNS Addresses set in Resolver:
     dns_set_in_os_addresses = dns.resolver.Resolver().nameservers

--- a/test/qa/lib/dns.py
+++ b/test/qa/lib/dns.py
@@ -1,6 +1,5 @@
 import dns.resolver
 
-
 # Used for test parametrization.
 DNS_NORD = ["103.86.96.100", "103.86.99.100"]
 DNS_NORD_IPV6 = ["2400:bb40:4444::100", "2400:bb40:8888::100"]
@@ -46,16 +45,16 @@ TPL_MSG_WARNING_DISABLING = "Disabling Threat Protection Lite."
 
 
 def is_unset() -> bool:
-    """ returns True when NordVPN app has not modified the DNS """
+    """returns True when NordVPN app has not modified the DNS"""
     return all(os_address != address
-        for os_address in dns.resolver.Resolver().nameservers
-            for address in ALL_TEST_DNS_ADDRESSES)
+               for os_address in dns.resolver.Resolver().nameservers
+               for address in ALL_TEST_DNS_ADDRESSES)
 
 
 def is_set_for(dns_set_in_app: list) -> bool:
-    """ returns True, if NordVPN application has successfuly set and overriden DNS servers in Resolver """
+    """returns True, if NordVPN application has successfully set and overriden DNS servers in Resolver"""
 
-    # DNS Adddresses set in Resolver:
+    # DNS Addresses set in Resolver:
     dns_set_in_os_addresses = dns.resolver.Resolver().nameservers
 
     # Make sure, that:

--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -50,7 +50,7 @@ def start_transfer(peer_address: str, *filepaths: str) -> sh.RunningCommand:
 
 
 def get_last_transfer(outgoing: bool = True, ssh_client: ssh.Ssh = None) -> Optional[str]:
-    """Return last id of the last received or sent transfer"""
+    """Return last id of the last received or sent transfer."""
     if ssh_client is None:
         transfers = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
     else:
@@ -104,7 +104,7 @@ def for_all_files_in_transfer(transfer: str, files: list[str], predicate: Callab
 
 
 def get_new_incoming_transfer(ssh_client: ssh.Ssh = None):
-    """Returns last incoming transfer that has not completed"""
+    """Returns last incoming transfer that has not completed."""
     local_transfer_id = get_last_transfer(outgoing=False, ssh_client=ssh_client)
     if local_transfer_id is None:
         return None, "there are no started transfers"

--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -1,10 +1,12 @@
-from lib import ssh
-from typing import Callable
-from collections import namedtuple
-import tempfile
 import os
-import sh
 import re
+import tempfile
+from collections import namedtuple
+from typing import Callable, Optional
+
+import sh
+
+from . import ssh
 
 SEND_NOWAIT_SUCCESS_MSG_PATTERN = r'File transfer ?([a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12}) has started in the background.'
 SEND_CANCELED_BY_PEER_PATTERN = r'File transfer \[?([a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12})\] canceled by peer'
@@ -12,6 +14,7 @@ SEND_CANCELED_BY_OTHER_PROCESS_PATTERN = r'File transfer \[?([a-z0-9]{8}-(?:[a-z
 CANCEL_SUCCESS_SENDER_SIDE_MSG = "File transfer canceled"
 
 Directory = namedtuple("Directory", "dir_path paths transfer_paths filenames")
+
 
 def create_directory(file_count: int, name_suffix: str = "", parent_dir: str = None) -> Directory:
     dir_path = tempfile.mkdtemp(dir=parent_dir)
@@ -36,8 +39,8 @@ def start_transfer(peer_address: str, *filepaths: str) -> sh.RunningCommand:
     buffer = ""
 
     # Read the output character by character, we cannot read it line by line because send prints some
-    # messages without the newline at the end and we cannot read it by X characters because before command
-    # is executed app connets to the daemon for non-deterministic amount of time displaying a spinner
+    # messages without the newline at the end, and we cannot read it by X characters because before command
+    # is executed app connects to the daemon for non-deterministic amount of time displaying a spinner
     for character in command:
         buffer += character
         if "Waiting for the peer to accept your transfer..." in buffer:
@@ -46,12 +49,12 @@ def start_transfer(peer_address: str, *filepaths: str) -> sh.RunningCommand:
     return command
 
 
-def get_last_transfer(outgoing: bool = True, ssh_client: ssh.Ssh = None) -> str:
+def get_last_transfer(outgoing: bool = True, ssh_client: ssh.Ssh = None) -> Optional[str]:
     """Return last id of the last received or sent transfer"""
     if ssh_client is None:
         transfers = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
     else:
-        transfers = ssh_client.exec_command(f"nordvpn fileshare list")
+        transfers = ssh_client.exec_command("nordvpn fileshare list")
     outgoing_index = transfers.index("Outgoing")
     transfers = transfers[outgoing_index:] if outgoing else transfers[:outgoing_index]
     transfer_ids = re.findall("([a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12})", transfers)
@@ -62,11 +65,11 @@ def get_last_transfer(outgoing: bool = True, ssh_client: ssh.Ssh = None) -> str:
     return re.findall("([a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12})", transfers)[-1]
 
 
-def get_transfer(transfer_id: str, ssh_client: ssh.Ssh = None) -> str:
+def get_transfer(transfer_id: str, ssh_client: ssh.Ssh = None) -> Optional[str]:
     if ssh_client is None:
         transfers = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
     else:
-        transfers = ssh_client.exec_command(f"nordvpn fileshare list")
+        transfers = ssh_client.exec_command("nordvpn fileshare list")
 
     transfer_entry = [transfer_entry for transfer_entry in transfers.split("\n") if transfer_id in transfer_entry]
 
@@ -76,21 +79,21 @@ def get_transfer(transfer_id: str, ssh_client: ssh.Ssh = None) -> str:
     return transfer_entry[0]
 
 
-def find_transfer_by_id(transfer_list: str, id: str) -> str:
+def find_transfer_by_id(transfer_list: str, idd: str) -> Optional[str]:
     for transfer_entry in transfer_list.strip("\n").split("\n"):
-        if id in transfer_entry:
+        if idd in transfer_entry:
             return transfer_entry
     return None
 
 
-def find_file_in_transfer(file_id: str, transfer_lines: list[str]) -> str:
+def find_file_in_transfer(file_id: str, transfer_lines: list[str]) -> Optional[str]:
     for file_entry in transfer_lines:
         if file_id in file_entry:
             return file_entry
     return None
 
 
-# returns true if all of the files are present in the transfer and meet the predicate
+# returns true if all the files are present in the transfer and meet the predicate
 def for_all_files_in_transfer(transfer: str, files: list[str], predicate: Callable[[str], bool]) -> bool:
     transfer = transfer.split("\n")
     for file in files:
@@ -104,7 +107,7 @@ def get_new_incoming_transfer(ssh_client: ssh.Ssh = None):
     """Returns last incoming transfer that has not completed"""
     local_transfer_id = get_last_transfer(outgoing=False, ssh_client=ssh_client)
     if local_transfer_id is None:
-        return None, f"there are no started transfers"
+        return None, "there are no started transfers"
 
     transfer_status = get_transfer(local_transfer_id, ssh_client)
     if transfer_status is None:

--- a/test/qa/lib/firewall.py
+++ b/test/qa/lib/firewall.py
@@ -269,7 +269,7 @@ def _get_firewall_rules(ports: list[Port] = None, subnets: list[str] = None) -> 
     # Connected & Port(s) allowlisted
     if ports:
         return _get_rules_allowlist_port_on(interface, ports)
-    return None
+    return []
 
 
 def is_active(ports: list[Port] = None, subnets: list[str] = None) -> bool:

--- a/test/qa/lib/firewall.py
+++ b/test/qa/lib/firewall.py
@@ -83,14 +83,14 @@ IP_ROUTE_TABLE = 205
 # -A OUTPUT -o {iface} -m mark --mark 0xe1f1 -m comment --comment nordvpn -j ACCEPT
 # -A OUTPUT -o {iface} -m comment --comment nordvpn -j DROP
 
-inputLanDiscoveryRules = [
+INPUT_LAN_DISCOVERY_RULES = [
     "-A INPUT -s 169.254.0.0/16 -i eth0 -m comment --comment nordvpn -j ACCEPT",
     "-A INPUT -s 192.168.0.0/16 -i eth0 -m comment --comment nordvpn -j ACCEPT",
     "-A INPUT -s 172.16.0.0/12 -i eth0 -m comment --comment nordvpn -j ACCEPT",
     "-A INPUT -s 10.0.0.0/8 -i eth0 -m comment --comment nordvpn -j ACCEPT",
 ]
 
-outputLanDiscoveryRules = [
+OUTPUT_LAN_DISCOVERY_RULES = [
     "-A OUTPUT -d 169.254.0.0/16 -o eth0 -m comment --comment nordvpn -j ACCEPT",
     "-A OUTPUT -d 192.168.0.0/16 -o eth0 -m comment --comment nordvpn -j ACCEPT",
     "-A OUTPUT -d 172.16.0.0/12 -o eth0 -m comment --comment nordvpn -j ACCEPT",
@@ -119,7 +119,7 @@ def __rules_allowlist_subnet_chain_input(interface: str, subnets: list[str]):
     result = []
 
     for subnet in subnets:
-        result += f"-A INPUT -s {subnet} -i {interface} -m comment --comment nordvpn -j ACCEPT",
+        result += (f"-A INPUT -s {subnet} -i {interface} -m comment --comment nordvpn -j ACCEPT", )
 
     current_subnet_rules_input_chain = []
 
@@ -137,7 +137,7 @@ def __rules_allowlist_subnet_chain_output(interface: str, subnets: list[str]):
     result = []
 
     for subnet in subnets:
-        result += f"-A OUTPUT -d {subnet} -o {interface} -m comment --comment nordvpn -j ACCEPT",
+        result += (f"-A OUTPUT -d {subnet} -o {interface} -m comment --comment nordvpn -j ACCEPT", )
 
     current_subnet_rules_input_chain = []
 
@@ -243,7 +243,7 @@ def _get_rules_allowlist_subnet_and_port_on(interface: str, subnets: list[str], 
     return result
 
 
-# ToDo: Add missing IPv6 rules (icmp6 & dhcp6)
+# TODO: Add missing IPv6 rules (icmp6 & dhcp6)
 def _get_firewall_rules(ports: list[Port] = None, subnets: list[str] = None) -> list[str]:
     # Default route interface
     interface = sh.ip.route.show("default").split(None)[4]
@@ -269,10 +269,11 @@ def _get_firewall_rules(ports: list[Port] = None, subnets: list[str] = None) -> 
     # Connected & Port(s) allowlisted
     if ports:
         return _get_rules_allowlist_port_on(interface, ports)
+    return None
 
 
 def is_active(ports: list[Port] = None, subnets: list[str] = None) -> bool:
-    """returns True when all expected rules are found in iptables, in matching order"""
+    """Returns True when all expected rules are found in iptables, in matching order."""
     print(sh.ip.route())
 
     expected_rules = _get_firewall_rules(ports, subnets)
@@ -296,7 +297,7 @@ def is_active(ports: list[Port] = None, subnets: list[str] = None) -> bool:
 
 
 def is_empty() -> bool:
-    """returns True when firewall does not have DROP rules"""
+    """Returns True when firewall does not have DROP rules."""
     return "DROP" not in sh.sudo.iptables("-S")
 
 
@@ -337,7 +338,7 @@ def sort_list_by_other_list(to_sort: list[str], sort_by: list[str]) -> list[str]
 
 
 def add_and_delete_random_route():
-    """Adds a random route, and deletes it. If this is not used, exceptions happen in allowlist tests"""
+    """Adds a random route, and deletes it. If this is not used, exceptions happen in allowlist tests."""
     cmd = sh.sudo.ip.route.add.default.via.bake("127.0.0.1")
     cmd.table(IP_ROUTE_TABLE)
     sh.sudo.ip.route.delete.default.table(IP_ROUTE_TABLE)

--- a/test/qa/lib/info.py
+++ b/test/qa/lib/info.py
@@ -2,7 +2,7 @@ import sh
 
 
 def collect():
-    """collect system information and return as multiline string"""
+    """Collect system information and return as multiline string."""
     link_layer_info = sh.sudo.ip.link()
     network_interface_info = sh.sudo.ip.addr()
     routing_info = sh.sudo.ip.route()

--- a/test/qa/lib/info.py
+++ b/test/qa/lib/info.py
@@ -5,7 +5,7 @@ def collect():
     """collect system information and return as multiline string"""
     link_layer_info = sh.sudo.ip.link()
     network_interface_info = sh.sudo.ip.addr()
-    rounting_info = sh.sudo.ip.route()
+    routing_info = sh.sudo.ip.route()
     firewall_info = sh.sudo.iptables("-S")
     nameserver_info = sh.sudo.cat("/etc/resolv.conf")
 
@@ -20,7 +20,7 @@ def collect():
             "Network Interfaces:",
             str(network_interface_info),
             "Routing:",
-            str(rounting_info),
+            str(routing_info),
             "Firewall:",
             str(firewall_info),
             "DNS:",

--- a/test/qa/lib/logging.py
+++ b/test/qa/lib/logging.py
@@ -8,7 +8,7 @@ FILE = f"{os.environ['WORKDIR']}/dist/logs/daemon.log"
 
 
 def log(data=None):
-    """log test name to the daemon logs or data if provided, but not both"""
+    """Log test name to the daemon logs or data if provided, but not both."""
     # Printing this way prints the pure data into a file, going the bash -c echo route
     # is vulnerable to double quotes character being found and subsequent lines being taken
     # as pure bash code (and failing as it begins to list processes taking them as commands)

--- a/test/qa/lib/logging.py
+++ b/test/qa/lib/logging.py
@@ -1,5 +1,6 @@
-"""Logging utilities to make it easier to write to daemon logs. """
+"""Logging utilities to make it easier to write to daemon logs."""
 import os
+
 import sh
 
 # log file location

--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -7,7 +7,7 @@ from . import logging, ssh
 
 
 def get_default_credentials():
-    """returns tuple[username,token]"""
+    """Returns tuple[username,token]."""
     default_username = os.environ.get("DEFAULT_LOGIN_USERNAME")
     default_token = os.environ.get("DEFAULT_LOGIN_TOKEN")
     ci_credentials = os.environ.get("NA_TESTS_CREDENTIALS")
@@ -21,7 +21,7 @@ def get_default_credentials():
 
 
 def login_as(username, ssh_client: ssh.Ssh = None):
-    """login_as specified user with optional delay before calling login"""
+    """login_as specified user with optional delay before calling login."""
 
     default_username, default_token = get_default_credentials()
     users = {

--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -1,8 +1,10 @@
-from lib import logging, ssh
-import sh
-import time
 import json
 import os
+
+import sh
+
+from . import logging, ssh
+
 
 def get_default_credentials():
     """returns tuple[username,token]"""
@@ -14,8 +16,9 @@ def get_default_credentials():
         dev_email = os.environ.get("GITLAB_USER_EMAIL")
         if dev_email in devs:
             default_username = devs[dev_email]["username"]
-            default_token= devs[dev_email]["token"]
+            default_token = devs[dev_email]["token"]
     return default_username, default_token
+
 
 def login_as(username, ssh_client: ssh.Ssh = None):
     """login_as specified user with optional delay before calling login"""

--- a/test/qa/lib/meshnet.py
+++ b/test/qa/lib/meshnet.py
@@ -46,8 +46,9 @@ def add_peer(ssh_client: ssh.Ssh,
              peer_allow_local: bool = True,
              peer_allow_incoming: bool = True):
     """
-    adds QA peer to meshnet
-    try to minimize usage of this, because there's a weekly invite limit
+    Adds QA peer to meshnet.
+
+    Try to minimize usage of this, because there's a weekly invite limit.
     """
     tester_allow_fileshare_arg = f"--allow-peer-send-files={str(tester_allow_fileshare).lower()}"
     tester_allow_routing_arg = f"--allow-traffic-routing={str(tester_allow_routing).lower()}"
@@ -67,7 +68,7 @@ def add_peer(ssh_client: ssh.Ssh,
 
 
 def get_peers(output: str) -> list:
-    """parses list of peer names from 'nordvpn meshnet peer list' output"""
+    """Parses list of peer names from 'nordvpn meshnet peer list' output."""
     output = output[output.find("Local Peers:"):]  # skip this device
     peers = []
     for line in output.split("\n"):
@@ -77,51 +78,54 @@ def get_peers(output: str) -> list:
 
 
 def get_this_device(output: str):
-    """parses current device hostname from 'nordvpn meshnet peer list' output"""
+    """Parses current device hostname from 'nordvpn meshnet peer list' output."""
     output_lines = output.split("\n")
     for i, line in enumerate(output_lines):
         if "This device:" in line:
             for subline in output_lines[i + 1:]:
                 if "Hostname:" in subline:
                     return strip_colors.sub('', subline.split(" ")[-1])
+    return None
 
 
 def get_this_device_ipv4(output: str):
-    """parses current device ip from 'nordvpn meshnet peer list' output"""
+    """Parses current device ip from 'nordvpn meshnet peer list' output."""
     output_lines = output.split("\n")
     for i, line in enumerate(output_lines):
         if "This device:" in line:
             for subline in output_lines[i + 1:]:
                 if "IP:" in subline:
                     return strip_colors.sub('', subline.split(" ")[-1])
+    return None
 
 
 def get_this_device_pubkey(output: str):
-    """parses current device pubkey from 'nordvpn meshnet peer list' output"""
+    """Parses current device pubkey from 'nordvpn meshnet peer list' output."""
     output_lines = output.split("\n")
     for i, line in enumerate(output_lines):
         if "This device:" in line:
             for subline in output_lines[i + 1:]:
                 if "Public Key:" in subline:
                     return strip_colors.sub('', subline.split(" ")[-1])
+    return None
 
 
 def remove_all_peers():
-    """removes all meshnet peers from local device"""
+    """Removes all meshnet peers from local device."""
     output = f"{sh.nordvpn.mesh.peer.list(_tty_out=False)}"  # convert to string, _tty_out false disables colors
     for p in get_peers(output):
         sh.nordvpn.mesh.peer.remove(p)
 
 
 def remove_all_peers_in_peer(ssh_client: ssh.Ssh):
-    """removes all meshnet peers from peer device"""
+    """Removes all meshnet peers from peer device."""
     output = ssh_client.exec_command("nordvpn mesh peer list")
     for p in get_peers(output):
         ssh_client.exec_command(f"nordvpn mesh peer remove {p}")
 
 
 def is_peer_reachable(ssh_client: ssh.Ssh, retry: int = 5) -> bool:
-    """returns True when ping to peer succeeds."""
+    """Returns True when ping to peer succeeds."""
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_hostname = get_this_device(output)
     i = 0
@@ -140,7 +144,7 @@ def is_peer_reachable(ssh_client: ssh.Ssh, retry: int = 5) -> bool:
 
 
 def get_sent_invites(output: str) -> list:
-    """parses list of sent invites from 'nordvpn meshnet inv list' output"""
+    """Parses list of sent invites from 'nordvpn meshnet inv list' output."""
     emails = []
     for line in output.split("\n"):
         if line.find("Received Invites:") != -1:
@@ -151,14 +155,14 @@ def get_sent_invites(output: str) -> list:
 
 
 def revoke_all_invites():
-    """revokes all sent meshnet invites in local device"""
+    """Revokes all sent meshnet invites in local device."""
     output = f"{sh.nordvpn.mesh.inv.list(_tty_out=False)}"  # convert to string, _tty_out false disables colors
     for i in get_sent_invites(output):
         sh.nordvpn.mesh.inv.revoke(i)
 
 
 def revoke_all_invites_in_peer(ssh_client: ssh.Ssh):
-    """revokes all sent meshnet invites in peer device"""
+    """Revokes all sent meshnet invites in peer device."""
     output = ssh_client.exec_command("nordvpn mesh inv list")
     for i in get_sent_invites(output):
         ssh_client.exec_command(f"nordvpn mesh inv revoke {i}")

--- a/test/qa/lib/network.py
+++ b/test/qa/lib/network.py
@@ -15,7 +15,7 @@ API_EXTERNAL_IP = "https://api.nordvpn.com/v1/helpers/ips/insights"
 
 
 def _is_internet_reachable(retry=5) -> bool:
-    """returns True when remote host is reachable by its public IP"""
+    """Returns True when remote host is reachable by its public IP."""
     i = 0
     while i < retry:
         try:
@@ -41,7 +41,7 @@ def _is_ipv6_internet_reachable(retry=5) -> bool:
 
 
 def _is_dns_resolvable(retry=5) -> bool:
-    """returns True when domain resolution is working"""
+    """Returns True when domain resolution is working."""
     i = 0
     while i < retry:
         try:
@@ -53,9 +53,8 @@ def _is_dns_resolvable(retry=5) -> bool:
     return False
 
 
-# noinspection PyBroadException
 def _is_dns_not_resolvable(retry=5) -> bool:
-    """returns True when domain resolution is not working"""
+    """Returns True when domain resolution is not working."""
     for _ in range(retry):
         try:
             with pytest.raises(sh.ErrorReturnCode_2) as ex:
@@ -64,27 +63,27 @@ def _is_dns_not_resolvable(retry=5) -> bool:
             return "Network is unreachable" in str(ex) or \
                 "Name or service not known" in str(ex) or \
                 "Temporary failure in name resolution" in str(ex)
-        except Exception:
+        except Exception:  # noqa: BLE001
             time.sleep(1)
     return False
 
 
 def is_not_available(retry=5) -> bool:
-    """returns True when network access is not available"""
+    """Returns True when network access is not available."""
     # If assert below fails, and you are running Kill Switch tests on your machine, inside of Docker,
     # set DNS in resolv.conf of your system to anything else but 127.0.0.53
     return not _is_internet_reachable(retry) and _is_dns_not_resolvable(retry)
 
 
 def is_available(retry=5) -> bool:
-    """returns True when network access is available or throws AssertionError otherwise"""
+    """Returns True when network access is available or throws AssertionError otherwise."""
     assert _is_internet_reachable(retry)
     assert _is_dns_resolvable(retry)
     return True
 
 
 def is_connected() -> bool:
-    """returns True when connected to VPN server or throws AssertionError otherwise"""
+    """Returns True when connected to VPN server or throws AssertionError otherwise."""
     assert daemon.is_connected()
     assert is_available()
     return True
@@ -107,7 +106,7 @@ def is_ipv6_connected(retry=5) -> bool:
 
 
 def is_disconnected(retry=5) -> bool:
-    """returns True when not connected to VPN server or throws AssertionError otherwise"""
+    """Returns True when not connected to VPN server or throws AssertionError otherwise."""
     assert firewall.is_empty()
     assert daemon.is_disconnected()
     assert is_available(retry)
@@ -116,7 +115,7 @@ def is_disconnected(retry=5) -> bool:
 
 # start the networking and wait for completion
 def start(default_gateway: str):
-    """Must pass default_gateway returned from stop()"""
+    """Must pass default_gateway returned from stop()."""
     if daemon.is_init_systemd():
         sh.sudo.nmcli.networking.on()
     else:
@@ -132,7 +131,7 @@ def start(default_gateway: str):
 
 # stop the networking and wait for completion
 def stop() -> str:
-    """Returns default_gateway to be used when starting network again"""
+    """Returns default_gateway to be used when starting network again."""
     default_gateway = None
     for line in sh.ip.route().split('\n'):
         if line.startswith('default'):
@@ -168,5 +167,5 @@ def unblock():
 
 
 def get_external_device_ip() -> str:
-    """returns external device IP"""
-    return requests.get(API_EXTERNAL_IP).json().get("ip")
+    """Returns external device IP."""
+    return requests.get(API_EXTERNAL_IP, timeout=5).json().get("ip")

--- a/test/qa/lib/notify.py
+++ b/test/qa/lib/notify.py
@@ -1,7 +1,9 @@
-from lib import server
-import sh
 import subprocess
 from threading import Thread
+
+import sh
+
+from . import server
 
 
 class NotificationCaptureThreadResult:
@@ -20,10 +22,34 @@ class NotificationCaptureThreadResult:
 NOTIFICATION_DETECTED = NotificationCaptureThreadResult(True, True, True)
 NOTIFICATION_NOT_DETECTED = NotificationCaptureThreadResult(False, False, False)
 
-
 # Used to check if error messages are correct
 NOTIFY_MSG_ERROR_ALREADY_ENABLED = "Notifications are already set to 'enabled'."
 NOTIFY_MSG_ERROR_ALREADY_DISABLED = "Notifications are already set to 'disabled'."
+
+
+def capture_notifications(message):
+    """
+        returns `NotificationCaptureThreadResult`, and contains booleans - icon_match, summary_match, body_match - according to found notification contents
+    """
+
+    # Timeout is needed, in order for Thread not to hang, as we need to exit the process at some point
+    # Timeout can be altered according to how fast you connect to NordVPN server
+    command = ["timeout", "6", "dbus-monitor", "--session", "type=method_call,interface=org.freedesktop.Notifications"]
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    result = NotificationCaptureThreadResult(False, False, False)
+
+    for line in process.stdout:
+        if "/usr/share/icons/hicolor/scalable/apps/nordvpn.svg" in line:
+            result.icon_match = True
+
+        if "NordVPN" in line:
+            result.summary_match = True
+
+        if message in line:
+            result.body_match = True
+
+    return result
 
 
 class NotificationCaptureThread(Thread):
@@ -32,36 +58,12 @@ class NotificationCaptureThread(Thread):
         self.value: NotificationCaptureThreadResult = NotificationCaptureThreadResult(False, False, False)
         self.expected_message = expected_msg
 
-    def capture_notifications(self, message):
-        """ 
-            returns `NotificationCaptureThreadResult`, and contains booleans - icon_match, summary_match, body_match - according to found notification contents
-        """
-
-        # Timeout is needed, in order for Thread not to hang, as we need to exit the process at some point
-        # Timeout can be altered according to how fast you connect to NordVPN server
-        command = ["timeout", "6", "dbus-monitor", "--session", "type=method_call,interface=org.freedesktop.Notifications"]
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-
-        result = NotificationCaptureThreadResult(False, False, False)
-
-        for line in process.stdout:
-            if "/usr/share/icons/hicolor/scalable/apps/nordvpn.svg" in line:
-                result.icon_match = True
-
-            if "NordVPN" in line:
-                result.summary_match = True
-
-            if message in line:
-                result.body_match = True
-
-        return result
-
     def run(self):
-        self.value = self.capture_notifications(self.expected_message)
+        self.value = capture_notifications(self.expected_message)
 
 
 def connect_and_capture_notifications(tech, proto, obfuscated) -> NotificationCaptureThreadResult:
-    """ returns [True, True, True] if notification with all expected contents from NordVPN was captured while connecting to VPN server """
+    """returns [True, True, True] if notification with all expected contents from NordVPN was captured while connecting to VPN server"""
 
     # Choose server for test, so we know the full expected message
     name, hostname = server.get_hostname_by(tech, proto, obfuscated)
@@ -80,7 +82,7 @@ def connect_and_capture_notifications(tech, proto, obfuscated) -> NotificationCa
 
 
 def disconnect_and_capture_notifications() -> NotificationCaptureThreadResult:
-    """ returns [True, True, True] if notification with all expected contents from NordVPN was captured while disconnecting from VPN server """
+    """returns [True, True, True] if notification with all expected contents from NordVPN was captured while disconnecting from VPN server"""
 
     # We know what message we expect to appear in notification
     expected_msg = "You are disconnected from NordVPN."
@@ -96,8 +98,8 @@ def disconnect_and_capture_notifications() -> NotificationCaptureThreadResult:
     return t_disconnect.value
 
 
-def print_tidy_exception(obj1: NotificationCaptureThreadResult, obj2: NotificationCaptureThreadResult) -> None:
-    """ Prints values of attributes from specified NotificationCaptureThreadResult type of objects """
+def print_tidy_exception(obj1: NotificationCaptureThreadResult, obj2: NotificationCaptureThreadResult) -> str:
+    """Prints values of attributes from specified NotificationCaptureThreadResult type of objects"""
     return \
         f"\n\n(icon, summary, body)\n" \
         f"({obj1.icon_match}, {obj1.summary_match}, {obj1.body_match}) - connect_notification / disconnect_notification - found\n" \

--- a/test/qa/lib/notify.py
+++ b/test/qa/lib/notify.py
@@ -28,9 +28,7 @@ NOTIFY_MSG_ERROR_ALREADY_DISABLED = "Notifications are already set to 'disabled'
 
 
 def capture_notifications(message):
-    """
-        returns `NotificationCaptureThreadResult`, and contains booleans - icon_match, summary_match, body_match - according to found notification contents
-    """
+    """Returns `NotificationCaptureThreadResult`, and contains booleans - icon_match, summary_match, body_match - according to found notification contents."""
 
     # Timeout is needed, in order for Thread not to hang, as we need to exit the process at some point
     # Timeout can be altered according to how fast you connect to NordVPN server
@@ -63,7 +61,7 @@ class NotificationCaptureThread(Thread):
 
 
 def connect_and_capture_notifications(tech, proto, obfuscated) -> NotificationCaptureThreadResult:
-    """returns [True, True, True] if notification with all expected contents from NordVPN was captured while connecting to VPN server"""
+    """Returns [True, True, True] if notification with all expected contents from NordVPN was captured while connecting to VPN server."""
 
     # Choose server for test, so we know the full expected message
     name, hostname = server.get_hostname_by(tech, proto, obfuscated)
@@ -82,7 +80,7 @@ def connect_and_capture_notifications(tech, proto, obfuscated) -> NotificationCa
 
 
 def disconnect_and_capture_notifications() -> NotificationCaptureThreadResult:
-    """returns [True, True, True] if notification with all expected contents from NordVPN was captured while disconnecting from VPN server"""
+    """Returns [True, True, True] if notification with all expected contents from NordVPN was captured while disconnecting from VPN server."""
 
     # We know what message we expect to appear in notification
     expected_msg = "You are disconnected from NordVPN."
@@ -99,9 +97,9 @@ def disconnect_and_capture_notifications() -> NotificationCaptureThreadResult:
 
 
 def print_tidy_exception(obj1: NotificationCaptureThreadResult, obj2: NotificationCaptureThreadResult) -> str:
-    """Prints values of attributes from specified NotificationCaptureThreadResult type of objects"""
+    """Prints values of attributes from specified NotificationCaptureThreadResult type of objects."""
     return \
-        f"\n\n(icon, summary, body)\n" \
-        f"({obj1.icon_match}, {obj1.summary_match}, {obj1.body_match}) - connect_notification / disconnect_notification - found\n" \
-        f"({obj2.icon_match}, {obj2.summary_match}, {obj2.body_match}) - notify.NOTIFICATION_DETECTED / notify.NOTIFICATION_NOT_DETECTED - expected" \
-        f"\n\n"
+        "\n\n(icon, summary, body)\n" + \
+        f"({obj1.icon_match}, {obj1.summary_match}, {obj1.body_match}) - connect_notification / disconnect_notification - found\n" + \
+        f"({obj2.icon_match}, {obj2.summary_match}, {obj2.body_match}) - notify.NOTIFICATION_DETECTED / notify.NOTIFICATION_NOT_DETECTED - expected" + \
+        "\n\n"

--- a/test/qa/lib/server.py
+++ b/test/qa/lib/server.py
@@ -1,11 +1,12 @@
 import logging
-import requests
 import time
 from urllib.parse import quote
 
+import requests
+
 
 def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
-    """ returns server name and hostname from core API """
+    """returns server name and hostname from core API"""
     tech_id = ""
 
     if technology != "":
@@ -42,7 +43,6 @@ def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
 
     if group_id != "":
         group_id = group_ids[group_id]
-
 
     # api limits
     time.sleep(2)

--- a/test/qa/lib/server.py
+++ b/test/qa/lib/server.py
@@ -6,7 +6,7 @@ import requests
 
 
 def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
-    """returns server name and hostname from core API"""
+    """Returns server name and hostname from core API."""
     tech_id = ""
 
     if technology != "":
@@ -48,14 +48,14 @@ def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
     time.sleep(2)
     url = f"https://api.nordvpn.com/v1/servers?limit=10&filters[servers.status]=online&filters[servers_technologies]={tech_id}&filters[servers_groups]={group_id}"
     logging.debug(url)
-    server = requests.get(url).json()[0]
+    server = requests.get(url, timeout=5).json()[0]
     return server["name"], server["hostname"]
 
 
 def get_server_info(server_name):
     server_name = quote(server_name)
     url = f"https://api.nordvpn.com/v1/servers?filters[servers.name]={server_name}&fields[servers.locations]"
-    server_info = requests.get(url).json()
+    server_info = requests.get(url, timeout=5).json()
 
     city = server_info[0]["locations"][0]["country"]["city"]["name"]
     country = server_info[0]["locations"][0]["country"]["name"]

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -2,12 +2,12 @@ import sh
 
 
 def get_server_ip() -> str:
-    """ returns str with IP Address of the server from `nordvpn status`, that NordVPN client is currently connected to """
+    """returns str with IP Address of the server from `nordvpn status`, that NordVPN client is currently connected to"""
     return sh.nordvpn.status().split('\n')[2].replace('IP: ', '')
 
 
 def get_current_connection_protocol():
-    """ returns str current connection protocol from `nordvpn settings` """
+    """returns str current connection protocol from `nordvpn settings`"""
     current_protocol = sh.nordvpn("settings").split('\n')[1]
 
     if "UDP" in current_protocol:
@@ -19,27 +19,27 @@ def get_current_connection_protocol():
 
 
 def get_is_obfuscated():
-    """ returns True, if Obfuscate is enabled in application settings """
+    """returns True, if Obfuscate is enabled in application settings"""
     return "Obfuscate: enabled" in sh.nordvpn.settings()
 
 
 def dns_visible_in_settings(dns: list) -> bool:
-    """ return True, if DNS that were passed as parameter are visible in app settings """
+    """return True, if DNS that were passed as parameter are visible in app settings"""
     current_dns_settings = sh.nordvpn("settings").split('\n')[-3]
 
     return all(entry in current_dns_settings for entry in dns)
 
 
 def get_is_tpl_enabled():
-    """ returns True, if Threat Protection Lite is enabled in application settings """
+    """returns True, if Threat Protection Lite is enabled in application settings"""
     return "Threat Protection Lite: enabled" in sh.nordvpn.settings()
 
 
 def get_is_notify_enabled():
-    """ returns True, if Threat Protection Lite is enabled in application settings """
+    """returns True, if Threat Protection Lite is enabled in application settings"""
     return "Notify: enabled" in sh.nordvpn.settings()
 
 
 def get_is_routing_enabled():
-    """ returns True, if Routing is enabled in application settings """
+    """returns True, if Routing is enabled in application settings"""
     return "Routing: enabled" in sh.nordvpn.settings()

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -2,12 +2,12 @@ import sh
 
 
 def get_server_ip() -> str:
-    """returns str with IP Address of the server from `nordvpn status`, that NordVPN client is currently connected to"""
+    """Returns str with IP Address of the server from `nordvpn status`, that NordVPN client is currently connected to."""
     return sh.nordvpn.status().split('\n')[2].replace('IP: ', '')
 
 
 def get_current_connection_protocol():
-    """returns str current connection protocol from `nordvpn settings`"""
+    """Returns str current connection protocol from `nordvpn settings`."""
     current_protocol = sh.nordvpn("settings").split('\n')[1]
 
     if "UDP" in current_protocol:
@@ -19,27 +19,27 @@ def get_current_connection_protocol():
 
 
 def get_is_obfuscated():
-    """returns True, if Obfuscate is enabled in application settings"""
+    """Returns True, if Obfuscate is enabled in application settings."""
     return "Obfuscate: enabled" in sh.nordvpn.settings()
 
 
 def dns_visible_in_settings(dns: list) -> bool:
-    """return True, if DNS that were passed as parameter are visible in app settings"""
+    """Return True, if DNS that were passed as parameter are visible in app settings."""
     current_dns_settings = sh.nordvpn("settings").split('\n')[-3]
 
     return all(entry in current_dns_settings for entry in dns)
 
 
 def get_is_tpl_enabled():
-    """returns True, if Threat Protection Lite is enabled in application settings"""
+    """Returns True, if Threat Protection Lite is enabled in application settings."""
     return "Threat Protection Lite: enabled" in sh.nordvpn.settings()
 
 
 def get_is_notify_enabled():
-    """returns True, if Threat Protection Lite is enabled in application settings"""
+    """Returns True, if Threat Protection Lite is enabled in application settings."""
     return "Notify: enabled" in sh.nordvpn.settings()
 
 
 def get_is_routing_enabled():
-    """returns True, if Routing is enabled in application settings"""
+    """Returns True, if Routing is enabled in application settings."""
     return "Routing: enabled" in sh.nordvpn.settings()

--- a/test/qa/lib/ssh.py
+++ b/test/qa/lib/ssh.py
@@ -15,7 +15,8 @@ class Ssh:
     def exec_command(self, command: str) -> str:
         _, stdout, stderr = self.client.exec_command(command)
         if stdout.channel.recv_exit_status() != 0:
-            raise RuntimeError(f'{stdout.read().decode()} {stderr.read().decode()}')
+            msg = f'{stdout.read().decode()} {stderr.read().decode()}'
+            raise RuntimeError(msg)
         return stdout.read().decode()
 
     # Sends file in the provided path to the ssh peer

--- a/test/qa/lib/ssh.py
+++ b/test/qa/lib/ssh.py
@@ -1,5 +1,6 @@
 import paramiko
 
+
 class Ssh:
     def __init__(self, hostname: str, username: str, password: str):
         self.client = paramiko.SSHClient()
@@ -9,7 +10,7 @@ class Ssh:
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     def connect(self):
-        self.client.connect(self.hostname, 22, username = self.username, password = self.password)
+        self.client.connect(self.hostname, 22, username=self.username, password=self.password)
 
     def exec_command(self, command: str) -> str:
         _, stdout, stderr = self.client.exec_command(command)

--- a/test/qa/ruff.toml
+++ b/test/qa/ruff.toml
@@ -1,0 +1,86 @@
+line-length = 220
+target-version = "py310"
+
+[lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # Unused function argument
+    "ARG001",
+    # Wrong type
+    "PT006",
+    # Missing explicit return at the end of function able to return non-None value
+    "RET503",
+    # Exception must not use an f-string literal, assign to variable first
+    "EM102",
+    # Do not catch blind exception
+    "BLE001",
+    # Trailing comma on bare tuple prohibited
+    "COM818",
+    # Unnecessary generator
+    "C402",
+    # Consider * instead of concatenation
+    "RUF005",
+    # Use elif instead of else then if, to reduce indentation
+    "PLR5501",
+    # Loop variable overwritten by assignment target
+    "PLW2901",
+    # Implicitly concatenated string literals over multiple lines
+    "ISC002",
+    # Variable in function should be lowercase
+    "N806",
+    # Variable in global scope should not be mixedCase
+    "N816",
+    # Trailing whitespace
+    "W291",
+    # One-line docstring should fit on one line
+    "D200",
+    # 1 blank line required between summary line and description
+    "D205",
+    # Docstring is over-indented
+    "D208",
+    # Multi-line docstring closing quotes should be on a separate line
+    "D209",
+    # Multi-line docstring summary should start at the second line
+    "D213",
+    # First line should end with a period
+    "D400",
+    # First word of the first line should be capitalized
+    "D403",
+    # Use specific rule codes when using noqa
+    "PGH004",
+    # Invalid TODO capitalization: ToDo should be TODO
+    "TD006",
+    # Probable use of requests call without timeout
+    "S113",
+    # Apply all rules
+    # "ALL"
+]
+
+ignore = [
+    # Line too long
+    "E501",
+    # Use ternary operator instead of if-else-block
+    "SIM108",
+    # Use a single `with` statement with multiple contexts instead of nested `with` statements
+    "SIM117",
+    # Rules to be selected in future
+    "UP007", "UP035", "RUF013", "D401", "PTH",
+    # Rules to be selected in future, but currently broken
+    "RET505",
+    # Rules ignored from ALL
+    "ANN001", "ANN101", "ANN201", "ANN202", "ANN204", "T201", "D100", "D101", "D102", "D103", "D104", "D105", "D107",
+    "D202", "D212", "COM812", "S101", "TD002", "TD003", "FIX002", "FBT001", "FBT002", "FBT003", "RUF001", "RUF010",
+    "Q000", "PLR0913", "PLR0915", "PLR0911", "PLR2004", "PT012", "PT017", "PT018", "PYI024", "C901", "TRY300",
+    "PERF203", "PERF401", "S60", "S108", "S311", "ISC003", "ERA001"
+]

--- a/test/qa/test_allowlist_port.py
+++ b/test/qa/test_allowlist_port.py
@@ -1,22 +1,19 @@
 import random
-from lib import (
-    allowlist,
-    daemon,
-    firewall,
-    info,
-    logging,
-    login
-)
-import lib
+
 import pytest
 import sh
 import timeout_decorator
 
+import lib
+from lib import allowlist, daemon, firewall, info, logging, login
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     firewall.add_and_delete_random_route()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     daemon.start()
     login.login_as("default")
@@ -24,6 +21,7 @@ def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -148,7 +146,7 @@ def test_allowlist_port_and_remove_connected(tech, proto, obfuscated, port):
 
 @pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS])
-def test_allowlist_port_remove_nonexistant_disconnected(tech, proto, obfuscated, port):
+def test_allowlist_port_remove_nonexistent_disconnected(tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
@@ -165,7 +163,7 @@ def test_allowlist_port_remove_nonexistant_disconnected(tech, proto, obfuscated,
 @pytest.mark.parametrize("port", lib.PORTS, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
-def test_allowlist_port_remove_nonexistant_connected(tech, proto, obfuscated, port):
+def test_allowlist_port_remove_nonexistent_connected(tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
     sh.nordvpn.connect()
@@ -182,7 +180,7 @@ def test_allowlist_port_remove_nonexistant_connected(tech, proto, obfuscated, po
 
 @pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
-def test_allowlist_port_range_remove_nonexistant_disconnected( tech, proto, obfuscated, port):
+def test_allowlist_port_range_remove_nonexistent_disconnected(tech, proto, obfuscated, port):
     port_range = port.value.split(":")
 
     lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -201,7 +199,7 @@ def test_allowlist_port_range_remove_nonexistant_disconnected( tech, proto, obfu
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
-def test_allowlist_port_range_remove_nonexistant_connected(tech, proto, obfuscated, port):
+def test_allowlist_port_range_remove_nonexistent_connected(tech, proto, obfuscated, port):
     port_range = port.value.split(":")
 
     lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -223,7 +221,7 @@ def test_allowlist_port_range_remove_nonexistant_connected(tech, proto, obfuscat
 def test_allowlist_port_range_twice_disconnected(tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    for x in range(2):
+    for _ in range(2):
         allowlist.add_ports_to_allowlist([port])
 
     assert not firewall.is_active([port])
@@ -238,7 +236,7 @@ def test_allowlist_port_range_twice_connected(tech, proto, obfuscated, port):
 
     sh.nordvpn.connect()
 
-    for x in range(2):
+    for _ in range(2):
         allowlist.add_ports_to_allowlist([port])
 
     assert firewall.is_active([port])

--- a/test/qa/test_allowlist_port.py
+++ b/test/qa/test_allowlist_port.py
@@ -8,21 +8,18 @@ import lib
 from lib import allowlist, daemon, firewall, info, logging, login
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     firewall.add_and_delete_random_route()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
@@ -33,7 +30,7 @@ def teardown_function(function):
 
 @pytest.mark.parametrize("port", lib.PORTS + lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS + lib.PORTS_RANGE])
 @pytest.mark.parametrize("allowlist_alias", lib.ALLOWLIST_ALIAS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_allowlist_does_not_create_new_routes_when_adding_deleting_port_disconnected(allowlist_alias, tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -51,7 +48,7 @@ def test_allowlist_does_not_create_new_routes_when_adding_deleting_port_disconne
 
 @pytest.mark.parametrize("port", lib.PORTS + lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS + lib.PORTS_RANGE])
 @pytest.mark.parametrize("allowlist_alias", lib.ALLOWLIST_ALIAS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_allowlist_does_not_create_new_routes_when_adding_deleting_port_connected(allowlist_alias, tech, proto, obfuscated, port):
@@ -71,7 +68,7 @@ def test_allowlist_does_not_create_new_routes_when_adding_deleting_port_connecte
     assert output_after_add == output_after_delete
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS])
 def test_allowlist_port_twice_disconnected(tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -90,7 +87,7 @@ def test_allowlist_port_twice_disconnected(tech, proto, obfuscated, port):
     assert not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -116,7 +113,7 @@ def test_allowlist_port_twice_connected(tech, proto, obfuscated, port):
     assert not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS + lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS + lib.PORTS_RANGE])
 def test_allowlist_port_and_remove_disconnected(tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -128,7 +125,7 @@ def test_allowlist_port_and_remove_disconnected(tech, proto, obfuscated, port):
     assert not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS + lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS + lib.PORTS_RANGE])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -144,7 +141,7 @@ def test_allowlist_port_and_remove_connected(tech, proto, obfuscated, port):
     assert firewall.is_active() and not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS])
 def test_allowlist_port_remove_nonexistent_disconnected(tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -159,7 +156,7 @@ def test_allowlist_port_remove_nonexistent_disconnected(tech, proto, obfuscated,
     assert expected_message in str(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -178,7 +175,7 @@ def test_allowlist_port_remove_nonexistent_connected(tech, proto, obfuscated, po
     assert expected_message in str(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
 def test_allowlist_port_range_remove_nonexistent_disconnected(tech, proto, obfuscated, port):
     port_range = port.value.split(":")
@@ -195,7 +192,7 @@ def test_allowlist_port_range_remove_nonexistent_disconnected(tech, proto, obfus
     assert expected_message in str(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -216,7 +213,7 @@ def test_allowlist_port_range_remove_nonexistent_connected(tech, proto, obfuscat
     assert expected_message in str(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
 def test_allowlist_port_range_twice_disconnected(tech, proto, obfuscated, port):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -227,7 +224,7 @@ def test_allowlist_port_range_twice_disconnected(tech, proto, obfuscated, port):
     assert not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -242,7 +239,7 @@ def test_allowlist_port_range_twice_connected(tech, proto, obfuscated, port):
     assert firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
 def test_allowlist_port_range_when_port_from_range_already_allowlisted_disconnected(tech, proto, obfuscated, port):
     port_range = port.value.split(":")
@@ -258,7 +255,7 @@ def test_allowlist_port_range_when_port_from_range_already_allowlisted_disconnec
     assert not firewall.is_active([port]) and not firewall.is_active([already_allowlisted_port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS_RANGE, ids=[f"{port.protocol}-{port.value}" for port in lib.PORTS_RANGE])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)

--- a/test/qa/test_allowlist_subnet.py
+++ b/test/qa/test_allowlist_subnet.py
@@ -19,21 +19,18 @@ from lib import (
 CIDR_32 = "/32"
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     firewall.add_and_delete_random_route()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
@@ -44,7 +41,7 @@ def teardown_function(function):
 
 @pytest.mark.parametrize("allowlist_alias", lib.ALLOWLIST_ALIAS)
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_allowlist_does_not_create_new_routes_when_adding_deleting_subnets_disconnected(allowlist_alias, tech, proto, obfuscated, subnet):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -62,7 +59,7 @@ def test_allowlist_does_not_create_new_routes_when_adding_deleting_subnets_disco
 
 @pytest.mark.parametrize("allowlist_alias", lib.ALLOWLIST_ALIAS)
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_allowlist_does_not_create_new_routes_when_adding_deleting_subnets_connected(allowlist_alias, tech, proto, obfuscated, subnet):
@@ -80,7 +77,7 @@ def test_allowlist_does_not_create_new_routes_when_adding_deleting_subnets_conne
     assert output_after_add == output_after_delete
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_allowlist_subnet(tech, proto, obfuscated):
@@ -103,7 +100,7 @@ def test_connect_allowlist_subnet(tech, proto, obfuscated):
     assert not firewall.is_active(None, ip_addresses_with_subnet)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_allowlist_subnet_connect(tech, proto, obfuscated):
@@ -126,7 +123,7 @@ def test_allowlist_subnet_connect(tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_allowlist_subnet_twice_disconnected(tech, proto, obfuscated, subnet):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -142,7 +139,7 @@ def test_allowlist_subnet_twice_disconnected(tech, proto, obfuscated, subnet):
 
 
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_allowlist_subnet_twice_connected(tech, proto, obfuscated, subnet):
@@ -164,7 +161,7 @@ def test_allowlist_subnet_twice_connected(tech, proto, obfuscated, subnet):
     assert not firewall.is_active(None, [subnet])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_allowlist_subnet_and_remove_disconnected(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -178,7 +175,7 @@ def test_allowlist_subnet_and_remove_disconnected(tech, proto, obfuscated):
     assert not firewall.is_active(None, ip_addresses_with_subnet)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_allowlist_subnet_and_remove_connected(tech, proto, obfuscated):
@@ -201,7 +198,7 @@ def test_allowlist_subnet_and_remove_connected(tech, proto, obfuscated):
     assert my_ip != network.get_external_device_ip()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
 def test_allowlist_subnet_remove_nonexistent_disconnected(tech, proto, obfuscated, subnet):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -213,7 +210,7 @@ def test_allowlist_subnet_remove_nonexistent_disconnected(tech, proto, obfuscate
     assert expected_message in str(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)

--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -1,24 +1,29 @@
-from lib import daemon, info, logging, login, network, server
-import lib
 import pytest
 import sh
 import timeout_decorator
 
+import lib
+from lib import daemon, info, logging, login, network, server
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()

--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -6,25 +6,21 @@ import lib
 from lib import daemon, info, logging, login, network, server
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
@@ -48,7 +44,7 @@ def autoconnect_base_test(group):
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_autoconnect_default(tech, proto, obfuscated):
@@ -56,7 +52,7 @@ def test_autoconnect_default(tech, proto, obfuscated):
     autoconnect_base_test("")
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_not_autoconnect(tech, proto, obfuscated):
@@ -70,7 +66,7 @@ def test_not_autoconnect(tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("group", lib.COUNTRIES + lib.COUNTRY_CODES)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_autoconnect_to_country(tech, proto, obfuscated, group):
@@ -79,7 +75,7 @@ def test_autoconnect_to_country(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.CITIES)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_autoconnect_to_city(tech, proto, obfuscated, group):
@@ -87,7 +83,7 @@ def test_autoconnect_to_city(tech, proto, obfuscated, group):
     autoconnect_base_test(group)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_autoconnect_to_random_server_by_name(tech, proto, obfuscated):
@@ -100,7 +96,7 @@ def test_autoconnect_to_random_server_by_name(tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("group", lib.STANDARD_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_autoconnect_to_standard_group(tech, proto, obfuscated, group):
@@ -109,7 +105,7 @@ def test_autoconnect_to_standard_group(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_autoconnect_to_additional_group(tech, proto, obfuscated, group):

--- a/test/qa/test_combinations.py
+++ b/test/qa/test_combinations.py
@@ -12,31 +12,27 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
 @pytest.mark.parametrize("group", lib.STANDARD_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_standard_group(tech, proto, obfuscated, group):
@@ -54,7 +50,7 @@ def test_connect_to_standard_group(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_additional_group(tech, proto, obfuscated, group):
@@ -71,8 +67,8 @@ def test_connect_to_additional_group(tech, proto, obfuscated, group):
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("target_tech,target_proto,target_obfuscated", lib.STANDARD_TECHNOLOGIES)
-@pytest.mark.parametrize("source_tech,source_proto,source_obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("target_tech", "target_proto", "target_obfuscated"), lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("source_tech", "source_proto", "source_obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_reconnect_matrix_standard(
@@ -103,8 +99,8 @@ def test_reconnect_matrix_standard(
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("target_tech,target_proto,target_obfuscated", lib.OBFUSCATED_TECHNOLOGIES)
-@pytest.mark.parametrize("source_tech,source_proto,source_obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("target_tech", "target_proto", "target_obfuscated"), lib.OBFUSCATED_TECHNOLOGIES)
+@pytest.mark.parametrize(("source_tech", "source_proto", "source_obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_reconnect_matrix_obfuscated(
@@ -135,7 +131,7 @@ def test_reconnect_matrix_obfuscated(
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("country, city", list(zip(lib.COUNTRIES, lib.CITIES)))
+@pytest.mark.parametrize(("country", "city"), list(zip(lib.COUNTRIES, lib.CITIES, strict=False)))
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_country_and_city(country, city):
@@ -162,8 +158,8 @@ def test_connect_country_and_city(country, city):
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("target_tech,target_proto,target_obfuscated", lib.STANDARD_TECHNOLOGIES)
-@pytest.mark.parametrize("source_tech,source_proto,source_obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("target_tech", "target_proto", "target_obfuscated"), lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("source_tech", "source_proto", "source_obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_status_change_technology_and_protocol(
@@ -196,8 +192,8 @@ def test_status_change_technology_and_protocol(
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("target_tech,target_proto,target_obfuscated", lib.STANDARD_TECHNOLOGIES)
-@pytest.mark.parametrize("source_tech,source_proto,source_obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("target_tech", "target_proto", "target_obfuscated"), lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("source_tech", "source_proto", "source_obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_status_change_technology_and_protocol_reconnect(

--- a/test/qa/test_combinations.py
+++ b/test/qa/test_combinations.py
@@ -1,3 +1,8 @@
+import pytest
+import sh
+import timeout_decorator
+
+import lib
 from lib import (
     daemon,
     info,
@@ -5,26 +10,26 @@ from lib import (
     login,
     network,
 )
-import lib
-import pytest
-import sh
-import timeout_decorator
 
 
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -71,12 +76,12 @@ def test_connect_to_additional_group(tech, proto, obfuscated, group):
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_reconnect_matrix_standard(
-    source_tech,
-    target_tech,
-    source_proto,
-    target_proto,
-    source_obfuscated,
-    target_obfuscated,
+        source_tech,
+        target_tech,
+        source_proto,
+        target_proto,
+        source_obfuscated,
+        target_obfuscated,
 ):
     lib.set_technology_and_protocol(source_tech, source_proto, source_obfuscated)
 
@@ -96,18 +101,19 @@ def test_reconnect_matrix_standard(
     print(output)
     assert lib.is_disconnect_successful(output)
     assert network.is_disconnected()
+
 
 @pytest.mark.parametrize("target_tech,target_proto,target_obfuscated", lib.OBFUSCATED_TECHNOLOGIES)
 @pytest.mark.parametrize("source_tech,source_proto,source_obfuscated", lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_reconnect_matrix_obfuscated(
-    source_tech,
-    target_tech,
-    source_proto,
-    target_proto,
-    source_obfuscated,
-    target_obfuscated,
+        source_tech,
+        target_tech,
+        source_proto,
+        target_proto,
+        source_obfuscated,
+        target_obfuscated,
 ):
     lib.set_technology_and_protocol(source_tech, source_proto, source_obfuscated)
 
@@ -127,8 +133,6 @@ def test_reconnect_matrix_obfuscated(
     print(output)
     assert lib.is_disconnect_successful(output)
     assert network.is_disconnected()
-
-
 
 
 @pytest.mark.parametrize("country, city", list(zip(lib.COUNTRIES, lib.CITIES)))
@@ -163,12 +167,12 @@ def test_connect_country_and_city(country, city):
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_status_change_technology_and_protocol(
-    source_tech,
-    target_tech,
-    source_proto,
-    target_proto,
-    source_obfuscated,
-    target_obfuscated,
+        source_tech,
+        target_tech,
+        source_proto,
+        target_proto,
+        source_obfuscated,
+        target_obfuscated,
 ):
     lib.set_technology_and_protocol(source_tech, source_proto, source_obfuscated)
 
@@ -197,12 +201,12 @@ def test_status_change_technology_and_protocol(
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_status_change_technology_and_protocol_reconnect(
-    source_tech,
-    target_tech,
-    source_proto,
-    target_proto,
-    source_obfuscated,
-    target_obfuscated,
+        source_tech,
+        target_tech,
+        source_proto,
+        target_proto,
+        source_obfuscated,
+        target_obfuscated,
 ):
     lib.set_technology_and_protocol(source_tech, source_proto, source_obfuscated)
 
@@ -210,7 +214,7 @@ def test_status_change_technology_and_protocol_reconnect(
         sh.nordvpn.connect()
 
     lib.set_technology_and_protocol(target_tech, target_proto, target_obfuscated)
-    
+
     with lib.Defer(sh.nordvpn.disconnect):
         sh.nordvpn.connect()
         assert target_tech.upper() in sh.nordvpn.status()

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -11,33 +11,30 @@ import lib
 from lib import daemon, info, logging, login, network, server, settings
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
 def capture_traffic() -> int:
     """
-    Captures traffic that goes to VPN server
-    :return: int - returns count of captured packets
+    Captures traffic that goes to VPN server.
+
+    :return: int - returns count of captured packets.
     """
 
     # Collect information needed for tshark filter
@@ -107,7 +104,7 @@ def disconnect_base_test():
     assert "nordlynx" not in sh.ip.a() and "nordtun" not in sh.ip.a()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_quick_connect(tech, proto, obfuscated):
@@ -117,7 +114,7 @@ def test_quick_connect(tech, proto, obfuscated):
     disconnect_base_test()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_quick_connect_double_only(tech, proto, obfuscated):
@@ -129,7 +126,7 @@ def test_quick_connect_double_only(tech, proto, obfuscated):
     disconnect_base_test()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_connect_to_server_absent(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -141,7 +138,7 @@ def test_connect_to_server_absent(tech, proto, obfuscated):
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_mistype_connect(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -153,7 +150,7 @@ def test_mistype_connect(tech, proto, obfuscated):
     assert network.is_disconnected()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_server_random_by_name(tech, proto, obfuscated):
@@ -165,7 +162,7 @@ def test_connect_to_server_random_by_name(tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_random_server_by_name_additional(tech, proto, obfuscated, group):
@@ -177,7 +174,7 @@ def test_connect_to_group_random_server_by_name_additional(tech, proto, obfuscat
 
 
 @pytest.mark.parametrize("group", lib.STANDARD_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_random_server_by_name_standard(tech, proto, obfuscated, group):
@@ -189,7 +186,7 @@ def test_connect_to_group_random_server_by_name_standard(tech, proto, obfuscated
 
 
 @pytest.mark.parametrize("group", lib.OVPN_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_random_server_by_name_ovpn(tech, proto, obfuscated, group):
@@ -201,7 +198,7 @@ def test_connect_to_group_random_server_by_name_ovpn(tech, proto, obfuscated, gr
 
 
 @pytest.mark.parametrize("group", lib.OVPN_OBFUSCATED_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OBFUSCATED_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OBFUSCATED_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_random_server_by_name_obfuscated(tech, proto, obfuscated, group):
@@ -213,7 +210,7 @@ def test_connect_to_group_random_server_by_name_obfuscated(tech, proto, obfuscat
 
 
 # the tun interface is recreated only for OpenVPN
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OBFUSCATED_TECHNOLOGIES + lib.OBFUSCATED_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OBFUSCATED_TECHNOLOGIES + lib.OBFUSCATED_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_network_restart_recreates_tun_interface(tech, proto, obfuscated):
@@ -232,7 +229,7 @@ def test_connect_network_restart_recreates_tun_interface(tech, proto, obfuscated
 
 
 # for Nordlynx normally the tunnel is not recreated
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES_BASIC1)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_BASIC1)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_network_restart_nordlynx(tech, proto, obfuscated):
@@ -254,7 +251,7 @@ def test_connect_network_restart_nordlynx(tech, proto, obfuscated):
         logging.log(info.collect())
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_quick_connect_double_disconnect(tech, proto, obfuscated):
@@ -265,7 +262,7 @@ def test_quick_connect_double_disconnect(tech, proto, obfuscated):
         disconnect_base_test()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_network_gone(tech, proto, obfuscated):
@@ -279,7 +276,7 @@ def test_connect_network_gone(tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("group", lib.STANDARD_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_standard(tech, proto, obfuscated, group):
@@ -290,7 +287,7 @@ def test_connect_to_group_standard(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_additional(tech, proto, obfuscated, group):
@@ -301,7 +298,7 @@ def test_connect_to_group_additional(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.OVPN_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_ovpn(tech, proto, obfuscated, group):
@@ -312,7 +309,7 @@ def test_connect_to_group_ovpn(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.OVPN_OBFUSCATED_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OBFUSCATED_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OBFUSCATED_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_obfuscated(tech, proto, obfuscated, group):
@@ -323,7 +320,7 @@ def test_connect_to_group_obfuscated(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.STANDARD_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_flag_group_standard(tech, proto, obfuscated, group):
@@ -340,7 +337,7 @@ def test_connect_to_flag_group_standard(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_flag_group_additional(tech, proto, obfuscated, group):
@@ -357,7 +354,7 @@ def test_connect_to_flag_group_additional(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.OVPN_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_flag_group_ovpn(tech, proto, obfuscated, group):
@@ -374,7 +371,7 @@ def test_connect_to_flag_group_ovpn(tech, proto, obfuscated, group):
 
 
 @pytest.mark.parametrize("group", lib.OVPN_OBFUSCATED_GROUPS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OBFUSCATED_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OBFUSCATED_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_flag_group_obfuscated(tech, proto, obfuscated, group):
@@ -390,7 +387,7 @@ def test_connect_to_flag_group_obfuscated(tech, proto, obfuscated, group):
     assert lib.is_connect_unsuccessful(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_group_invalid(tech, proto, obfuscated):
@@ -404,7 +401,7 @@ def test_connect_to_group_invalid(tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("country", lib.COUNTRIES)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_country(tech, proto, obfuscated, country):
@@ -415,7 +412,7 @@ def test_connect_to_country(tech, proto, obfuscated, country):
 
 
 @pytest.mark.parametrize("country_code", lib.COUNTRY_CODES)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_country_code(tech, proto, obfuscated, country_code):
@@ -426,7 +423,7 @@ def test_connect_to_country_code(tech, proto, obfuscated, country_code):
 
 
 @pytest.mark.parametrize("city", lib.CITIES)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_city(tech, proto, obfuscated, city):
@@ -437,8 +434,8 @@ def test_connect_to_city(tech, proto, obfuscated, city):
 
 
 def get_unavailable_groups():
-    """Returns groups that are not available with current connection settings"""
-    ALL_GROUPS = ['Africa_The_Middle_East_And_India',
+    """Returns groups that are not available with current connection settings."""
+    ALL_GROUPS = ['Africa_The_Middle_East_And_India',  # noqa: N806
                   'Asia_Pacific',
                   'Dedicated_IP',
                   'Double_VPN',
@@ -449,12 +446,13 @@ def get_unavailable_groups():
                   'Standard_VPN_Servers',
                   'The_Americas']
 
-    CURRENT_GROUPS = str(sh.nordvpn.groups()).strip("%-\r  ").strip().split(", ")
+    # TODO: Fix .strip("%-\r  ")
+    CURRENT_GROUPS = str(sh.nordvpn.groups()).strip("%-\r  ").strip().split(", ")  # noqa: B005, N806
 
     return set(ALL_GROUPS) - set(CURRENT_GROUPS)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_unavailable_groups(tech, proto, obfuscated):
@@ -463,7 +461,7 @@ def test_connect_to_unavailable_groups(tech, proto, obfuscated):
 
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    UNAVAILABLE_GROUPS = get_unavailable_groups()
+    UNAVAILABLE_GROUPS = get_unavailable_groups()  # noqa: N806
     logging.log("UNAVAILABLE_GROUPS: " + str(UNAVAILABLE_GROUPS))
 
     for group in UNAVAILABLE_GROUPS:
@@ -475,7 +473,7 @@ def test_connect_to_unavailable_groups(tech, proto, obfuscated):
         assert lib.is_connect_unsuccessful(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connect_to_unavailable_servers(tech, proto, obfuscated):
@@ -484,7 +482,7 @@ def test_connect_to_unavailable_servers(tech, proto, obfuscated):
 
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    UNAVAILABLE_GROUPS = get_unavailable_groups()
+    UNAVAILABLE_GROUPS = get_unavailable_groups()  # noqa: N806
     logging.log("UNAVAILABLE_GROUPS: " + str(UNAVAILABLE_GROUPS))
 
     for group in UNAVAILABLE_GROUPS:
@@ -497,7 +495,7 @@ def test_connect_to_unavailable_servers(tech, proto, obfuscated):
         assert lib.is_connect_unsuccessful(ex)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(60)
 def test_status_connected(tech, proto, obfuscated):
@@ -517,11 +515,12 @@ def test_status_connected(tech, proto, obfuscated):
 
         status_time = time.monotonic()
 
-        status_output = sh.nordvpn.status().lstrip('\r-\r  \r\r-\r  \r')
-        status_info = dict((a.strip().lower(), b.strip())
+        # TODO: Fix .lstrip('\r-\r  \r\r-\r  \r')
+        status_output = sh.nordvpn.status().lstrip('\r-\r  \r\r-\r  \r')  # noqa: B005
+        status_info = {a.strip().lower(): b.strip()
                            for a, b in (element.split(':')
                                         for element in
-                                        filter(lambda line: len(line.split(':')) == 2, status_output.split('\n'))))
+                                        filter(lambda line: len(line.split(':')) == 2, status_output.split('\n')))}
 
         print("status_info: " + str(status_info))
         print("status_info: " + str(sh.nordvpn.status()))

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -518,9 +518,9 @@ def test_status_connected(tech, proto, obfuscated):
         # TODO: Fix .lstrip('\r-\r  \r\r-\r  \r')
         status_output = sh.nordvpn.status().lstrip('\r-\r  \r\r-\r  \r')  # noqa: B005
         status_info = {a.strip().lower(): b.strip()
-                           for a, b in (element.split(':')
-                                        for element in
-                                        filter(lambda line: len(line.split(':')) == 2, status_output.split('\n')))}
+                       for a, b in (element.split(':')
+                                    for element in
+                                    filter(lambda line: len(line.split(':')) == 2, status_output.split('\n')))}
 
         print("status_info: " + str(status_info))
         print("status_info: " + str(sh.nordvpn.status()))

--- a/test/qa/test_connect6.py
+++ b/test/qa/test_connect6.py
@@ -1,3 +1,10 @@
+import random
+
+import pytest
+import sh
+import timeout_decorator
+
+import lib
 from lib import (
     daemon,
     info,
@@ -5,27 +12,26 @@ from lib import (
     login,
     network,
 )
-import lib
-import pytest
-import random
-import sh
-import timeout_decorator
 
 
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()

--- a/test/qa/test_connect6.py
+++ b/test/qa/test_connect6.py
@@ -14,30 +14,26 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES_WITH_IPV6[:-1])
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_WITH_IPV6[:-1])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_ipv6_connect(tech, proto, obfuscated):

--- a/test/qa/test_dns.py
+++ b/test/qa/test_dns.py
@@ -6,36 +6,32 @@ import lib
 from lib import daemon, dns, info, logging, login, settings
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
-    # Make sure that Custom DNS, IPv6 and Threat Protection Lite are disabled before we execute each test 
+    # Make sure that Custom DNS, IPv6 and Threat Protection Lite are disabled before we execute each test
     lib.set_dns("off")
     lib.set_ipv6("off")
     lib.set_threat_protection_lite("off")
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
 @pytest.mark.parametrize("tpl_alias", dns.TPL_ALIAS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_set_tpl_on_off_connected(tpl_alias, tech, proto, obfuscated):
@@ -64,7 +60,7 @@ def test_set_tpl_on_off_connected(tpl_alias, tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("tpl_alias", dns.TPL_ALIAS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_set_tpl_on_and_connect(tpl_alias, tech, proto, obfuscated):
@@ -85,7 +81,7 @@ def test_set_tpl_on_and_connect(tpl_alias, tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("tpl_alias", dns.TPL_ALIAS)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_set_tpl_off_and_connect(tpl_alias, tech, proto, obfuscated):
@@ -108,7 +104,7 @@ def test_set_tpl_off_and_connect(tpl_alias, tech, proto, obfuscated):
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_tpl_on_set_custom_dns_disconnected(tech, proto, obfuscated, nameserver):
@@ -128,7 +124,7 @@ def test_tpl_on_set_custom_dns_disconnected(tech, proto, obfuscated, nameserver)
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_tpl_on_set_custom_dns_connected(tech, proto, obfuscated, nameserver):
@@ -151,7 +147,7 @@ def test_tpl_on_set_custom_dns_connected(tech, proto, obfuscated, nameserver):
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_connect(tech, proto, obfuscated, nameserver):
@@ -173,7 +169,7 @@ def test_custom_dns_connect(tech, proto, obfuscated, nameserver):
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_off_connect(tech, proto, obfuscated, nameserver):
@@ -197,7 +193,7 @@ def test_custom_dns_off_connect(tech, proto, obfuscated, nameserver):
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_set_custom_dns_connected(tech, proto, obfuscated, nameserver):
@@ -216,7 +212,7 @@ def test_set_custom_dns_connected(tech, proto, obfuscated, nameserver):
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_set_custom_dns_off_connected(tech, proto, obfuscated, nameserver):
@@ -238,8 +234,8 @@ def test_set_custom_dns_off_connected(tech, proto, obfuscated, nameserver):
     assert dns.is_unset()
 
 
-@pytest.mark.parametrize("nameserver,expected_error", dns.DNS_CASES_ERROR)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("nameserver", "expected_error"), dns.DNS_CASES_ERROR)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_errors_disconnected(tech, proto, obfuscated, nameserver, expected_error):
@@ -253,8 +249,8 @@ def test_custom_dns_errors_disconnected(tech, proto, obfuscated, nameserver, exp
     assert dns.is_unset()
 
 
-@pytest.mark.parametrize("nameserver,expected_error", dns.DNS_CASES_ERROR)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("nameserver", "expected_error"), dns.DNS_CASES_ERROR)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_errors_connected(tech, proto, obfuscated, nameserver, expected_error):
@@ -274,7 +270,7 @@ def test_custom_dns_errors_connected(tech, proto, obfuscated, nameserver, expect
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_already_set_disconnected(tech, proto, obfuscated, nameserver):
@@ -295,7 +291,7 @@ def test_custom_dns_already_set_disconnected(tech, proto, obfuscated, nameserver
 
 
 @pytest.mark.parametrize("nameserver", dns.DNS_CASES_CUSTOM)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_already_set_connected(tech, proto, obfuscated, nameserver):
@@ -320,7 +316,7 @@ def test_custom_dns_already_set_connected(tech, proto, obfuscated, nameserver):
     assert dns.is_unset()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_already_disabled_disconnected(tech, proto, obfuscated):
@@ -334,7 +330,7 @@ def test_custom_dns_already_disabled_disconnected(tech, proto, obfuscated):
     assert dns.is_unset()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_custom_dns_already_disabled_connected(tech, proto, obfuscated):

--- a/test/qa/test_dns6.py
+++ b/test/qa/test_dns6.py
@@ -1,28 +1,26 @@
-from lib import (
-    daemon,
-    dns,
-    info,
-    logging,
-    login,
-    settings
-)
-import lib
-import pytest
 import random
+
+import pytest
 import sh
 import timeout_decorator
 
+import lib
+from lib import daemon, dns, info, logging, login, settings
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
@@ -32,6 +30,7 @@ def setup_function(function):
     lib.set_threat_protection_lite("off")
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -53,11 +52,11 @@ def test_dns_connect(tech, proto, obfuscated, threat_protection_lite):
 
         if threat_protection_lite == "on":
             assert settings.get_is_tpl_enabled()
-            assert settings.dns_visible_in_settings("disabled")
+            assert settings.dns_visible_in_settings(["disabled"])
             assert dns.is_set_for(dns.DNS_TPL_IPV6 + dns.DNS_TPL)
         else:
             assert not settings.get_is_tpl_enabled()
-            assert settings.dns_visible_in_settings("disabled")
+            assert settings.dns_visible_in_settings(["disabled"])
             assert dns.is_set_for(dns.DNS_NORD_IPV6 + dns.DNS_NORD)
 
     assert dns.is_unset()
@@ -82,12 +81,12 @@ def test_set_dns_connected(tech, proto, obfuscated):
         sh.nordvpn.connect(random.choice(lib.IPV6_SERVERS))
 
         assert not settings.get_is_tpl_enabled()
-        assert settings.dns_visible_in_settings("disabled")
+        assert settings.dns_visible_in_settings(["disabled"])
         assert dns.is_set_for(dns.DNS_NORD_IPV6 + dns.DNS_NORD)
 
         lib.set_threat_protection_lite("on")
         assert settings.get_is_tpl_enabled()
-        assert settings.dns_visible_in_settings("disabled")
+        assert settings.dns_visible_in_settings(["disabled"])
         assert dns.is_set_for(dns.DNS_TPL_IPV6 + dns.DNS_TPL)
 
     assert dns.is_unset()

--- a/test/qa/test_dns6.py
+++ b/test/qa/test_dns6.py
@@ -8,20 +8,17 @@ import lib
 from lib import daemon, dns, info, logging, login, settings
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
     # Make sure that Custom DNS, IPv6 and Threat Protection Lite are disabled before we execute each test
@@ -30,14 +27,13 @@ def setup_function(function):
     lib.set_threat_protection_lite("off")
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
 @pytest.mark.parametrize("threat_protection_lite", lib.THREAT_PROTECTION_LITE)
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_dns_connect(tech, proto, obfuscated, threat_protection_lite):
@@ -62,7 +58,7 @@ def test_dns_connect(tech, proto, obfuscated, threat_protection_lite):
     assert dns.is_unset()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_set_dns_connected(tech, proto, obfuscated):

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -15,13 +15,12 @@ from lib import daemon, fileshare, info, logging, login, meshnet, poll, ssh
 ssh_client = ssh.Ssh("qa-peer", "root", "root")
 
 workdir = "/tmp"
-testFiles = ["testing_fileshare_0.txt", "testing_fileshare_1.txt", "testing_fileshare_2.txt", "testing_fileshare_3.txt"]
+test_files = ["testing_fileshare_0.txt", "testing_fileshare_1.txt", "testing_fileshare_2.txt", "testing_fileshare_3.txt"]
 
 default_download_directory = "/home/qa/Downloads"
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
     lib.set_technology_and_protocol("nordlynx", "", "")
@@ -45,7 +44,7 @@ def setup_module(module):
     assert meshnet.is_peer_reachable(ssh_client)
 
     message = "testing fileshare"
-    for file in testFiles:
+    for file in test_files:
         filepath = f"{workdir}/{file}"
         with open(filepath, "w") as f:
             f.write(message)
@@ -53,8 +52,7 @@ def setup_module(module):
     ssh_client.exec_command("mkdir /root/Downloads")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     dest_logs_path = f"{os.environ['WORKDIR']}/dist/logs"
     # Preserve other peer log
     output = ssh_client.exec_command("cat /var/log/nordvpn/daemon.log")
@@ -72,13 +70,11 @@ def teardown_module(module):
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
     ssh_client.exec_command("rm -rf /tmp/*")
@@ -139,7 +135,7 @@ def test_accept(accept_directories):
 
     local_transfer_id = None
     error_message = None
-    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
+    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):  # noqa: B007
         if local_transfer_id is not None:
             break
 
@@ -165,7 +161,7 @@ def test_accept(accept_directories):
 
     receiver_files_status_ok = False
     transfer = None
-    for receiver_files_status_ok, transfer in poll(check_files_status_receiver, attempts=10):
+    for receiver_files_status_ok, transfer in poll(check_files_status_receiver, attempts=10):  # noqa: B007
         if receiver_files_status_ok is True:
             break
 
@@ -176,7 +172,7 @@ def test_accept(accept_directories):
         return fileshare.for_all_files_in_transfer(tsfr, transfer_files, predicate), tsfr
 
     sender_files_status_ok = False
-    for sender_files_status_ok, transfer in poll(check_files_status_sender, attempts=10):
+    for sender_files_status_ok, transfer in poll(check_files_status_sender, attempts=10):  # noqa: B007
         if sender_files_status_ok is True:
             break
 
@@ -249,7 +245,7 @@ def test_fileshare_transfer_multiple_files(background: bool, peer_name: meshnet.
     dir3 = fileshare.create_directory(2, "3")
 
     # transfer dir1 and dir2 as directories and individual files from dir3, i.e /<dir1> /<dir2> /<dir3>/<file1> /<dir3>/<file2>
-    files_to_transfer = [dir1.dir_path, dir2.dir_path] + dir3.paths
+    files_to_transfer = [dir1.dir_path, dir2.dir_path, *dir3.paths]
 
     if background:
         command_handle = sh.nordvpn.fileshare.send("--background", peer_address, *files_to_transfer)
@@ -498,7 +494,7 @@ def test_transfers_persistence():
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_this_device_ipv4(output)
 
-    sh.nordvpn.fileshare.send("--background", peer_address, f"{workdir}/{testFiles[0]}")
+    sh.nordvpn.fileshare.send("--background", peer_address, f"{workdir}/{test_files[0]}")
 
     time.sleep(1)
 
@@ -536,7 +532,7 @@ def test_transfers_persistence_load():
     nordvpnd_memory_usage = get_memory_usage(int(nordvpnd_pid))
     nordfileshared_memory_usage = get_memory_usage(int(nordfileshared_pid))
 
-    filepath = f"{workdir}/{testFiles[0]}"
+    filepath = f"{workdir}/{test_files[0]}"
 
     # give time to start and connect
     time.sleep(1)
@@ -618,9 +614,9 @@ def get_memory_usage(pid):
 
 
 def format_memory_usage(rss):
-    KB = 1024
-    MB = 1024 * 1024
-    GB = 1024 * 1024 * 1024
+    KB = 1024  # noqa: N806
+    MB = 1024 * 1024  # noqa: N806
+    GB = 1024 * 1024 * 1024  # noqa: N806
 
     if rss >= GB:
         return f'{round(rss / GB, 2)}gb'
@@ -722,7 +718,7 @@ def test_accept_destination_directory_does_not_exist():
 
     local_transfer_id = None
     error_message = None
-    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
+    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):  # noqa: B007
         if local_transfer_id is not None:
             break
 
@@ -744,7 +740,7 @@ def test_accept_destination_directory_symlink():
 
     local_transfer_id = None
     error_message = None
-    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
+    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):  # noqa: B007
         if local_transfer_id is not None:
             break
 
@@ -772,7 +768,7 @@ def test_accept_destination_directory_not_a_directory():
 
     local_transfer_id = None
     error_message = None
-    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
+    for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):  # noqa: B007
         if local_transfer_id is not None:
             break
 
@@ -788,7 +784,7 @@ def test_accept_destination_directory_not_a_directory():
 def test_autoaccept():
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_name = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
-    subprocess.run(["nordvpn", "mesh", "peer", "auto-accept", "enable", peer_name])
+    subprocess.run(["nordvpn", "mesh", "peer", "auto-accept", "enable", peer_name], check=False)
     # subprocess.run(["nordvpn", "mesh", "peer", "auto-accept", "enable", peer_name])
 
     time.sleep(10)
@@ -868,7 +864,7 @@ def test_clear():
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_this_device_ipv4(output)
 
-    sh.nordvpn.fileshare.send("--background", peer_address, f"{workdir}/{testFiles[0]}")
+    sh.nordvpn.fileshare.send("--background", peer_address, f"{workdir}/{test_files[0]}")
     time.sleep(1)
     local_transfer_id0 = fileshare.get_last_transfer()
     peer_transfer_id0 = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
@@ -883,7 +879,7 @@ def test_clear():
     transfer_time0 = time.time()
     time.sleep(3)
 
-    sh.nordvpn.fileshare.send("--background", peer_address, f"{workdir}/{testFiles[1]}")
+    sh.nordvpn.fileshare.send("--background", peer_address, f"{workdir}/{test_files[1]}")
     time.sleep(1)
     local_transfer_id1 = fileshare.get_last_transfer()
     peer_transfer_id1 = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1,17 +1,16 @@
-from lib import daemon, info, logging, login, meshnet, ssh, fileshare, poll
-import lib
-import sh
-import re
-import time
-import pytest
-import tempfile
 import os
-import psutil
-import subprocess
+import re
 import shutil
-import pwd
+import subprocess
+import tempfile
+import time
 
-import logging as logger
+import psutil
+import pytest
+import sh
+
+import lib
+from lib import daemon, fileshare, info, logging, login, meshnet, poll, ssh
 
 ssh_client = ssh.Ssh("qa-peer", "root", "root")
 
@@ -20,6 +19,8 @@ testFiles = ["testing_fileshare_0.txt", "testing_fileshare_1.txt", "testing_file
 
 default_download_directory = "/home/qa/Downloads"
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
@@ -49,13 +50,14 @@ def setup_module(module):
         with open(filepath, "w") as f:
             f.write(message)
 
-    ssh_client.exec_command(f"mkdir /root/Downloads")
+    ssh_client.exec_command("mkdir /root/Downloads")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     dest_logs_path = f"{os.environ['WORKDIR']}/dist/logs"
-    # Presere other peer log
-    output = ssh_client.exec_command(f"cat /var/log/nordvpn/daemon.log")
+    # Preserve other peer log
+    output = ssh_client.exec_command("cat /var/log/nordvpn/daemon.log")
     with open(f"{dest_logs_path}/other-peer-daemon.log", "w") as f:
         f.write(output)
     shutil.copy("/home/qa/.config/nordvpn/nordfileshared.log", dest_logs_path)
@@ -70,10 +72,12 @@ def teardown_module(module):
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -81,10 +85,10 @@ def teardown_function(function):
 
 
 @pytest.mark.parametrize("accept_directories",
-    [["nested", "outer"],
-    ["nested"],
-    ["outer", "nested/inner"],
-    ["nested/inner"]])
+                         [["nested", "outer"],
+                          ["nested"],
+                          ["outer", "nested/inner"],
+                          ["nested/inner"]])
 def test_accept(accept_directories):
     output = f'{sh.nordvpn.mesh.peer.list(_tty_out=False)}'
     address = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
@@ -131,8 +135,10 @@ def test_accept(accept_directories):
     logging.log(data="------------------------------------------------------")
 
     # accept entire transfer
-    output = ssh_client.exec_command(f"nordvpn fileshare send --background {address} {nested_dir} {outer_dir}")
+    ssh_client.exec_command(f"nordvpn fileshare send --background {address} {nested_dir} {outer_dir}")
 
+    local_transfer_id = None
+    error_message = None
     for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
         if local_transfer_id is not None:
             break
@@ -141,7 +147,7 @@ def test_accept(accept_directories):
 
     peer_transfer_id = fileshare.get_last_transfer(ssh_client=ssh_client)
 
-    output = sh.nordvpn.fileshare.accept("--background", "--path", "/tmp", local_transfer_id, *accept_directories).stdout.decode("utf-8")
+    sh.nordvpn.fileshare.accept("--background", "--path", "/tmp", local_transfer_id, *accept_directories).stdout.decode("utf-8")
 
     def predicate(file_entry: str) -> bool:
         file_entry_columns = file_entry.split(' ')
@@ -154,9 +160,11 @@ def test_accept(accept_directories):
         return False
 
     def check_files_status_receiver():
-        transfer = sh.nordvpn.fileshare.list(local_transfer_id).stdout.decode("utf-8")
-        return fileshare.for_all_files_in_transfer(transfer, transfer_files, predicate), transfer
+        tsfr = sh.nordvpn.fileshare.list(local_transfer_id).stdout.decode("utf-8")
+        return fileshare.for_all_files_in_transfer(tsfr, transfer_files, predicate), tsfr
 
+    receiver_files_status_ok = False
+    transfer = None
     for receiver_files_status_ok, transfer in poll(check_files_status_receiver, attempts=10):
         if receiver_files_status_ok is True:
             break
@@ -164,9 +172,10 @@ def test_accept(accept_directories):
     assert receiver_files_status_ok is True, f"invalid file status on receiver side, transfer {transfer}, files {accept_directories} should be downloaded"
 
     def check_files_status_sender():
-        transfer = ssh_client.exec_command(f"nordvpn fileshare list {peer_transfer_id}")
-        return fileshare.for_all_files_in_transfer(transfer, transfer_files, predicate), transfer
+        tsfr = ssh_client.exec_command(f"nordvpn fileshare list {peer_transfer_id}")
+        return fileshare.for_all_files_in_transfer(tsfr, transfer_files, predicate), tsfr
 
+    sender_files_status_ok = False
     for sender_files_status_ok, transfer in poll(check_files_status_sender, attempts=10):
         if sender_files_status_ok is True:
             break
@@ -180,9 +189,9 @@ def test_fileshare_transfer(background: bool, peer_name: meshnet.PeerName):
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_peer_name(output, peer_name)
 
-    workdir = fileshare.create_directory(1)
+    wdir = fileshare.create_directory(1)
 
-    filepath = workdir.paths[0]
+    filepath = wdir.paths[0]
     message = "testing fileshare"
     with open(filepath, "w", encoding="utf-8") as file:
         file.write(message)
@@ -199,7 +208,7 @@ def test_fileshare_transfer(background: bool, peer_name: meshnet.PeerName):
     local_transfer_id = fileshare.get_last_transfer()
     peer_transfer_id = None
 
-    for last_peer_transfer_id, _ in poll(lambda : fileshare.get_new_incoming_transfer(ssh_client), attempts=10):
+    for last_peer_transfer_id, _ in poll(lambda: fileshare.get_new_incoming_transfer(ssh_client), attempts=10):
         if last_peer_transfer_id is not None:
             peer_transfer_id = last_peer_transfer_id
             break
@@ -210,7 +219,7 @@ def test_fileshare_transfer(background: bool, peer_name: meshnet.PeerName):
 
     time.sleep(1)
 
-    peer_filepath = f"/tmp/{workdir.filenames[0]}"
+    peer_filepath = f"/tmp/{wdir.filenames[0]}"
     output = ssh_client.exec_command(f"cat {peer_filepath}")
     assert message in output
 
@@ -284,13 +293,13 @@ def test_fileshare_transfer_multiple_files_selective_accept(background: bool):
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
 
-    workdir = fileshare.create_directory(4)
+    wdir = fileshare.create_directory(4)
 
     if background:
-        output = sh.nordvpn.fileshare.send("--background", peer_address, workdir.dir_path).stdout.decode("utf-8")
+        output = sh.nordvpn.fileshare.send("--background", peer_address, wdir.dir_path).stdout.decode("utf-8")
         assert len(re.findall(r'File transfer ?([a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12}) has started in the background.', output)) > 0
     else:
-        fileshare.start_transfer(peer_address, workdir.dir_path)
+        fileshare.start_transfer(peer_address, wdir.dir_path)
 
     time.sleep(1)
 
@@ -298,34 +307,34 @@ def test_fileshare_transfer_multiple_files_selective_accept(background: bool):
     peer_transfer_id = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
 
     transfer = sh.nordvpn.fileshare.list(local_transfer_id).stdout.decode("utf-8")
-    assert fileshare.for_all_files_in_transfer(transfer, workdir.transfer_paths, lambda file_entry: "request sent" in file_entry)
+    assert fileshare.for_all_files_in_transfer(transfer, wdir.transfer_paths, lambda file_entry: "request sent" in file_entry)
 
-    output = ssh_client.exec_command(
-        f"nordvpn fileshare accept --path / {peer_transfer_id} {workdir.transfer_paths[0]} {workdir.transfer_paths[2]}"
+    ssh_client.exec_command(
+        f"nordvpn fileshare accept --path / {peer_transfer_id} {wdir.transfer_paths[0]} {wdir.transfer_paths[2]}"
     )
 
     time.sleep(1)
 
     transfer = sh.nordvpn.fileshare.list(local_transfer_id).stdout.decode("utf-8")
-    assert "uploaded" in fileshare.find_file_in_transfer(workdir.transfer_paths[0], transfer.split("\n"))
-    assert "canceled" in fileshare.find_file_in_transfer(workdir.transfer_paths[1], transfer.split("\n"))
-    assert "uploaded" in fileshare.find_file_in_transfer(workdir.transfer_paths[2], transfer.split("\n"))
-    assert "canceled" in fileshare.find_file_in_transfer(workdir.transfer_paths[3], transfer.split("\n"))
+    assert "uploaded" in fileshare.find_file_in_transfer(wdir.transfer_paths[0], transfer.split("\n"))
+    assert "canceled" in fileshare.find_file_in_transfer(wdir.transfer_paths[1], transfer.split("\n"))
+    assert "uploaded" in fileshare.find_file_in_transfer(wdir.transfer_paths[2], transfer.split("\n"))
+    assert "canceled" in fileshare.find_file_in_transfer(wdir.transfer_paths[3], transfer.split("\n"))
 
     transfer = ssh_client.exec_command(f"nordvpn fileshare list {peer_transfer_id}")
-    assert "downloaded" in fileshare.find_file_in_transfer(workdir.transfer_paths[0], transfer.split("\n"))
-    assert "canceled" in fileshare.find_file_in_transfer(workdir.transfer_paths[1], transfer.split("\n"))
-    assert "downloaded" in fileshare.find_file_in_transfer(workdir.transfer_paths[2], transfer.split("\n"))
-    assert "canceled" in fileshare.find_file_in_transfer(workdir.transfer_paths[3], transfer.split("\n"))
+    assert "downloaded" in fileshare.find_file_in_transfer(wdir.transfer_paths[0], transfer.split("\n"))
+    assert "canceled" in fileshare.find_file_in_transfer(wdir.transfer_paths[1], transfer.split("\n"))
+    assert "downloaded" in fileshare.find_file_in_transfer(wdir.transfer_paths[2], transfer.split("\n"))
+    assert "canceled" in fileshare.find_file_in_transfer(wdir.transfer_paths[3], transfer.split("\n"))
 
 
-def test_fileshare_gracefull_cancel():
-    workdir = fileshare.create_directory(1)
+def test_fileshare_graceful_cancel():
+    wdir = fileshare.create_directory(1)
 
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
 
-    command_handle = fileshare.start_transfer(peer_address, *workdir.paths)
+    command_handle = fileshare.start_transfer(peer_address, *wdir.paths)
 
     time.sleep(1)
 
@@ -336,17 +345,17 @@ def test_fileshare_gracefull_cancel():
     local_transfer_id = fileshare.get_last_transfer()
     peer_transfer_id = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
 
-    assert workdir.filenames[0] in sh.nordvpn.fileshare.list(local_transfer_id)
+    assert wdir.filenames[0] in sh.nordvpn.fileshare.list(local_transfer_id)
     assert "canceled" in sh.nordvpn.fileshare.list(local_transfer_id)
 
     output = ssh_client.exec_command(f"nordvpn fileshare list {peer_transfer_id}")
-    assert workdir.filenames[0] in output
+    assert wdir.filenames[0] in output
     assert "canceled" in output
 
     assert command_handle.is_alive() is False
     assert command_handle.exit_code == 0
 
-    transfers = ssh_client.exec_command(f"nordvpn fileshare list")
+    transfers = ssh_client.exec_command("nordvpn fileshare list")
     assert "canceled by peer" in fileshare.find_transfer_by_id(transfers, peer_transfer_id)
 
     transfers = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
@@ -361,13 +370,13 @@ def test_fileshare_cancel_transfer(background: bool, single_file: bool, sender_c
     peer_address = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
 
     if single_file:
-        dir = fileshare.create_directory(1)
-        path = dir.paths[0]
-        expected_files = [dir.filenames[0]]
+        d = fileshare.create_directory(1)
+        path = d.paths[0]
+        expected_files = [d.filenames[0]]
     else:
-        dir = fileshare.create_directory(5)
-        path = dir.dir_path
-        expected_files = dir.transfer_paths
+        d = fileshare.create_directory(5)
+        path = d.dir_path
+        expected_files = d.transfer_paths
 
     if background:
         command_handle = sh.nordvpn.fileshare.send("--background", peer_address, path)
@@ -385,7 +394,7 @@ def test_fileshare_cancel_transfer(background: bool, single_file: bool, sender_c
         if not background:
             output = command_handle.stdout.decode("utf-8")
             assert len(re.findall(fileshare.SEND_CANCELED_BY_OTHER_PROCESS_PATTERN, output)) > 0
-    else: # receiver cancels
+    else:  # receiver cancels
         output = ssh_client.exec_command(f"nordvpn fileshare cancel {peer_transfer_id}")
         assert fileshare.CANCEL_SUCCESS_SENDER_SIDE_MSG in output
         if not background:
@@ -409,7 +418,7 @@ def test_fileshare_cancel_transfer(background: bool, single_file: bool, sender_c
 
         transfers = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
         assert "canceled" in fileshare.find_transfer_by_id(transfers, local_transfer_id)
-    else: # receiver cancels
+    else:  # receiver cancels
         transfers = ssh_client.exec_command("nordvpn fileshare list")
         assert "canceled" in fileshare.find_transfer_by_id(transfers, peer_transfer_id)
 
@@ -422,22 +431,22 @@ def test_fileshare_cancel_file_not_in_flight(sender_cancels: bool):
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
 
-    workdir = fileshare.create_directory(5)
-    sh.nordvpn.fileshare.send("--background", peer_address, workdir.dir_path)
+    wdir = fileshare.create_directory(5)
+    sh.nordvpn.fileshare.send("--background", peer_address, wdir.dir_path)
 
     time.sleep(1)
 
     local_transfer_id = fileshare.get_last_transfer()
     peer_transfer_id = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
 
-    file_to_cancel = workdir.transfer_paths[2]
+    file_to_cancel = wdir.transfer_paths[2]
     if sender_cancels:
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
-            output = sh.nordvpn.fileshare.cancel(local_transfer_id, file_to_cancel)
+            sh.nordvpn.fileshare.cancel(local_transfer_id, file_to_cancel)
             assert "This file is not in progress." in ex
-    else: # receiver cancels
+    else:  # receiver cancels
         with pytest.raises(RuntimeError) as ex:
-            output = ssh_client.exec_command(f"nordvpn fileshare cancel {peer_transfer_id} {file_to_cancel}")
+            ssh_client.exec_command(f"nordvpn fileshare cancel {peer_transfer_id} {file_to_cancel}")
             assert "This file is not in progress." in ex
 
 
@@ -448,8 +457,8 @@ def test_fileshare_file_limit_exceeded(background: bool, multiple_directories: b
     peer_address = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
 
     if multiple_directories:
-        workdir = fileshare.create_directory(1001)
-        dirs = [workdir.dir_path]
+        wdir = fileshare.create_directory(1001)
+        dirs = [wdir.dir_path]
     else:
         dir1 = fileshare.create_directory(400)
         dir2 = fileshare.create_directory(400)
@@ -484,6 +493,7 @@ def test_fileshare_file_directory_depth_exceeded(background: bool):
 
     assert "File depth cannot exceed 5 directories. Try archiving the directory." in str(ex.value)
 
+
 def test_transfers_persistence():
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_this_device_ipv4(output)
@@ -495,14 +505,14 @@ def test_transfers_persistence():
     local_transfer_id = fileshare.get_last_transfer()
     peer_transfer_id = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
 
-    ssh_client.exec_command("nordvpn fileshare accept {}".format(peer_transfer_id))
+    ssh_client.exec_command(f"nordvpn fileshare accept {peer_transfer_id}")
 
     sh.nordvpn.set.mesh.off()
     sh.nordvpn.set.mesh.on()
     time.sleep(1)
 
     assert local_transfer_id in sh.nordvpn.fileshare.list()
-    assert meshnet.is_peer_reachable(ssh_client) # Wait to reestablish connection for further tests
+    assert meshnet.is_peer_reachable(ssh_client)  # Wait to reestablish connection for further tests
     sh.nordvpn.mesh.peer.refresh()
 
 
@@ -537,32 +547,32 @@ def test_transfers_persistence_load():
     assert len(peer_address.strip()) != 0
     assert meshnet.is_peer_reachable(ssh_client)
 
-    min_send_time_ns = 100000000000 # 100s
+    min_send_time_ns = 100000000000  # 100s
     min_send_time_itr = 0
     max_send_time_ns = 0
     max_send_time_itr = 0
     sleep_s = 1
-    sleep_ns = sleep_s * 1000 * 1000 * 1000 # nanoseconds
+    sleep_ns = sleep_s * 1000 * 1000 * 1000  # nanoseconds
 
     transfers_count = 50
-    nordfileshared_mem_delta_max_limit = 35000000 # bytes
+    nordfileshared_mem_delta_max_limit = 35000000  # bytes
 
-    logging.log("test_transfers_persistence_load: start loop range: 0..{}".format(transfers_count))
+    logging.log(f"test_transfers_persistence_load: start loop range: 0..{transfers_count}")
 
     total_send_time_ns = 0
     start_time_ns = time.time_ns()
 
     for i in range(transfers_count):
         start2_time_ns = time.time_ns()
-        logging.log("[{:5d}/{}]a peer_address[ {} ] file[ {} ]".format(i, transfers_count, peer_address, filepath))
+        logging.log(f"[{i:5d}/{transfers_count}]a peer_address[ {peer_address} ] file[ {filepath} ]")
         output = sh.nordvpn.fileshare.send("--background", peer_address, filepath)
-        logging.log("[{:5d}/{}]b fileshare send output[ {} ]".format(i, transfers_count, output))
+        logging.log(f"[{i:5d}/{transfers_count}]b fileshare send output[ {output} ]")
         time.sleep(sleep_s)
 
         local_transfer_id = fileshare.get_last_transfer()
         peer_transfer_id = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
-        logging.log(data="[{:5d}/{}]c transferID[ {} ]".format(i, transfers_count, local_transfer_id))
-        ssh_client.exec_command("nordvpn fileshare accept {}".format(peer_transfer_id))
+        logging.log(data=f"[{i:5d}/{transfers_count}]c transferID[ {local_transfer_id} ]")
+        ssh_client.exec_command(f"nordvpn fileshare accept {peer_transfer_id}")
 
         send_time_ns = (time.time_ns() - start2_time_ns) - sleep_ns
         total_send_time_ns += send_time_ns
@@ -589,13 +599,13 @@ def test_transfers_persistence_load():
     completed_count = int(result)
 
     logging.log("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-    logging.log("transfers_count: {} / completed_count: {}".format(transfers_count, completed_count))
-    logging.log(" before test nordvpnd mem: {} ;; nordfileshared mem: {}/raw:{}".format(format_memory_usage(nordvpnd_memory_usage), format_memory_usage(nordfileshared_memory_usage), nordfileshared_memory_usage))
-    logging.log("  after test nordvpnd mem: {} ;; nordfileshared mem: {}/raw:{}".format(format_memory_usage(nordvpnd_memory_usage2), format_memory_usage(nordfileshared_memory_usage2), nordfileshared_memory_usage2))
-    logging.log("       nordvpnd mem delta: {} ;; nordfileshared mem delta: {}/raw:{}".format(format_memory_usage(nordvpnd_memory_usage_delta), format_memory_usage(nordfileshared_memory_usage_delta), nordfileshared_memory_usage_delta))
-    logging.log("nordvpnd mem per transfer: {} ;; nordfileshared mem per transfer: {}".format(format_memory_usage(nordvpnd_memory_usage_per_tr), format_memory_usage(nordfileshared_memory_usage_per_tr)))
-    logging.log("            avg send time: {} ;; min send time: {}/@{} ;; max send time: {}/@{}".format(format_time(avg_send_time_ns), format_time(min_send_time_ns), min_send_time_itr, format_time(max_send_time_ns), max_send_time_itr))
-    logging.log("               total time: {} ;; total send time: {} ".format(format_time(finish_time_ns-start_time_ns), format_time(total_send_time_ns)))
+    logging.log(f"transfers_count: {transfers_count} / completed_count: {completed_count}")
+    logging.log(f" before test nordvpnd mem: {format_memory_usage(nordvpnd_memory_usage)} ;; nordfileshared mem: {format_memory_usage(nordfileshared_memory_usage)}/raw:{nordfileshared_memory_usage}")
+    logging.log(f"  after test nordvpnd mem: {format_memory_usage(nordvpnd_memory_usage2)} ;; nordfileshared mem: {format_memory_usage(nordfileshared_memory_usage2)}/raw:{nordfileshared_memory_usage2}")
+    logging.log(f"       nordvpnd mem delta: {format_memory_usage(nordvpnd_memory_usage_delta)} ;; nordfileshared mem delta: {format_memory_usage(nordfileshared_memory_usage_delta)}/raw:{nordfileshared_memory_usage_delta}")
+    logging.log(f"nordvpnd mem per transfer: {format_memory_usage(nordvpnd_memory_usage_per_tr)} ;; nordfileshared mem per transfer: {format_memory_usage(nordfileshared_memory_usage_per_tr)}")
+    logging.log(f"            avg send time: {format_time(avg_send_time_ns)} ;; min send time: {format_time(min_send_time_ns)}/@{min_send_time_itr} ;; max send time: {format_time(max_send_time_ns)}/@{max_send_time_itr}")
+    logging.log(f"               total time: {format_time(finish_time_ns - start_time_ns)} ;; total send time: {format_time(total_send_time_ns)} ")
     logging.log("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
     assert completed_count >= transfers_count
@@ -605,6 +615,7 @@ def test_transfers_persistence_load():
 def get_memory_usage(pid):
     process = psutil.Process(pid)
     return process.memory_info().rss
+
 
 def format_memory_usage(rss):
     KB = 1024
@@ -620,6 +631,7 @@ def format_memory_usage(rss):
     else:
         return f'{round(rss, 2)}b'
 
+
 def format_time(nanoseconds):
     if nanoseconds < 1000:
         return f'{int(nanoseconds)}ns'
@@ -629,6 +641,7 @@ def format_time(nanoseconds):
         return f'{int(nanoseconds / 1000000)}ms'
     else:
         return f'{int(nanoseconds / 1000000000)}s'
+
 
 @pytest.mark.parametrize("peer_name", list(meshnet.PeerName))
 def test_permissions_send_allowed(peer_name):
@@ -682,12 +695,12 @@ def test_permissions_meshnet_receive_forbidden(peer_name):
     expected_transfer_list = expected_transfer_list[expected_transfer_list.index("Incoming"):].strip()
 
     output = f'{sh.nordvpn.mesh.peer.list(_tty_out=False)}'
-    tester_addess = meshnet.get_peer_name(output, peer_name)
+    tester_address = meshnet.get_peer_name(output, peer_name)
 
     file_name = "/tmp/file_allowed"
     ssh_client.exec_command(f"echo > {file_name}")
     with pytest.raises(RuntimeError) as ex:
-        ssh_client.exec_command(f"nordvpn fileshare send --background {tester_addess} {file_name}")
+        ssh_client.exec_command(f"nordvpn fileshare send --background {tester_address} {file_name}")
         assert "peer does not allow file transfers" in ex
 
     actual_transfer_list = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
@@ -707,6 +720,8 @@ def test_accept_destination_directory_does_not_exist():
     ssh_client.exec_command(f"touch {filename}")
     ssh_client.exec_command(f"nordvpn fileshare send --background {address} {filename}")
 
+    local_transfer_id = None
+    error_message = None
     for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
         if local_transfer_id is not None:
             break
@@ -714,7 +729,7 @@ def test_accept_destination_directory_does_not_exist():
     assert local_transfer_id is not None, error_message
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
-        output = sh.nordvpn.fileshare.accept("--background", "--path", "invalid_dir", local_transfer_id).stdout.decode("utf-8")
+        sh.nordvpn.fileshare.accept("--background", "--path", "invalid_dir", local_transfer_id).stdout.decode("utf-8")
         assert "Download directory invalid_dir does not exist. Make sure the directory exists or provide an alternative via --path" in ex
 
 
@@ -727,6 +742,8 @@ def test_accept_destination_directory_symlink():
     ssh_client.exec_command(f"touch {filename}")
     ssh_client.exec_command(f"nordvpn fileshare send --background {address} {filename}")
 
+    local_transfer_id = None
+    error_message = None
     for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
         if local_transfer_id is not None:
             break
@@ -740,7 +757,7 @@ def test_accept_destination_directory_symlink():
     os.symlink(dirpath, linkpath)
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
-        output = sh.nordvpn.fileshare.accept("--background", "--path", linkpath, local_transfer_id).stdout.decode("utf-8")
+        sh.nordvpn.fileshare.accept("--background", "--path", linkpath, local_transfer_id).stdout.decode("utf-8")
         assert f"Download directory {linkpath} is a symlink. You can provide provide an alternative via --path" in ex
 
 
@@ -753,6 +770,8 @@ def test_accept_destination_directory_not_a_directory():
     ssh_client.exec_command(f"touch {filename}")
     ssh_client.exec_command(f"nordvpn fileshare send --background {address} {filename}")
 
+    local_transfer_id = None
+    error_message = None
     for local_transfer_id, error_message in poll(fileshare.get_new_incoming_transfer):
         if local_transfer_id is not None:
             break
@@ -762,14 +781,14 @@ def test_accept_destination_directory_not_a_directory():
     _, path = tempfile.mkstemp()
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
-        output = sh.nordvpn.fileshare.accept("--background", "--path", path, local_transfer_id).stdout.decode("utf-8")
+        sh.nordvpn.fileshare.accept("--background", "--path", path, local_transfer_id).stdout.decode("utf-8")
         assert f"Download directory {path} is a symlink. You can provide provide an alternative via --path" in ex
 
 
 def test_autoaccept():
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_name = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
-    output = subprocess.run(["nordvpn", "mesh", "peer", "auto-accept", "enable", peer_name])
+    subprocess.run(["nordvpn", "mesh", "peer", "auto-accept", "enable", peer_name])
     # subprocess.run(["nordvpn", "mesh", "peer", "auto-accept", "enable", peer_name])
 
     time.sleep(10)
@@ -780,7 +799,7 @@ def test_autoaccept():
     filename = "autoaccepted"
     peer_file_path = f"/home/qapeer/{filename}"
     ssh_client.exec_command(f"echo > {peer_file_path}")
-    output = ssh_client.exec_command(f"nordvpn fileshare send --background {host_address} {peer_file_path}")
+    ssh_client.exec_command(f"nordvpn fileshare send --background {host_address} {peer_file_path}")
 
     def check_if_file_received():
         last_transfer_id = fileshare.get_last_transfer(outgoing=False)
@@ -789,6 +808,7 @@ def test_autoaccept():
         file_entry = fileshare.find_file_in_transfer(filename, transfer_lines)
         return file_entry is not None and "downloaded" in file_entry
 
+    file_received = None
     for file_received in poll(check_if_file_received, attempts=10):
         if file_received is True:
             break
@@ -802,14 +822,14 @@ def test_peers_autocomplete():
     output = sh.nordvpn.fileshare.send("--generate-bash-completion")
     assert peer_hostname in output
     output = sh.nordvpn.fileshare.send(peer_hostname, "--generate-bash-completion")
-    assert peer_hostname not in output # Only first argument should be autocompleted
+    assert peer_hostname not in output  # Only first argument should be autocompleted
 
 
 def test_transfers_autocomplete():
     output = ssh_client.exec_command("nordvpn mesh peer list")
     peer_address = meshnet.get_peer_name(output, meshnet.PeerName.Ip)
-    workdir = fileshare.create_directory(2)
-    fileshare.start_transfer(peer_address, *workdir.paths)
+    wdir = fileshare.create_directory(2)
+    fileshare.start_transfer(peer_address, *wdir.paths)
 
     time.sleep(1)
     peer_transfer_id = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
@@ -818,7 +838,7 @@ def test_transfers_autocomplete():
 
     # Path should use default autocomplete
     output = ssh_client.exec_command("nordvpn fileshare accept --path --generate-bash-completion")
-    assert peer_transfer_id not in output 
+    assert peer_transfer_id not in output
 
     # Autocomplete transfers
     output = ssh_client.exec_command("nordvpn fileshare accept --path /tmp --generate-bash-completion")
@@ -830,8 +850,8 @@ def test_transfers_autocomplete():
 
     # Autocomplete transfer files
     output = ssh_client.exec_command(f"nordvpn fileshare accept --path /tmp {peer_transfer_id} --generate-bash-completion")
-    assert workdir.filenames[0] in output 
-    assert workdir.filenames[1] in output
+    assert wdir.filenames[0] in output
+    assert wdir.filenames[1] in output
 
     ssh_client.exec_command(f"nordvpn fileshare accept --path /tmp {peer_transfer_id}")
 
@@ -852,7 +872,7 @@ def test_clear():
     time.sleep(1)
     local_transfer_id0 = fileshare.get_last_transfer()
     peer_transfer_id0 = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
-    ssh_client.exec_command("nordvpn fileshare accept {}".format(peer_transfer_id0))
+    ssh_client.exec_command(f"nordvpn fileshare accept {peer_transfer_id0}")
 
     transfers = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
     assert "completed" in fileshare.find_transfer_by_id(transfers, local_transfer_id0)
@@ -867,7 +887,7 @@ def test_clear():
     time.sleep(1)
     local_transfer_id1 = fileshare.get_last_transfer()
     peer_transfer_id1 = fileshare.get_last_transfer(outgoing=False, ssh_client=ssh_client)
-    ssh_client.exec_command("nordvpn fileshare accept {}".format(peer_transfer_id1))
+    ssh_client.exec_command(f"nordvpn fileshare accept {peer_transfer_id1}")
 
     transfers = sh.nordvpn.fileshare.list().stdout.decode("utf-8")
     assert "completed" in fileshare.find_transfer_by_id(transfers, local_transfer_id0)
@@ -887,7 +907,7 @@ def test_clear():
     assert "completed" in fileshare.find_transfer_by_id(transfers, peer_transfer_id0)
     assert "completed" in fileshare.find_transfer_by_id(transfers, peer_transfer_id1)
 
-    ssh_client.exec_command("nordvpn fileshare clear {} seconds".format(int(time.time() - transfer_time0)))
+    ssh_client.exec_command(f"nordvpn fileshare clear {int(time.time() - transfer_time0)} seconds")
 
     transfers = ssh_client.exec_command("nordvpn fileshare list")
     assert fileshare.find_transfer_by_id(transfers, peer_transfer_id0) is None

--- a/test/qa/test_firewall.py
+++ b/test/qa/test_firewall.py
@@ -1,32 +1,37 @@
-from lib import (
-    allowlist,
-    daemon,
-    info,
-    logging,
-    login,
-    network,
-    firewall,
-)
-import lib
 import pytest
 import sh
 import timeout_decorator
 
+import lib
+from lib import (
+    allowlist,
+    daemon,
+    firewall,
+    info,
+    logging,
+    login,
+    network,
+)
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -163,16 +168,16 @@ def test_firewall_05_allowlist_subnet(tech, proto, obfuscated, subnet):
 
             lib.set_firewall("on")
             allowlist.add_subnet_to_allowlist([subnet])
-            assert not firewall.is_active("", [subnet])
+            assert not firewall.is_active(None, [subnet])
 
             sh.nordvpn.connect()
             assert network.is_connected()
-            assert firewall.is_active("", [subnet])
+            assert firewall.is_active(None, [subnet])
 
             lib.set_firewall("off")
-            assert not firewall.is_active("", [subnet])
+            assert not firewall.is_active(None, [subnet])
         assert network.is_disconnected()
-    assert not firewall.is_active("", [subnet])
+    assert not firewall.is_active(None, [subnet])
 
 
 @pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
@@ -217,7 +222,7 @@ def test_firewall_07_with_killswitch_while_connected(tech, proto, obfuscated):
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_lan_discovery(tech, proto, obfuscated, before_connect):
-    with lib.Defer(lambda: sh.nordvpn.set("lan-discovery", "off", _ok_code=(0,1))):
+    with lib.Defer(lambda: sh.nordvpn.set("lan-discovery", "off", _ok_code=(0, 1))):
         with lib.Defer(sh.nordvpn.disconnect):
             lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -252,7 +257,7 @@ def test_firewall_lan_discovery(tech, proto, obfuscated, before_connect):
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_lan_allowlist_interaction(tech, proto, obfuscated):
-    with lib.Defer(lambda: sh.nordvpn.set("lan-discovery", "off", _ok_code=(0,1))):
+    with lib.Defer(lambda: sh.nordvpn.set("lan-discovery", "off", _ok_code=(0, 1))):
         with lib.Defer(sh.nordvpn.disconnect):
             lib.set_technology_and_protocol(tech, proto, obfuscated)
 

--- a/test/qa/test_firewall.py
+++ b/test/qa/test_firewall.py
@@ -14,30 +14,26 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connected_firewall_disable(tech, proto, obfuscated):
@@ -57,7 +53,7 @@ def test_connected_firewall_disable(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connected_firewall_enable(tech, proto, obfuscated):
@@ -77,7 +73,7 @@ def test_connected_firewall_enable(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_disable_connect(tech, proto, obfuscated):
@@ -94,7 +90,7 @@ def test_firewall_disable_connect(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_enable_connect(tech, proto, obfuscated):
@@ -111,7 +107,7 @@ def test_firewall_enable_connect(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -134,7 +130,7 @@ def test_firewall_02_allowlist_port(tech, proto, obfuscated, port):
     assert not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("ports", lib.PORTS_RANGE)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(100)
@@ -157,7 +153,7 @@ def test_firewall_03_allowlist_ports_range(tech, proto, obfuscated, ports):
     assert not firewall.is_active([ports])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -180,7 +176,7 @@ def test_firewall_05_allowlist_subnet(tech, proto, obfuscated, subnet):
     assert not firewall.is_active(None, [subnet])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_firewall_06_with_killswitch(tech, proto, obfuscated):
     with lib.Defer(sh.nordvpn.set.killswitch.off):
         lib.set_technology_and_protocol(tech, proto, obfuscated)
@@ -193,7 +189,7 @@ def test_firewall_06_with_killswitch(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_07_with_killswitch_while_connected(tech, proto, obfuscated):
@@ -217,7 +213,7 @@ def test_firewall_07_with_killswitch_while_connected(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.parametrize("before_connect", [True, False])
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -235,25 +231,25 @@ def test_firewall_lan_discovery(tech, proto, obfuscated, before_connect):
                 sh.nordvpn.set("lan-discovery", "on")
 
             rules = sh.sudo.iptables("-S", "INPUT")
-            for rule in firewall.inputLanDiscoveryRules:
+            for rule in firewall.INPUT_LAN_DISCOVERY_RULES:
                 assert rule in rules, f"{rule} input rule not found in iptables."
 
             rules = sh.sudo.iptables("-S", "OUTPUT")
-            for rule in firewall.outputLanDiscoveryRules:
+            for rule in firewall.OUTPUT_LAN_DISCOVERY_RULES:
                 assert rule in rules, f"{rule} output rule not found in iptables"
 
             sh.nordvpn.set("lan-discovery", "off")
 
             rules = sh.sudo.iptables("-S", "INPUT")
-            for rule in firewall.inputLanDiscoveryRules:
+            for rule in firewall.INPUT_LAN_DISCOVERY_RULES:
                 assert rule not in rules, f"{rule} input rule not found in iptables."
 
             rules = sh.sudo.iptables("-S", "OUTPUT")
-            for rule in firewall.outputLanDiscoveryRules:
+            for rule in firewall.OUTPUT_LAN_DISCOVERY_RULES:
                 assert rule not in rules, f"{rule} output rule not found in iptables"
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_lan_allowlist_interaction(tech, proto, obfuscated):
@@ -277,9 +273,9 @@ def test_firewall_lan_allowlist_interaction(tech, proto, obfuscated):
             sh.nordvpn.set("lan-discovery", "off")
 
             rules = sh.sudo.iptables("-S", "INPUT")
-            for rule in firewall.inputLanDiscoveryRules:
+            for rule in firewall.INPUT_LAN_DISCOVERY_RULES:
                 assert rule not in rules, f"{rule} input rule not found in iptables."
 
             rules = sh.sudo.iptables("-S", "OUTPUT")
-            for rule in firewall.outputLanDiscoveryRules:
+            for rule in firewall.OUTPUT_LAN_DISCOVERY_RULES:
                 assert rule not in rules, f"{rule} output rule not found in iptables"

--- a/test/qa/test_firewall6.py
+++ b/test/qa/test_firewall6.py
@@ -16,30 +16,26 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connected_firewall_disable(tech, proto, obfuscated):
@@ -60,7 +56,7 @@ def test_connected_firewall_disable(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connected_firewall_enable(tech, proto, obfuscated):
@@ -81,7 +77,7 @@ def test_connected_firewall_enable(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_disable_connect(tech, proto, obfuscated):
@@ -99,7 +95,7 @@ def test_firewall_disable_connect(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_enable_connect(tech, proto, obfuscated):
@@ -117,7 +113,7 @@ def test_firewall_enable_connect(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -142,7 +138,7 @@ def test_firewall_ipv6_02_allowlist_port(tech, proto, obfuscated, port):
         assert not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.parametrize("ports", lib.PORTS_RANGE)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -167,7 +163,7 @@ def test_firewall_ipv6_03_allowlist_ports_range(tech, proto, obfuscated, ports):
         assert not firewall.is_active([ports])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.parametrize("port", lib.PORTS)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -192,7 +188,7 @@ def test_firewall_ipv6_04_allowlist_port_and_protocol(tech, proto, obfuscated, p
         assert not firewall.is_active([port])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.parametrize("subnet", lib.SUBNETS)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
@@ -217,7 +213,7 @@ def test_firewall_ipv6_05_allowlist_subnet(tech, proto, obfuscated, subnet):
         assert not firewall.is_active(None, [subnet])
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @timeout_decorator.timeout(40)
 def test_firewall_ipv6_06_with_killswitch(tech, proto, obfuscated):
     with lib.Defer(lambda: lib.set_killswitch("off")):
@@ -232,7 +228,7 @@ def test_firewall_ipv6_06_with_killswitch(tech, proto, obfuscated):
     assert not firewall.is_active()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_firewall_ipv6_07_with_killswitch_while_connected(tech, proto, obfuscated):

--- a/test/qa/test_firewall6.py
+++ b/test/qa/test_firewall6.py
@@ -1,33 +1,39 @@
-from lib import (
-    allowlist,
-    daemon,
-    info,
-    logging,
-    login,
-    network,
-    firewall,
-)
-import lib
 import random
+
 import pytest
 import sh
 import timeout_decorator
 
+import lib
+from lib import (
+    allowlist,
+    daemon,
+    firewall,
+    info,
+    logging,
+    login,
+    network,
+)
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -198,17 +204,17 @@ def test_firewall_ipv6_05_allowlist_subnet(tech, proto, obfuscated, subnet):
             lib.set_firewall("on")
             lib.set_ipv6("on")
             allowlist.add_subnet_to_allowlist([subnet])
-            assert not firewall.is_active("", [subnet])
+            assert not firewall.is_active(None, [subnet])
 
             sh.nordvpn.connect(random.choice(lib.IPV6_SERVERS))
             assert network.is_ipv4_and_ipv6_connected(20)
-            assert firewall.is_active("", [subnet])
+            assert firewall.is_active(None, [subnet])
 
             lib.set_firewall("off")
-            assert not firewall.is_active("", [subnet])
+            assert not firewall.is_active(None, [subnet])
             assert network.is_ipv4_and_ipv6_connected(20)
         assert network.is_disconnected()
-        assert not firewall.is_active("", [subnet])
+        assert not firewall.is_active(None, [subnet])
 
 
 @pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)

--- a/test/qa/test_gateway.py
+++ b/test/qa/test_gateway.py
@@ -1,3 +1,8 @@
+import pytest
+import sh
+import timeout_decorator
+
+import lib
 from lib import (
     daemon,
     info,
@@ -5,26 +10,26 @@ from lib import (
     login,
     network,
 )
-import lib
-import sh
-import pytest
-import timeout_decorator
 
 
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()

--- a/test/qa/test_gateway.py
+++ b/test/qa/test_gateway.py
@@ -12,25 +12,21 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 

--- a/test/qa/test_killswitch.py
+++ b/test/qa/test_killswitch.py
@@ -1,3 +1,8 @@
+import pytest
+import sh
+import timeout_decorator
+
+import lib
 from lib import (
     daemon,
     info,
@@ -5,29 +10,30 @@ from lib import (
     login,
     network,
 )
-import lib
-import pytest
-import sh
-import timeout_decorator
 
 
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
+
 
 MSG_KILLSWITCH_ON = "Kill Switch is set to 'enabled' successfully."
 MSG_KILLSWITCH_OFF = "Kill Switch is set to 'disabled' successfully."
@@ -130,9 +136,7 @@ def test_killswitch_off_connected(tech, proto, obfuscated):
 @pytest.mark.parametrize("tech_to,proto_to,obfuscated_to", lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
-def test_killswitch_reconnect(
-    tech_from, proto_from, obfuscated_from, tech_to, proto_to, obfuscated_to
-):
+def test_killswitch_reconnect(tech_from, proto_from, obfuscated_from, tech_to, proto_to, obfuscated_to):
     lib.set_technology_and_protocol(tech_from, proto_from, obfuscated_from)
     assert network.is_available()
 

--- a/test/qa/test_killswitch.py
+++ b/test/qa/test_killswitch.py
@@ -12,25 +12,21 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
@@ -39,7 +35,7 @@ MSG_KILLSWITCH_ON = "Kill Switch is set to 'enabled' successfully."
 MSG_KILLSWITCH_OFF = "Kill Switch is set to 'disabled' successfully."
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_killswitch_on_disconnected(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
     assert network.is_available()
@@ -55,7 +51,7 @@ def test_killswitch_on_disconnected(tech, proto, obfuscated):
     assert network.is_available()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_killswitch_on_connect(tech, proto, obfuscated):
@@ -84,7 +80,7 @@ def test_killswitch_on_connect(tech, proto, obfuscated):
     assert network.is_available()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_killswitch_on_connected(tech, proto, obfuscated):
@@ -107,7 +103,7 @@ def test_killswitch_on_connected(tech, proto, obfuscated):
     assert network.is_available()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_killswitch_off_connected(tech, proto, obfuscated):
@@ -132,8 +128,8 @@ def test_killswitch_off_connected(tech, proto, obfuscated):
     assert network.is_available()
 
 
-@pytest.mark.parametrize("tech_from,proto_from,obfuscated_from", lib.TECHNOLOGIES)
-@pytest.mark.parametrize("tech_to,proto_to,obfuscated_to", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech_from", "proto_from", "obfuscated_from"), lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech_to", "proto_to", "obfuscated_to"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_killswitch_reconnect(tech_from, proto_from, obfuscated_from, tech_to, proto_to, obfuscated_to):

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -1,3 +1,8 @@
+import pytest
+import sh
+import timeout_decorator
+
+import lib
 from lib import (
     daemon,
     info,
@@ -5,24 +10,24 @@ from lib import (
     login,
     network,
 )
-import lib
-import pytest
-import sh
-import timeout_decorator
 
 
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -37,7 +42,7 @@ def test_login():
 def test_invalid_token_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--token", "xyz%#")
-    
+
     assert "We couldn't log you in - the access token is not valid. Please check if you've entered the token correctly. If the issue persists, contact our customer support." in str(ex.value)
 
 
@@ -49,6 +54,7 @@ def test_repeated_login():
             login.login_as("default")
 
         assert "You are already logged in." in str(ex.value)
+
 
 @pytest.mark.skip(reason="can't get login token for expired account")
 def test_expired_account_connect():
@@ -87,9 +93,9 @@ def test_login_while_connected():
 def test_login_without_internet():
     default_gateway = network.stop()
 
-    with pytest.raises(sh.ErrorReturnCode_1) as ex:
+    with pytest.raises(sh.ErrorReturnCode_1):
         login.login_as("default")
-        
+
     network.start(default_gateway)
 
 
@@ -128,21 +134,21 @@ def test_logout_disconnects():
 def test_missing_token_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--token")
-    
+
     assert "Token parameter value is missing." in str(ex.value)
 
 
 def test_missing_url_callback_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--callback")
-    
+
     assert "Expected a url." in str(ex.value)
 
 
 def test_invalid_url_callback_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--callback", "https://www.google.com/")
-    
+
     assert "Expected a url with nordvpn scheme." in str(ex.value)
 
 
@@ -168,7 +174,7 @@ def test_repeated_login_callback_invalid_url():
 
 def test_repeated_login_callback_nordvpn_scheme_url():
     login.login_as("default")
-    
+
     with lib.Defer(lambda: sh.nordvpn.logout("--persist-token")):
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh.nordvpn.login("--callback", "nordvpn://")

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -12,23 +12,19 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -11,8 +11,7 @@ from lib import daemon, info, logging, login, meshnet, network, ssh
 ssh_client = ssh.Ssh("qa-peer", "root", "root")
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     ssh_client.connect()
     daemon.install_peer(ssh_client)
     daemon.start()
@@ -30,8 +29,7 @@ def setup_module(module):
     meshnet.add_peer(ssh_client)
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     meshnet.revoke_all_invites()
     meshnet.remove_all_peers()
     ssh_client.exec_command("nordvpn set mesh off")
@@ -44,13 +42,11 @@ def teardown_module(module):
     ssh_client.disconnect()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
@@ -77,7 +73,7 @@ def test_mesh_removed_machine_by_other():
         'Accept': 'application/json',
         'Authorization': 'Bearer token:' + mytoken,
     }
-    response = requests.get('https://api.nordvpn.com/v1/meshnet/machines', headers=headers)
+    response = requests.get('https://api.nordvpn.com/v1/meshnet/machines', headers=headers, timeout=5)
     for itm in response.json():
         if str(itm['hostname']) in myname:
             mymachineid = itm['identifier']
@@ -87,12 +83,12 @@ def test_mesh_removed_machine_by_other():
         'Accept': 'application/json',
         'Authorization': 'Bearer token:' + mytoken,
     }
-    requests.delete('https://api.nordvpn.com/v1/meshnet/machines/' + mymachineid, headers=headers)
+    requests.delete('https://api.nordvpn.com/v1/meshnet/machines/' + mymachineid, headers=headers, timeout=5)
 
     # machine not found error should be handled by disabling meshnet
     try:
         sh.nordvpn.mesh.peer.list()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         assert "Meshnet is not enabled." in str(e)
 
     sh.nordvpn.set.meshnet.on()  # enable back on for other tests
@@ -271,15 +267,14 @@ def test_lan_discovery_exitnode(lan_discovery: bool, local: bool):
             if local and lan_discovery:
                 if lan_drop_rule_idx < routing_rule_idx:
                     return False, f"Routing rule was added after LAN block rule for subnet {lan}\nrules:\n{rules}"
-            else:
-                if lan_drop_rule_idx > routing_rule_idx:
-                    return False, f"Routing rule was added before LAN block rule for subnet {lan}\nrules:\n{rules}"
+            elif lan_drop_rule_idx > routing_rule_idx:
+                return False, f"Routing rule was added before LAN block rule for subnet {lan}\nrules:\n{rules}"
 
         return True, ""
 
     sh.nordvpn.connect()
     with lib.Defer(sh.nordvpn.disconnect):
-        for (result, message) in lib.poll(check_rules_routing):
+        for (result, message) in lib.poll(check_rules_routing):  # noqa: B007
             if result:
                 break
         assert result, message
@@ -312,7 +307,7 @@ def test_remove_peer_firewall_update():
         return False, f"Rules for peer were not removed from firewall\nPeer IP: {peer_ip}\nrules:\n{rules}"
 
     result, message = None, None
-    for (result, message) in lib.poll(all_peer_permissions_removed):
+    for (result, message) in lib.poll(all_peer_permissions_removed):  # noqa: B007
         if result:
             break
 

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -1,21 +1,24 @@
-from lib import daemon, info, logging, login, meshnet, network, ssh
-import lib
-import sh
-import requests
-import pytest
-import timeout_decorator
-import subprocess
 import os
+
+import pytest
+import requests
+import sh
+import timeout_decorator
+
+import lib
+from lib import daemon, info, logging, login, meshnet, network, ssh
 
 ssh_client = ssh.Ssh("qa-peer", "root", "root")
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     ssh_client.connect()
     daemon.install_peer(ssh_client)
     daemon.start()
     daemon.start_peer(ssh_client)
     login.login_as("default")
-    login.login_as("qa-peer", ssh_client) # TODO: same account is used for everybody, tests can't be run in parallel
+    login.login_as("qa-peer", ssh_client)  # TODO: same account is used for everybody, tests can't be run in parallel
     lib.set_technology_and_protocol("nordlynx", "", "")
     sh.nordvpn.set.meshnet.on()
     ssh_client.exec_command("nordvpn set mesh on")
@@ -27,6 +30,7 @@ def setup_module(module):
     meshnet.add_peer(ssh_client)
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     meshnet.revoke_all_invites()
     meshnet.remove_all_peers()
@@ -40,10 +44,12 @@ def teardown_module(module):
     ssh_client.disconnect()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -58,7 +64,7 @@ def test_meshnet_connect():
 def test_mesh_removed_machine_by_other():
     # find my token from cli
     mytoken = ""
-    output =  sh.nordvpn.token()
+    output = sh.nordvpn.token()
     for ln in output.splitlines():
         if "Token:" in ln:
             _, mytoken = ln.split(None, 2)
@@ -69,7 +75,7 @@ def test_mesh_removed_machine_by_other():
     mymachineid = ""
     headers = {
         'Accept': 'application/json',
-        'Authorization': 'Bearer token:'+mytoken,
+        'Authorization': 'Bearer token:' + mytoken,
     }
     response = requests.get('https://api.nordvpn.com/v1/meshnet/machines', headers=headers)
     for itm in response.json():
@@ -79,17 +85,17 @@ def test_mesh_removed_machine_by_other():
     # remove myself using api call
     headers = {
         'Accept': 'application/json',
-        'Authorization': 'Bearer token:'+mytoken,
+        'Authorization': 'Bearer token:' + mytoken,
     }
-    response = requests.delete('https://api.nordvpn.com/v1/meshnet/machines/'+mymachineid, headers=headers)
+    requests.delete('https://api.nordvpn.com/v1/meshnet/machines/' + mymachineid, headers=headers)
 
     # machine not found error should be handled by disabling meshnet
     try:
-        output = sh.nordvpn.mesh.peer.list()
+        sh.nordvpn.mesh.peer.list()
     except Exception as e:
         assert "Meshnet is not enabled." in str(e)
 
-    sh.nordvpn.set.meshnet.on() # enable back on for other tests
+    sh.nordvpn.set.meshnet.on()  # enable back on for other tests
     meshnet.add_peer(ssh_client)
 
 
@@ -107,7 +113,7 @@ def test_allowlist_incoming_connection():
         ssh_client_mesh.exec_command("nordvpn set killswitch on")
         with lib.Defer(lambda: ssh_client_mesh.exec_command("nordvpn set killswitch off")):
             # We should not have direct connection anymore after connecting to VPN
-            with pytest.raises(sh.ErrorReturnCode_1) as ex:
+            with pytest.raises(sh.ErrorReturnCode_1):
                 assert "icmp_seq=" not in sh.ping("-c", "1", "qa-peer")
 
                 ssh_client_mesh.exec_command(f"nordvpn allowlist add subnet {my_ip}/32")
@@ -121,36 +127,37 @@ def validate_input_chain(peer_ip: str, routing: bool, local: bool, incoming: boo
 
     fileshare_rule = f"-A INPUT -s {peer_ip}/32 -p tcp -m tcp --dport 49111 -m comment --comment nordvpn -j ACCEPT"
     if (fileshare_rule in rules) != fileshare:
-        return (False, f"Fileshare permissions configured incorrectly, rule expected: {fileshare}\nrules:{rules}")
+        return False, f"Fileshare permissions configured incorrectly, rule expected: {fileshare}\nrules:{rules}"
 
     incoming_rule = f"-A INPUT -s {peer_ip}/32 -m comment --comment nordvpn -j ACCEPT"
     if (incoming_rule in rules) != incoming:
-        return (False, f"Incoming permissions configured incorrectly, rule expected: {incoming}\nrules:{rules}")
+        return False, f"Incoming permissions configured incorrectly, rule expected: {incoming}\nrules:{rules}"
 
     # If incoming is not enabled, no rules other than fileshare(if enabled) for that peer should be added
     if not incoming:
         if fileshare:
             rules = rules.replace(fileshare_rule, "")
         if peer_ip not in rules:
-            return (True, "")
+            return True, ""
         else:
-            return (False, f"Rules for peer({peer_ip}) found in the INCOMING chain but peer does not have the icoming permissions\nrules:\n{rules}")
+            return False, f"Rules for peer({peer_ip}) found in the INCOMING chain but peer does not have the incoming permissions\nrules:\n{rules}"
 
-    incomig_rule_idx = rules.find(incoming_rule)
+    incoming_rule_idx = rules.find(incoming_rule)
 
     for lan in meshnet.LANS:
         lan_rule = f"-A INPUT -s {peer_ip}/32 -d {lan} -m comment --comment nordvpn -j DROP"
         lan_rule_idx = rules.find(lan_rule)
         if (routing and local) and lan_rule_idx != -1:
-            return (False, f"LAN/Routing permissions configured incorrectly\nlocal enabled: {local}\nrouting enabled: {routing}\nrules:\n{rules}")
+            return False, f"LAN/Routing permissions configured incorrectly\nlocal enabled: {local}\nrouting enabled: {routing}\nrules:\n{rules}"
         # verify that lan_rule is located above the local rule
-        if lan_rule_idx > incomig_rule_idx:
-            return (False, f"LAN/Routing rules ineffective(added after incoming traffic rule)\nlocal enabled: {local}\nrouting enabled: {routing}\nrules:\n{rules}")
+        if lan_rule_idx > incoming_rule_idx:
+            return False, f"LAN/Routing rules ineffective(added after incoming traffic rule)\nlocal enabled: {local}\nrouting enabled: {routing}\nrules:\n{rules}"
 
-    return (True, "")
+    return True, ""
 
 
 def validate_forward_chain(peer_ip: str, routing: bool, local: bool, incoming: bool, fileshare: bool) -> (bool, str):
+    _, _ = incoming, fileshare
     rules = sh.sudo.iptables("-S", "FORWARD")
 
     # This rule is added above the LAN denial rules if both local and routing is allowed to peer, or bellow LAN denial
@@ -159,9 +166,9 @@ def validate_forward_chain(peer_ip: str, routing: bool, local: bool, incoming: b
     routing_enabled_rule_index = rules.find(routing_enabled_rule)
 
     if routing and (routing_enabled_rule_index == -1):
-        return (False, f"Routing permission not found\nrules:{rules}")
+        return False, f"Routing permission not found\nrules:{rules}"
     if not routing and (routing_enabled_rule_index != -1):
-        return (False, f"Routing permission found\nrules:{rules}")
+        return False, f"Routing permission found\nrules:{rules}"
 
     for lan in meshnet.LANS:
         lan_drop_rule = f"-A FORWARD -s 100.64.0.0/10 -d {lan} -m comment --comment nordvpn-exitnode-transient -j DROP"
@@ -169,21 +176,21 @@ def validate_forward_chain(peer_ip: str, routing: bool, local: bool, incoming: b
 
         # If any peer has routing or local permission, lan block rules should be added, otherwise no rules should be added.
         if (routing or local) and lan_drop_rule_index == -1:
-            return (False, f"LAN drop rule not added for subnet {lan}\nrules:\n{rules}")
+            return False, f"LAN drop rule not added for subnet {lan}\nrules:\n{rules}"
         elif (not routing) and (not lan) and lan_drop_rule_index != -1:
-            return (False, f"LAN drop rule added for subnet {lan}\nrules:\n{rules}")
+            return False, f"LAN drop rule added for subnet {lan}\nrules:\n{rules}"
 
         if routing:
             # Local is allowed, routing rule should be above LAN block rules to allow peer to access any subnet.
             if local and (lan_drop_rule_index < routing_enabled_rule_index):
-                return (False, f"LAN drop rule for subnet {lan} added before routing\nrules: {rules}")
-            # Local is not allowed, routing rule should be bellow LAN block rules to deny peer access to local subnets.
+                return False, f"LAN drop rule for subnet {lan} added before routing\nrules: {rules}"
+            # Local is not allowed, routing rule should be below LAN block rules to deny peer access to local subnets.
             if (not local) and (lan_drop_rule_index > routing_enabled_rule_index):
-                return (False, f"LAN drop rule for subnet {lan} added after routing\nrules: {rules}")
+                return False, f"LAN drop rule for subnet {lan} added after routing\nrules: {rules}"
             continue
 
         # If routing is not enabled, but lan is enabled, there should be one rule for each local network for the peer.
-        # They should be located abouve the LAN block rules.
+        # They should be located above the LAN block rules.
         if not local:
             continue
 
@@ -191,13 +198,12 @@ def validate_forward_chain(peer_ip: str, routing: bool, local: bool, incoming: b
         lan_allow_rule_index = rules.find(lan_allow_rule)
 
         if lan_allow_rule not in rules:
-            return (False, f"LAN allow rule for subnet {lan} not found\nrules:\n{rules}")
+            return False, f"LAN allow rule for subnet {lan} not found\nrules:\n{rules}"
 
         if lan_allow_rule_index > lan_drop_rule_index:
-            return (False, f"LAN allow rule is added after LAN drop rule\nrules:\n{rules}")
+            return False, f"LAN allow rule is added after LAN drop rule\nrules:\n{rules}"
 
-
-    return (True, "")
+    return True, ""
 
 
 def set_permissions(peer: str, routing: bool, local: bool, incoming: bool, fileshare: bool):
@@ -254,22 +260,22 @@ def test_lan_discovery_exitnode(lan_discovery: bool, local: bool):
         routing_rule = f"-A FORWARD -s {peer_ip}/32 -m comment --comment nordvpn-exitnode-transient -j ACCEPT"
         routing_rule_idx = rules.find(routing_rule)
         if routing_rule_idx == -1:
-            return (False, f"Routing rule not found\nrules:\n{rules}")
+            return False, f"Routing rule not found\nrules:\n{rules}"
 
         for lan in meshnet.LANS:
             lan_drop_rule = f"-A FORWARD -s 100.64.0.0/10 -d {lan} -m comment --comment nordvpn-exitnode-transient -j DROP"
             lan_drop_rule_idx = rules.find(lan_drop_rule)
             if lan_drop_rule_idx == -1:
-                return (False, f"LAN drop rule not found for subnet {lan}\nrules:\n{rules}")
+                return False, f"LAN drop rule not found for subnet {lan}\nrules:\n{rules}"
 
             if local and lan_discovery:
                 if lan_drop_rule_idx < routing_rule_idx:
-                    return (False, f"Routing rule was added after LAN block rule for subnet {lan}\nrules:\n{rules}")
+                    return False, f"Routing rule was added after LAN block rule for subnet {lan}\nrules:\n{rules}"
             else:
                 if lan_drop_rule_idx > routing_rule_idx:
-                    return (False, f"Routing rule was added before LAN block rule for subnet {lan}\nrules:\n{rules}")
+                    return False, f"Routing rule was added before LAN block rule for subnet {lan}\nrules:\n{rules}"
 
-        return (True, "")
+        return True, ""
 
     sh.nordvpn.connect()
     with lib.Defer(sh.nordvpn.disconnect):
@@ -302,9 +308,10 @@ def test_remove_peer_firewall_update():
     def all_peer_permissions_removed() -> (bool, str):
         rules = sh.sudo.iptables("-S")
         if peer_ip not in rules:
-            return (True, "")
-        return (False, f"Rules for peer were not removed from firewall\nPeer IP: {peer_ip}\nrules:\n{rules}")
+            return True, ""
+        return False, f"Rules for peer were not removed from firewall\nPeer IP: {peer_ip}\nrules:\n{rules}"
 
+    result, message = None, None
     for (result, message) in lib.poll(all_peer_permissions_removed):
         if result:
             break
@@ -315,7 +322,7 @@ def test_remove_peer_firewall_update():
 def test_account_switch():
     sh.nordvpn.logout("--persist-token")
     login.login_as("qa-peer")
-    sh.nordvpn.set.mesh.on() # expecting failure here
+    sh.nordvpn.set.mesh.on()  # expecting failure here
 
     # Recover starting state (this is the simplest way)
     teardown_module(None)
@@ -323,7 +330,6 @@ def test_account_switch():
 
 
 def test_invite_send_repeated():
-
     with lib.Defer(lambda: sh.nordvpn.meshnet.invite.revoke("test@test.com")):
         meshnet.send_meshnet_invite("test@test.com")
 
@@ -334,7 +340,6 @@ def test_invite_send_repeated():
 
 
 def test_invite_send_own_email():
-    
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite(os.environ.get("DEFAULT_LOGIN_USERNAME"))
 
@@ -342,7 +347,6 @@ def test_invite_send_own_email():
 
 
 def test_invite_send_not_an_email():
-
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite("test")
 
@@ -351,53 +355,47 @@ def test_invite_send_not_an_email():
 
 @pytest.mark.skip(reason="A different error message is expected - LVPN-262")
 def test_invite_send_long_email():
-    
     # A long email address containing more than 256 characters is created
     email = "test" * 65 + "@test.com"
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite(email)
 
-    assert not "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." in str(ex.value)
+    assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in str(ex.value)
 
 
 @pytest.mark.skip(reason="A different error message is expected - LVPN-262")
 def test_invite_send_email_special_character():
-    
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite("\u2222@test.com")
 
-    assert not "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." in str(ex.value)
+    assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in str(ex.value)
 
 
 def test_invite_revoke():
-
     meshnet.send_meshnet_invite("test@test.com")
 
     assert "Meshnet invitation to 'test@test.com' was revoked." in sh.nordvpn.meshnet.invite.revoke("test@test.com")
 
 
 def test_invite_revoke_repeated():
-
     with lib.Defer(lambda: sh.nordvpn.meshnet.invite.revoke("test@test.com")):
         meshnet.send_meshnet_invite("test@test.com")
-    
+
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.meshnet.invite.revoke("test@test.com")
 
     assert "No invitation from 'test@test.com' was found." in str(ex.value)
 
 
-def test_invite_revoke_non_existant():
-    
+def test_invite_revoke_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.meshnet.invite.revoke("test@test.com")
 
     assert "No invitation from 'test@test.com' was found." in str(ex.value)
 
 
-def test_invite_revoke_non_existant_long_email():
-    
+def test_invite_revoke_non_existent_long_email():
     email = "test" * 65 + "@test.com"
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
@@ -406,24 +404,21 @@ def test_invite_revoke_non_existant_long_email():
     assert f"No invitation from '{email}' was found." in str(ex.value)
 
 
-def test_invite_revoke_non_existant_special_character():
-    
+def test_invite_revoke_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.meshnet.invite.revoke("\u2222@test.com")
 
     assert "No invitation from '\u2222@test.com' was found." in str(ex.value)
 
 
-def test_invite_deny_non_existant():
-    
+def test_invite_deny_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.meshnet.invite.deny("test@test.com")
 
     assert "No invitation from 'test@test.com' was found." in str(ex.value)
 
 
-def test_invite_deny_non_existant_long_email():
-    
+def test_invite_deny_non_existent_long_email():
     email = "test" * 65 + "@test.com"
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
@@ -432,24 +427,21 @@ def test_invite_deny_non_existant_long_email():
     assert f"No invitation from '{email}' was found." in str(ex.value)
 
 
-def test_invite_deny_non_existant_special_character():
-    
+def test_invite_deny_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.meshnet.invite.deny("\u2222@test.com")
 
     assert "No invitation from '\u2222@test.com' was found." in str(ex.value)
 
 
-def test_invite_accept_non_existant():
-    
+def test_invite_accept_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.meshnet.invite.accept("test@test.com")
 
     assert "No invitation from 'test@test.com' was found." in str(ex.value)
 
 
-def test_invite_accept_non_existant_long_email():
-    
+def test_invite_accept_non_existent_long_email():
     email = "test" * 65 + "@test.com"
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
@@ -458,8 +450,7 @@ def test_invite_accept_non_existant_long_email():
     assert f"No invitation from '{email}' was found." in str(ex.value)
 
 
-def test_invite_accept_non_existant_special_character():
-    
+def test_invite_accept_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.meshnet.invite.accept("\u2222@test.com")
 

--- a/test/qa/test_misc.py
+++ b/test/qa/test_misc.py
@@ -11,26 +11,22 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     network.unblock()
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log()
 
 

--- a/test/qa/test_misc.py
+++ b/test/qa/test_misc.py
@@ -1,29 +1,35 @@
+import pytest
+import sh
+import timeout_decorator
+
+import lib
 from lib import (
     daemon,
     logging,
     login,
     network,
 )
-import lib
-import pytest
-import sh
-import timeout_decorator
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     network.unblock()
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log()
 

--- a/test/qa/test_notify.py
+++ b/test/qa/test_notify.py
@@ -1,27 +1,24 @@
-from lib import (
-    daemon,
-    info,
-    logging,
-    login,
-    notify,
-    settings
-)
-import lib
 import pytest
 import sh
 import timeout_decorator
 
+import lib
+from lib import daemon, info, logging, login, notify, settings
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     daemon.start()
     login.login_as("default")
 
 
+# noinspection PyUnusedLocal
 def teardown_module(module):
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     logging.log()
 
@@ -29,6 +26,7 @@ def setup_function(function):
     lib.set_notify("off")
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -61,7 +59,7 @@ def test_notifications_enabled_connect(tech, proto, obfuscated):
 
     sh.nordvpn.set.notify.on()
     assert settings.get_is_notify_enabled()
-    
+
     connect_notification = notify.connect_and_capture_notifications(tech, proto, obfuscated)
 
     # Should fail here, if tested with 3.16.6, since notification icon is missing

--- a/test/qa/test_notify.py
+++ b/test/qa/test_notify.py
@@ -6,33 +6,29 @@ import lib
 from lib import daemon, info, logging, login, notify, settings
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
     # Make sure that Notifications are disabled before we execute each test
     lib.set_notify("off")
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notifications_disabled_connect(tech, proto, obfuscated):
@@ -51,7 +47,7 @@ def test_notifications_disabled_connect(tech, proto, obfuscated):
         notify.print_tidy_exception(connect_notification, notify.NOTIFICATION_NOT_DETECTED)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notifications_enabled_connect(tech, proto, obfuscated):
@@ -72,7 +68,7 @@ def test_notifications_enabled_connect(tech, proto, obfuscated):
         notify.print_tidy_exception(disconnect_notification, notify.NOTIFICATION_DETECTED)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notifications_enabled_connected_disable(tech, proto, obfuscated):
@@ -95,7 +91,7 @@ def test_notifications_enabled_connected_disable(tech, proto, obfuscated):
         notify.print_tidy_exception(disconnect_notification, notify.NOTIFICATION_NOT_DETECTED)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notifications_disabled_connected_enable(tech, proto, obfuscated):
@@ -117,7 +113,7 @@ def test_notifications_disabled_connected_enable(tech, proto, obfuscated):
         notify.print_tidy_exception(disconnect_notification, notify.NOTIFICATION_DETECTED)
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notify_already_enabled_disconnected(tech, proto, obfuscated):
@@ -131,7 +127,7 @@ def test_notify_already_enabled_disconnected(tech, proto, obfuscated):
     assert settings.get_is_notify_enabled()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notify_already_enabled_connected(tech, proto, obfuscated):
@@ -148,7 +144,7 @@ def test_notify_already_enabled_connected(tech, proto, obfuscated):
         assert settings.get_is_notify_enabled()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notify_already_disabled_disconnected(tech, proto, obfuscated):
@@ -161,7 +157,7 @@ def test_notify_already_disabled_disconnected(tech, proto, obfuscated):
     assert not settings.get_is_notify_enabled()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_notify_already_disabled_connected(tech, proto, obfuscated):

--- a/test/qa/test_routing.py
+++ b/test/qa/test_routing.py
@@ -8,21 +8,18 @@ import lib
 from lib import allowlist, daemon, firewall, info, logging, login, network, settings
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     firewall.add_and_delete_random_route()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
@@ -42,7 +39,7 @@ MSG_ROUTING_ON_ALREADY = "Routing is already set to 'enabled'."
 MSG_ROUTING_USED_BY_MESH = "Routing is currently used by Meshnet. Disable it first."
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_routing_enabled_connect(tech, proto, obfuscated):
@@ -66,7 +63,7 @@ def test_routing_enabled_connect(tech, proto, obfuscated):
 
 
 @pytest.mark.skip("LVPN-3273; LVPN-1574")
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_routing_disabled_connect(tech, proto, obfuscated):
@@ -92,7 +89,7 @@ def test_routing_disabled_connect(tech, proto, obfuscated):
 
 
 @pytest.mark.skip("LVPN-3273")
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connected_routing_disable_enable(tech, proto, obfuscated):
@@ -117,7 +114,7 @@ def test_connected_routing_disable_enable(tech, proto, obfuscated):
 
 
 @pytest.mark.skip("LVPN-3273; LVPN-1574")
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_connected_routing_enable_disable(tech, proto, obfuscated):
@@ -145,7 +142,7 @@ def test_connected_routing_enable_disable(tech, proto, obfuscated):
 
 
 @pytest.mark.skip("LVPN-4360")
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES_BASIC1)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_BASIC1)
 def test_meshnet_on_routing_disable(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
@@ -154,7 +151,7 @@ def test_meshnet_on_routing_disable(tech, proto, obfuscated):
     assert settings.get_is_routing_enabled()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_routing_already_enabled(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
     lib.set_routing("on")
@@ -163,7 +160,7 @@ def test_routing_already_enabled(tech, proto, obfuscated):
     assert settings.get_is_routing_enabled()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_routing_already_disabled(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
     lib.set_routing("off")
@@ -173,7 +170,7 @@ def test_routing_already_disabled(tech, proto, obfuscated):
 
 
 @pytest.mark.skip("LVPN-3273")
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_toggle_routing_in_the_middle_of_the_connection(tech, proto, obfuscated):
@@ -204,7 +201,7 @@ def test_toggle_routing_in_the_middle_of_the_connection(tech, proto, obfuscated)
     assert network.is_available()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 @pytest.mark.flaky(reruns=2, reruns_delay=90)
 @timeout_decorator.timeout(40)
 def test_routing_when_iprule_already_exists(tech, proto, obfuscated):

--- a/test/qa/test_routing.py
+++ b/test/qa/test_routing.py
@@ -1,25 +1,19 @@
 import time
 
-from lib import (
-    allowlist,
-    daemon,
-    firewall,
-    info,
-    login,
-    logging,
-    network,
-    settings
-)
-import sh
-import lib
 import pytest
+import sh
 import timeout_decorator
 
+import lib
+from lib import allowlist, daemon, firewall, info, logging, login, network, settings
 
+
+# noinspection PyUnusedLocal
 def setup_module(module):
     firewall.add_and_delete_random_route()
 
 
+# noinspection PyUnusedLocal
 def setup_function(function):
     daemon.start()
     login.login_as("default")
@@ -27,6 +21,7 @@ def setup_function(function):
     logging.log()
 
 
+# noinspection PyUnusedLocal
 def teardown_function(function):
     logging.log(data=info.collect())
     logging.log()
@@ -40,9 +35,9 @@ SUBNET_1 = "2.2.2.2"
 SUBNET_2 = "3.3.3.3"
 SUBNET_3 = "4.4.4.4"
 
-MSG_ROUTING_OFF =  "Routing is set to 'disabled' successfully."
+MSG_ROUTING_OFF = "Routing is set to 'disabled' successfully."
 MSG_ROUTING_ON = "Routing is set to 'enabled' successfully."
-MSG_ROUTING_OFF_ALREADY =  "Routing is already set to 'disabled'."
+MSG_ROUTING_OFF_ALREADY = "Routing is already set to 'disabled'."
 MSG_ROUTING_ON_ALREADY = "Routing is already set to 'enabled'."
 MSG_ROUTING_USED_BY_MESH = "Routing is currently used by Meshnet. Disable it first."
 
@@ -86,12 +81,11 @@ def test_routing_disabled_connect(tech, proto, obfuscated):
 
     assert network.is_not_available()
 
-    assert not "fwmark" in sh.ip.rule.show.table(firewall.IP_ROUTE_TABLE)
-    assert not SUBNET_1 in sh.ip.route()
+    assert "fwmark" not in sh.ip.rule.show.table(firewall.IP_ROUTE_TABLE)
+    assert SUBNET_1 not in sh.ip.route()
 
     network_interface = "nordtun" if tech == "openvpn" else "nordlynx"
-    assert not network_interface in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
-
+    assert network_interface not in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
 
     assert MSG_ROUTING_ON_ALREADY in sh.nordvpn.set.routing.on()
     assert settings.get_is_routing_enabled()
@@ -111,8 +105,8 @@ def test_connected_routing_disable_enable(tech, proto, obfuscated):
 
     assert MSG_ROUTING_OFF in sh.nordvpn.set.routing.off()
     assert not settings.get_is_routing_enabled()
-    assert not network_interface in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
-    assert not "mark" in sh.ip.rule()
+    assert network_interface not in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
+    assert "mark" not in sh.ip.rule()
     assert network.is_not_available()
 
     assert MSG_ROUTING_ON in sh.nordvpn.set.routing.on()
@@ -145,8 +139,8 @@ def test_connected_routing_enable_disable(tech, proto, obfuscated):
 
     assert MSG_ROUTING_OFF in sh.nordvpn.set.routing.off()
     assert not settings.get_is_routing_enabled()
-    assert not network_interface in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
-    assert not "mark" in sh.ip.rule()
+    assert network_interface not in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
+    assert "mark" not in sh.ip.rule()
     assert network.is_not_available()
 
 
@@ -198,8 +192,8 @@ def test_toggle_routing_in_the_middle_of_the_connection(tech, proto, obfuscated)
     lib.set_routing("off")
     routes = sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
     rules = sh.ip.rule()
-    assert not network_interface in routes
-    assert not "mark" in rules
+    assert network_interface not in routes
+    assert "mark" not in rules
     assert network.is_not_available()
 
     lib.set_routing("on")
@@ -226,6 +220,7 @@ def test_routing_when_iprule_already_exists(tech, proto, obfuscated):
     assert "mark" in rules
     assert network.is_available()
 
+    rule = []
     for line in rules:
         if "fwmark" in line:
             rule = line.split()[1:]
@@ -248,4 +243,3 @@ def test_routing_when_iprule_already_exists(tech, proto, obfuscated):
 
         routes = sh.ip.route.show.table("main")
         assert f"default dev {network_interface}" not in routes
-

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -12,25 +12,21 @@ from lib import (
 )
 
 
-# noinspection PyUnusedLocal
-def setup_module(module):
+def setup_module(module):  # noqa: ARG001
     daemon.start()
     login.login_as("default")
 
 
-# noinspection PyUnusedLocal
-def teardown_module(module):
+def teardown_module(module):  # noqa: ARG001
     sh.nordvpn.logout("--persist-token")
     daemon.stop()
 
 
-# noinspection PyUnusedLocal
-def setup_function(function):
+def setup_function(function):  # noqa: ARG001
     logging.log()
 
 
-# noinspection PyUnusedLocal
-def teardown_function(function):
+def teardown_function(function):  # noqa: ARG001
     logging.log(data=info.collect())
     logging.log()
 
@@ -41,7 +37,7 @@ autoconnect_on_parameters = [
 ]
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES_BASIC1)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_BASIC1)
 def test_obfuscate_nonobfucated(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
     assert network.is_available()
@@ -53,7 +49,7 @@ def test_obfuscate_nonobfucated(tech, proto, obfuscated):
 
 @pytest.mark.skip(reason="LVPN-2119")
 @timeout_decorator.timeout(40)
-@pytest.mark.parametrize("server,obfuscated,error_message", autoconnect_on_parameters)
+@pytest.mark.parametrize(("server", "obfuscated", "error_message"), autoconnect_on_parameters)
 def test_autoconnect_on_server_obfuscation_mismatch(server, obfuscated, error_message):
     lib.set_technology_and_protocol("openvpn", "tcp", obfuscated)
 
@@ -79,7 +75,7 @@ set_obfuscate_parameters = [
 
 @timeout_decorator.timeout(40)
 @pytest.mark.skip(reason="LVPN-2119")
-@pytest.mark.parametrize("obfuscate_initial_state,server,error_message", set_obfuscate_parameters)
+@pytest.mark.parametrize(("obfuscate_initial_state", "server", "error_message"), set_obfuscate_parameters)
 def test_set_obfuscate_server_obfuscation_mismatch(obfuscate_initial_state, server, error_message):
     lib.set_technology_and_protocol("openvpn", "tcp", obfuscate_initial_state)
 
@@ -101,19 +97,19 @@ def test_set_obfuscate_server_obfuscation_mismatch(obfuscate_initial_state, serv
     sh.nordvpn.set.autoconnect.off()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES_BASIC2 + lib.TECHNOLOGIES_BASIC1)
-def test_set_technology(tech, proto, obfuscated):
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_BASIC2 + lib.TECHNOLOGIES_BASIC1)
+def test_set_technology(tech, proto, obfuscated):  # noqa: ARG001
     assert f"Technology is set to '{tech.upper()}' successfully." in sh.nordvpn.set.technology(tech)
     assert tech.upper() in sh.nordvpn.settings()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.OVPN_STANDARD_TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OVPN_STANDARD_TECHNOLOGIES)
 def test_protocol_in_settings(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
     assert proto.upper() in sh.nordvpn.settings()
 
 
-@pytest.mark.parametrize("tech,proto,obfuscated", lib.TECHNOLOGIES)
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_technology_set_options(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 


### PR DESCRIPTION
Fix warnings for undeclared variables, unused variables and wrong types. Clean Python imports by removing unused and self imports. Optimize their order. Automatically reformat the code style.

Add ruff Python linter GitHub job.