### PR TITLE
Correctly check error message from sysctl

### DIFF
--- a/kernel/sysctl_setter.go
+++ b/kernel/sysctl_setter.go
@@ -85,7 +85,7 @@ func (s *SysctlSetterImpl) Exists() bool {
 	}
 
 	if _, err := Parameter(s.paramName); err != nil {
-		return strings.Contains(err.Error(), "cannot stat")
+		return !strings.Contains(err.Error(), "cannot stat")
 	}
 
 	return true


### PR DESCRIPTION
If error message contains "cannot stat" then the value doesn't exist into the system.
