### PR TITLE
Fix missing downloads directory in snap package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ coverage/unit
 # Env files
 .env
 .pcap
+
+# Snap files
+parts
+prime
+stage
+*.snap

--- a/cli/cli_fileshare.go
+++ b/cli/cli_fileshare.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/client"
 	dpb "github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/fileshare"
 	"github.com/NordSecurity/nordvpn-linux/fileshare/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	mpb "github.com/NordSecurity/nordvpn-linux/meshnet/pb"
@@ -251,23 +252,17 @@ func (c *cmd) FileshareAccept(ctx *cli.Context) error {
 	}
 
 	var path string
+	var err error
 	if ctx.IsSet(flagFilesharePath) {
-		var err error
 		path, err = filepath.Abs(ctx.String(flagFilesharePath))
 		if err != nil {
 			return fmt.Errorf(MsgFileshareInvalidPath, formatError(err))
 		}
 	} else {
-		downloads, ok := os.LookupEnv("XDG_DOWNLOAD_DIR")
-		if !ok {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				log.Print("determining user home directory: " + err.Error())
-				return fmt.Errorf(MsgFileshareAcceptHomeError)
-			}
-			path = filepath.Join(home, "Downloads")
-		} else {
-			path = downloads
+		path, err = fileshare.GetDefaultDownloadDirectory()
+		if err != nil {
+			log.Print("determining user home directory: " + err.Error())
+			return fmt.Errorf(MsgFileshareAcceptHomeError)
 		}
 	}
 

--- a/fileshare/fileshare_process/fileshare_process_manager.go
+++ b/fileshare/fileshare_process/fileshare_process_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sync"
 
 	childprocess "github.com/NordSecurity/nordvpn-linux/child_process"
 	"github.com/NordSecurity/nordvpn-linux/fileshare/pb"
@@ -15,9 +14,7 @@ import (
 
 var FileshareURL = fmt.Sprintf("%s://%s", internal.Proto, internal.FileshareSocket)
 
-type FileshareProcessClient struct {
-	mu sync.Mutex
-}
+type FileshareProcessClient struct{}
 
 func NewFileshareProcessClient() *FileshareProcessClient {
 	return &FileshareProcessClient{}
@@ -37,9 +34,6 @@ func getFileshareClient() (pb.FileshareClient, *grpc.ClientConn, error) {
 }
 
 func (f *FileshareProcessClient) Ping(nowait bool) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
 	client, clientConn, err := getFileshareClient()
 	if err != nil {
 		return fmt.Errorf("failed to initialize the connection: %w", err)
@@ -58,9 +52,6 @@ func (f *FileshareProcessClient) Ping(nowait bool) error {
 }
 
 func (f *FileshareProcessClient) Stop(bool) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
 	client, clientConn, err := getFileshareClient()
 	if err != nil {
 		return fmt.Errorf("failed to initialize the connection: %w", err)

--- a/fileshare/filesystem.go
+++ b/fileshare/filesystem.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"golang.org/x/sys/unix"
@@ -64,13 +63,17 @@ func (stdFs StdFilesystem) Lstat(path string) (fs.FileInfo, error) {
 
 // GetDefaultDownloadDirectory returns users Downloads directory or an error if it doesn't exist
 func GetDefaultDownloadDirectory() (string, error) {
-	username, err := user.Current()
-
-	if err != nil {
-		return "", fmt.Errorf("failed to obtain username: %s", err.Error())
+	downloads, ok := os.LookupEnv("XDG_DOWNLOAD_DIR")
+	if ok {
+		return downloads, nil
 	}
 
-	path := filepath.Join(username.HomeDir, "Downloads")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to obtain user home directory: %s", err.Error())
+	}
+
+	path := filepath.Join(homeDir, "Downloads")
 	if _, err = os.Stat(path); err != nil {
 		return "", fmt.Errorf("user downloads directory not found: %s", err.Error())
 	}

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -76,6 +76,7 @@ func SystemDListener() (net.Listener, error) {
 type runDirListener struct {
 	listener net.Listener
 	socket   string
+	pidfile  string
 }
 
 func (rdl *runDirListener) Accept() (net.Conn, error) {
@@ -85,7 +86,7 @@ func (rdl *runDirListener) Accept() (net.Conn, error) {
 func (rdl *runDirListener) Close() error {
 	listenerCloseErr := rdl.listener.Close()
 
-	cleanPidFile()
+	cleanPidFile(rdl.pidfile)
 
 	var protoRemoveErr error
 	var dirRemoveErr error
@@ -148,6 +149,7 @@ func ManualListenerIfNotInUse(socket string, perm fs.FileMode, pidfile string) f
 		return &runDirListener{
 			listener: listener,
 			socket:   socket,
+			pidfile:  pidfile,
 		}, nil
 	}
 }
@@ -207,9 +209,9 @@ func checkPidFile(pidfile string) error {
 	return nil
 }
 
-func cleanPidFile() {
-	if FileExists(DaemonPid) {
-		if err := FileDelete(DaemonPid); err != nil {
+func cleanPidFile(pidFile string) {
+	if pidFile != "" && FileExists(pidFile) {
+		if err := FileDelete(pidFile); err != nil {
 			log.Println(ErrorPrefix, "removing pid file:", err)
 		}
 	}

--- a/norduser/group_monitor.go
+++ b/norduser/group_monitor.go
@@ -77,8 +77,9 @@ func getNordvpnGroupMembers() (userSet, error) {
 }
 
 type userIDs struct {
-	uid uint32
-	gid uint32
+	uid  uint32
+	gid  uint32
+	home string
 }
 
 func getUID(username string) (userIDs, error) {
@@ -98,8 +99,9 @@ func getUID(username string) (userIDs, error) {
 	}
 
 	return userIDs{
-		uid: uint32(uid),
-		gid: uint32(gid),
+		uid:  uint32(uid),
+		gid:  uint32(gid),
+		home: user.HomeDir,
 	}, nil
 }
 
@@ -139,7 +141,7 @@ func (n *NordvpnGroupMonitor) handleGroupUpdate(currentGroupMembers userSet, new
 			continue
 		}
 
-		if err := n.norduserd.Enable(userID.uid, userID.gid); err != nil {
+		if err := n.norduserd.Enable(userID.uid, userID.gid, userID.home); err != nil {
 			log.Println("enabling norduserd for member:", err)
 		}
 	}
@@ -153,7 +155,7 @@ func (n *NordvpnGroupMonitor) startForEveryGroupMember(groupMembers userSet) {
 			continue
 		}
 
-		if err := n.norduserd.Enable(user.uid, user.gid); err != nil {
+		if err := n.norduserd.Enable(user.uid, user.gid, user.home); err != nil {
 			log.Println("failed to start norduser for group member:", err)
 		}
 	}

--- a/norduser/grpc_interceptor.go
+++ b/norduser/grpc_interceptor.go
@@ -3,6 +3,8 @@ package norduser
 import (
 	"context"
 	"log"
+	"os/user"
+	"strconv"
 
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/norduser/service"
@@ -31,12 +33,16 @@ func (n *StartNorduserdMiddleware) middleware(ctx context.Context) {
 		var err error
 		ucred, err = internal.StringToUcred(peer.AuthInfo.AuthType())
 		if err != nil {
-			log.Println("failed to convert auth info to user credentials: ", err.Error())
+			log.Println("failed to convert auth info to user credentials:", err.Error())
 		}
 	}
 
-	if err := n.nodruserd.Enable(ucred.Uid, ucred.Gid); err != nil {
-		log.Println("failed to enable norduserd: ", err)
+	u, err := user.LookupId(strconv.FormatInt(int64(ucred.Uid), 10))
+	if err != nil {
+		log.Println("failed to find user by UID:", err)
+	}
+	if err := n.nodruserd.Enable(ucred.Uid, ucred.Gid, u.HomeDir); err != nil {
+		log.Println("failed to enable norduserd:", err)
 	}
 }
 

--- a/norduser/process/norduser_process_manager.go
+++ b/norduser/process/norduser_process_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sync"
 
 	childprocess "github.com/NordSecurity/nordvpn-linux/child_process"
 	"github.com/NordSecurity/nordvpn-linux/internal"
@@ -18,7 +17,6 @@ func NorduserURL(uid uint32) string {
 }
 
 type NorduserProcessClient struct {
-	mu  sync.Mutex
 	uid uint32
 }
 
@@ -41,9 +39,6 @@ func getNorduserClient(uid uint32) (pb.NorduserClient, *grpc.ClientConn, error) 
 }
 
 func (n *NorduserProcessClient) Ping(nowait bool) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	client, clientConn, err := getNorduserClient(n.uid)
 	if err != nil {
 		return fmt.Errorf("failed to initialize the connection: %w", err)
@@ -62,9 +57,6 @@ func (n *NorduserProcessClient) Ping(nowait bool) error {
 }
 
 func (n *NorduserProcessClient) Stop(disable bool) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	client, clientConn, err := getNorduserClient(n.uid)
 	if err != nil {
 		return fmt.Errorf("failed to initialize the connection: %w", err)

--- a/norduser/server.go
+++ b/norduser/server.go
@@ -75,7 +75,7 @@ func (s *Server) StopFileshare(context.Context, *pb.Empty) (*pb.StopFileshareRes
 
 	fileshareStatus := s.fileshareProcessManager.ProcessStatus()
 	if fileshareStatus == childprocess.NotRunning {
-		log.Println("Received stop fileshare request but fileshare is already running, status is: ", fileshareStatus)
+		log.Println("Received stop fileshare request but fileshare is already not running, status is: ", fileshareStatus)
 		return &pb.StopFileshareResponse{Success: true}, nil
 	}
 

--- a/norduser/service/combined.go
+++ b/norduser/service/combined.go
@@ -7,7 +7,7 @@ import (
 )
 
 type NorduserService interface {
-	Enable(uid uint32, gid uint32) error
+	Enable(uid uint32, gid uint32, home string) error
 	Disable(uid uint32) error
 	Stop(uid uint32) error
 	StopAll()
@@ -36,7 +36,7 @@ func NewNorduserService() *Combined {
 	}
 }
 
-func (c *Combined) Enable(uid uint32, gid uint32) error {
+func (c *Combined) Enable(uid uint32, gid uint32, home string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -51,7 +51,7 @@ func (c *Combined) Enable(uid uint32, gid uint32) error {
 		log.Println("failed to disable norduser sytemd after enable has failed")
 	}
 
-	if err := c.childProcess.Enable(uid, gid); err != nil {
+	if err := c.childProcess.Enable(uid, gid, home); err != nil {
 		return fmt.Errorf("enabling norduserd via fork: %w", err)
 	}
 

--- a/norduser/service/fork.go
+++ b/norduser/service/fork.go
@@ -53,7 +53,7 @@ func isRunning(uid uint32) (bool, error) {
 }
 
 // Enable starts norduser process
-func (f *ChildProcessNorduser) Enable(uid uint32, gid uint32) (err error) {
+func (f *ChildProcessNorduser) Enable(uid uint32, gid uint32, home string) (err error) {
 	running, err := isRunning(uid)
 	if err != nil {
 		return fmt.Errorf("failed to determine if the process is already running: %w", err)
@@ -76,6 +76,10 @@ func (f *ChildProcessNorduser) Enable(uid uint32, gid uint32) (err error) {
 		Groups: []uint32{uint32(nordvpnGid)},
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: credential}
+	// os.UserHomeDir always returns value of $HOME and spawning child process copies
+	// environment variables from a parent process, therefore value of $HOME will be root home
+	// dir, where user usually does not have access.
+	cmd.Env = append(cmd.Env, "HOME="+home)
 	f.commandHandles[uid] = cmd
 
 	return cmd.Start()

--- a/norduser/service/snap.go
+++ b/norduser/service/snap.go
@@ -17,7 +17,7 @@ func NewNorduserSnapService() NorduserSnap {
 	return NorduserSnap{}
 }
 
-func (n NorduserSnap) Enable(uint32, uint32) error {
+func (n NorduserSnap) Enable(uint32, uint32, string) error {
 	return nil
 }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,7 +63,6 @@ apps:
       PREFIX_COMMON: $SNAP_COMMON
       PREFIX_DATA: $SNAP_DATA
       PREFIX_STATIC: $SNAP
-      USER_DATA: $SNAP_USER_COMMON
     plugs:
       - home
       - network

--- a/test/mock/norduser/service/combined.go
+++ b/test/mock/norduser/service/combined.go
@@ -2,11 +2,11 @@ package service
 
 type MockNorduserCombinedService struct{}
 
-func (m *MockNorduserCombinedService) Enable(uid uint32, gid uint32) error { return nil }
+func (m *MockNorduserCombinedService) Enable(uint32, uint32, string) error { return nil }
 
-func (m *MockNorduserCombinedService) Disable(uid uint32) error { return nil }
+func (m *MockNorduserCombinedService) Disable(uint32) error { return nil }
 
-func (m *MockNorduserCombinedService) Stop(uid uint32) error { return nil }
+func (m *MockNorduserCombinedService) Stop(uint32) error { return nil }
 
 func (m *MockNorduserCombinedService) StopAll() {}
 


### PR DESCRIPTION
    Snap sets the value of `$HOME` to `$SNAP_USER_DATA`, therefore explicit
    usage of `$SHAN_USER_DATA` is not needed. This results in `$HOME` value
    respected in most places with the exception of `addAutostart` as it will
    not work if added to `$SNAP_USER_DATA`.