### PR TITLE
Fix tray notifications and remove leak

### DIFF
--- a/tray/monitor.go
+++ b/tray/monitor.go
@@ -242,7 +242,10 @@ func (ti *Instance) maybeRedraw(result bool, previous bool) bool {
 	return result || previous
 }
 
-func (ti *Instance) pollingMonitor(ticker <-chan time.Time) {
+func (ti *Instance) pollingMonitor() {
+	ticker := time.NewTicker(PollingUpdateInterval)
+	defer ticker.Stop()
+
 	fullUpdate := true
 	fullUpdateLast := time.Time{}
 	for {
@@ -267,8 +270,8 @@ func (ti *Instance) pollingMonitor(ticker <-chan time.Time) {
 		case fullUpdate = <-ti.updateChan:
 		case <-systray.TrayOpenedCh:
 			fullUpdate = true
-		case ts := <-ticker:
-			if ts.Sub(fullUpdateLast) > PollingFullUpdateInterval {
+		case ts := <-ticker.C:
+			if ts.Sub(fullUpdateLast) >= PollingFullUpdateInterval {
 				fullUpdate = true
 			} else {
 				fullUpdate = false

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -112,8 +112,7 @@ func OnReady(ti *Instance) {
 
 	time.AfterFunc(NotifierStartDelay, func() { ti.notifier.start() })
 
-	ticker := time.Tick(PollingUpdateInterval)
-	go ti.pollingMonitor(ticker)
+	go ti.pollingMonitor()
 
 	go func() {
 		for {

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -106,7 +106,7 @@ func OnReady(ti *Instance) {
 
 	systray.SetIconName(ti.iconDisconnected)
 	ti.state.vpnStatus = "Disconnected"
-	ti.state.notifyEnabled = true
+	ti.state.notifyEnabled = false
 	ti.redrawChan = make(chan struct{})
 	ti.updateChan = make(chan bool)
 


### PR DESCRIPTION
* disable notifications by default, and update the value when the tray will be able to fetch the real daemon settings
* `time.Tick` is reported that is leaking. To fix the warning move the time inside `pollingMonitor` and add a defer to stop it, even though for now the function never returns