### PR TITLE
Before disabling IPv6 check if the kernel module is loaded

### DIFF
--- a/ipv6/ipv6.go
+++ b/ipv6/ipv6.go
@@ -2,8 +2,10 @@
 package ipv6
 
 import (
+	"log"
 	"sync"
 
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/kernel"
 )
 
@@ -30,12 +32,19 @@ func NewIpv6() *Ipv6 {
 func (i *Ipv6) Block() error {
 	i.Lock()
 	defer i.Unlock()
-	return i.sysctlSetter.Set()
+	if i.sysctlSetter.IsEnabled() {
+		return i.sysctlSetter.Set()
+	}
+	log.Println(internal.InfoPrefix, "IPv6 module is not enabled")
+	return nil
 }
 
 // Unblock Ipv6 and restore previous settings from backup.
 func (i *Ipv6) Unblock() error {
 	i.Lock()
 	defer i.Unlock()
-	return i.sysctlSetter.Unset()
+	if i.sysctlSetter.IsEnabled() {
+		return i.sysctlSetter.Unset()
+	}
+	return nil
 }

--- a/ipv6/ipv6.go
+++ b/ipv6/ipv6.go
@@ -32,7 +32,7 @@ func NewIpv6() *Ipv6 {
 func (i *Ipv6) Block() error {
 	i.Lock()
 	defer i.Unlock()
-	if i.sysctlSetter.IsEnabled() {
+	if i.sysctlSetter.Exists() {
 		return i.sysctlSetter.Set()
 	}
 	log.Println(internal.InfoPrefix, "IPv6 module is not enabled")
@@ -43,7 +43,7 @@ func (i *Ipv6) Block() error {
 func (i *Ipv6) Unblock() error {
 	i.Lock()
 	defer i.Unlock()
-	if i.sysctlSetter.IsEnabled() {
+	if i.sysctlSetter.Exists() {
 		return i.sysctlSetter.Unset()
 	}
 	return nil

--- a/kernel/sysctl_setter.go
+++ b/kernel/sysctl_setter.go
@@ -80,7 +80,7 @@ func (s *SysctlSetterImpl) Unset() error {
 }
 
 func (s *SysctlSetterImpl) Exists() bool {
-	if !internal.FileExists(strings.ReplaceAll(s.paramName, ".", ".")) {
+	if !internal.FileExists("/proc/sys/" + strings.ReplaceAll(s.paramName, ".", "/")) {
 		return false
 	}
 

--- a/kernel/sysctl_setter.go
+++ b/kernel/sysctl_setter.go
@@ -79,7 +79,7 @@ func (s *SysctlSetterImpl) Unset() error {
 	return nil
 }
 
-func (s *SysctlSetterImpl) IsEnabled() bool {
+func (s *SysctlSetterImpl) Exists() bool {
 	if !internal.FileExists(strings.ReplaceAll(s.paramName, ".", ".")) {
 		return false
 	}

--- a/kernel/sysctl_setter.go
+++ b/kernel/sysctl_setter.go
@@ -1,6 +1,11 @@
 package kernel
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NordSecurity/nordvpn-linux/internal"
+)
 
 type SysctlSetter interface {
 	Set() error
@@ -72,4 +77,16 @@ func (s *SysctlSetterImpl) Unset() error {
 		s.changed = false
 	}
 	return nil
+}
+
+func (s *SysctlSetterImpl) IsEnabled() bool {
+	if !internal.FileExists(strings.ReplaceAll(s.paramName, ".", ".")) {
+		return false
+	}
+
+	if _, err := Parameter(s.paramName); err != nil {
+		return strings.Contains(err.Error(), "cannot stat")
+	}
+
+	return true
 }


### PR DESCRIPTION
If IPv6 is disabled from GRUB the application will fail to connect to VPN because it cannot disable IPv6.