### PR TITLE
Fix dns handling on headless/docker systems

### DIFF
--- a/daemon/dns/dns_resolvectl.go
+++ b/daemon/dns/dns_resolvectl.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"os/exec"
 	"strings"
-
-	"github.com/NordSecurity/nordvpn-linux/internal"
 )
 
 // Executables
@@ -27,7 +25,13 @@ func (m *Resolvectl) Unset(iface string) error {
 }
 
 func (m *Resolvectl) IsAvailable() bool {
-	return internal.IsCommandAvailable(execResolvectl)
+	// resolvectl binary can be installed/available in headless/docker system;
+	// let's check if it is functional;
+	// #nosec G204 -- input is properly validated
+	if _, err := exec.Command("resolvectl", "status").CombinedOutput(); err != nil {
+		return false
+	}
+	return true
 }
 
 func (m *Resolvectl) Name() string {


### PR DESCRIPTION
There could be a situation when `systemd` and `resolvectl` get installed in the docker image as a dependency e.g. `openssh-server` but is not active. Out DNS handling methods (one of them) was checking if `resolvectl` command is available in the system and then try to handle DNS settings using that command but it was non-functional. Implemented extra validation.