### PR TITLE
Check for nil inside the Tun function and return nil

### DIFF
--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -331,7 +331,11 @@ func (l *Libtelio) State() vpn.State {
 func (l *Libtelio) Tun() tunnel.T {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.tun
+	if l.tun != nil {
+		return l.tun
+	}
+
+	return nil
 }
 
 // Enable initiates the tunnel if it is not initiated yet. It can be

--- a/daemon/vpn/openvpn/openvpn.go
+++ b/daemon/vpn/openvpn/openvpn.go
@@ -291,7 +291,10 @@ func (ovpn *OpenVPN) setTun(tun tunnel.Tunnel) {
 func (ovpn *OpenVPN) Tun() tunnel.T {
 	ovpn.Lock()
 	defer ovpn.Unlock()
-	return ovpn.tun
+	if ovpn.tun != nil {
+		return ovpn.tun
+	}
+	return nil
 }
 
 func (ovpn *OpenVPN) setState(arg string) {


### PR DESCRIPTION
Because the Tun members are interfaces the returned value will always be no-nil, even when the member is nil.
To prevent crashes check in the getter if the member is nil and in that case return nil instead of the member.