### PR TITLE
Add moose logging configuration

### DIFF
--- a/cmd/daemon/events_moose.go
+++ b/cmd/daemon/events_moose.go
@@ -3,8 +3,11 @@
 package main
 
 import (
+	"os"
+
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/events/moose"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 )
 
 var (
@@ -14,6 +17,12 @@ var (
 
 func newAnalytics(eventsDbPath string, fs *config.FilesystemConfigManager,
 	ver, env, id string) *moose.Subscriber {
+	_ = os.Setenv("MOOSE_LOG_FILE", "Stdout")
+	logLevel := "error"
+	if !internal.IsProdEnv(env) {
+		logLevel = "debug"
+	}
+	_ = os.Setenv("MOOSE_LOG", logLevel)
 	return &moose.Subscriber{
 		EventsDbPath: eventsDbPath,
 		Config:       fs,


### PR DESCRIPTION
Moose logs will be printed to stdout now. Log level:
* `debug` for development builds
* `error` for production builds