### PR TITLE
Enable go in sudo mode in Builder image

### DIFF
--- a/ci/docker/builder/Dockerfile
+++ b/ci/docker/builder/Dockerfile
@@ -43,6 +43,9 @@ ARG GROUP_ID=1000
 
 RUN groupadd --system nordvpn && groupadd -g ${GROUP_ID} builder && useradd -l -m -u ${USER_ID} -g builder -G nordvpn builder && echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
+# Enable `go` in sudo mode
+RUN echo "Defaults secure_path=\"$(dirname $(which go)):$PATH\"" | sudo tee --append /etc/sudoers.d/env_keep
+
 RUN chown -R builder:builder /go/pkg/mod
 
 USER builder


### PR DESCRIPTION
Enable `go` in `sudo` mode in Builder image. We need to run `cgo` tests in `sudo` mode in Builder image in CI