### PR TITLE
Release 3.17.3

### DIFF
--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -19,9 +19,10 @@ jobs:
         github.event.label.name == 'gitlab'
       )
     steps:
-      - uses: NordSecurity/trigger-gitlab-pipeline@v1
+      - uses: NordSecurity/trigger-gitlab-pipeline@v2.0.0
         with:
           ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
           project-id: ${{ secrets.PROJECT_ID }}
-          ref: ${{ secrets.REF }}
-          token: ${{ secrets.TOKEN }}
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          triggered-ref: ${{ secrets.TRIGGERED_REF }}
+          trigger-token: ${{ secrets.TRIGGER_TOKEN }}

--- a/contrib/changelog/prod/3.17.3_1709544316.md
+++ b/contrib/changelog/prod/3.17.3_1709544316.md
@@ -1,0 +1,3 @@
+* Fixed: Routing through Meshnet devices connected to an OpenVPN server used to mean a trip to no-internet land. Not anymore.
+* Fixed: We've refined help-related messages. They're now more accurate, guiding you without the guesswork.
+* We’ve made other tweaks and fixes to make your NordVPN experience smoother, faster, and more reliable.

--- a/fileshare/service/fork.go
+++ b/fileshare/service/fork.go
@@ -30,8 +30,7 @@ func (f *ForkFileshare) Enable(uid, gid uint32) (err error) {
 	// Set up log file
 	fileFlags := os.O_APPEND | os.O_WRONLY | os.O_CREATE
 	logFilePath := internal.GetFilesharedLogPath(strconv.Itoa(int(uid)))
-	// #nosec G304 -- logFilePath is properly validated
-	logFile, err := os.OpenFile(logFilePath, fileFlags, internal.PermUserRW)
+	logFile, err := internal.OpenOrCreateRegularFile(logFilePath, fileFlags, internal.PermUserRW)
 	if err != nil {
 		return fmt.Errorf("opening fileshare log file %s: %w", logFilePath, err)
 	}

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -76,6 +76,9 @@ const (
 
 	// FileshareHistoryFile is the storage file used by libdrop
 	FileshareHistoryFile = "fileshare_history.db"
+
+	// Extension for log files
+	LogFileExtension = ".log"
 )
 
 var (
@@ -156,7 +159,7 @@ func GetFilesharedConfigDirPath(homeDirectory string) (string, error) {
 
 // GetFilesharedLogPath when logs aren't handled by systemd
 func GetFilesharedLogPath(uid string) string {
-	filesharedLogFilename := Fileshared + ".log"
+	const filesharedLogFilename = Fileshared + LogFileExtension
 	if uid == "0" {
 		return filepath.Join(LogPath, filesharedLogFilename)
 	}
@@ -170,7 +173,7 @@ func GetFilesharedLogPath(uid string) string {
 
 	if err != nil {
 		log.Printf("users fileshared logs will be stored in %s: %s", LogPath, err.Error())
-		return filepath.Join(LogPath, Fileshared+"-"+uid+".log")
+		return filepath.Join(LogPath, Fileshared+"-"+uid+LogFileExtension)
 	}
 
 	return filepath.Join(configDir, filesharedLogFilename)


### PR DESCRIPTION
Changelog:
* Fixed: Routing through Meshnet devices connected to an OpenVPN server used to mean a trip to no-internet land. Not anymore.
* Fixed: We've refined help-related messages. They're now more accurate, guiding you without the guesswork.
* We’ve made other tweaks and fixes to make your NordVPN experience smoother, faster, and more reliable.
