### PR TITLE
release 3.17.4

### DIFF
--- a/contrib/changelog/prod/3.17.3_1709544316.md
+++ b/contrib/changelog/prod/3.17.3_1709544316.md
@@ -1,0 +1,3 @@
+* Fixed: Routing through Meshnet devices connected to an OpenVPN server used to mean a trip to no-internet land. Not anymore.
+* Fixed: We've refined help-related messages. They're now more accurate, guiding you without the guesswork.
+* We’ve made other tweaks and fixes to make your NordVPN experience smoother, faster, and more reliable.

--- a/contrib/changelog/prod/3.17.4_1712147372.md
+++ b/contrib/changelog/prod/3.17.4_1712147372.md
@@ -1,0 +1,1 @@
+* Fixed: We discovered that DNS configurations went off-track when your LAN access was enabled. The bug is no more.

--- a/daemon/dns/dns_resolved.go
+++ b/daemon/dns/dns_resolved.go
@@ -81,7 +81,7 @@ func setDNSWithSystemdResolve(ifname string, addresses []string) error {
 		"org.freedesktop.resolve1",
 		"/org/freedesktop/resolve1",
 		"org.freedesktop.resolve1.Manager",
-		"SetLinkDomains", "ia(sb)", fmt.Sprintf("%d", iface.Index), "1", "~.", "true",
+		"SetLinkDomains", "ia(sb)", fmt.Sprintf("%d", iface.Index), "1", ".", "true",
 	).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("setting link routing domains for %s via dbus: %s: %w", iface.Name, strings.TrimSpace(string(out)), err)

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -295,6 +295,15 @@ func FileWritable(path string) bool {
 	}
 }
 
+func IsFile(fileName string) bool {
+	fileInfo, err := os.Lstat(fileName)
+	if err != nil {
+		return false
+	}
+
+	return fileInfo.Mode().IsRegular()
+}
+
 // FileDelete deletes file from system
 func FileDelete(path string) error {
 	return os.Remove(path)
@@ -594,4 +603,29 @@ func prefixPath(p string, envKey string) string {
 		dir = "/"
 	}
 	return filepath.Clean(dir + p)
+}
+
+// Will open or create the given file.
+// If a file already exists with the given name but is not a regular file,
+// e.g. a symlink, it will be deleted and a regular file re-created instead
+func OpenOrCreateRegularFile(fileName string, flags int, permission fs.FileMode) (*os.File, error) {
+	fileName = filepath.Clean(fileName)
+	// check if it is a file before opening, because if it is a pipe will block on open
+	if !IsFile(fileName) {
+		if err := os.Remove(fileName); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("cannot delete file %s: %w", fileName, err)
+		}
+	}
+	// #nosec G304 -- fileName was cleaned before
+	file, err := os.OpenFile(fileName, flags, permission)
+	if err != nil {
+		return nil, fmt.Errorf("opening file %s: %w", fileName, err)
+	}
+
+	// check again that the file is a regular file after it is open to be sure it was not changed between checking and opening it
+	if !IsFile(fileName) {
+		return nil, fmt.Errorf("not a regular file %s", fileName)
+	}
+
+	return file, nil
 }


### PR DESCRIPTION
When LAN access is enabled if the DNS is not correctly configured on the VPN interface will result in DNS leaks.
Fixes: 
* cherry-pick the fix for DNS headless devices
* fix configuring the DNS