### PR TITLE
Don't show empty fields at meshnet routing

### DIFF
--- a/tray/menu.go
+++ b/tray/menu.go
@@ -91,12 +91,20 @@ func addVpnSection(ti *Instance) {
 	mStatus.Disable()
 
 	if ti.state.vpnStatus == "Connected" {
-		mHostname := systray.AddMenuItem("Server: "+ti.state.vpnHostname, "Server: "+ti.state.vpnHostname)
-		mHostname.Disable()
-		mCity := systray.AddMenuItem("City: "+ti.state.vpnCity, "City: "+ti.state.vpnCity)
-		mCity.Disable()
-		mCountry := systray.AddMenuItem("Country: "+ti.state.vpnCountry, "Country: "+ti.state.vpnCountry)
-		mCountry.Disable()
+		if ti.state.vpnHostname != "" {
+			mHostname := systray.AddMenuItem("Server: "+ti.state.vpnHostname, "Server: "+ti.state.vpnHostname)
+			mHostname.Disable()
+		}
+
+		if ti.state.vpnCity != "" {
+			mCity := systray.AddMenuItem("City: "+ti.state.vpnCity, "City: "+ti.state.vpnCity)
+			mCity.Disable()
+		}
+
+		if ti.state.vpnCountry != "" {
+			mCountry := systray.AddMenuItem("Country: "+ti.state.vpnCountry, "Country: "+ti.state.vpnCountry)
+			mCountry.Disable()
+		}
 		mDisconnect := systray.AddMenuItem("Disconnect", "Disconnect")
 		go func() {
 			success := false


### PR DESCRIPTION
At meshnet routing some of the fields, like city and country, are empty. In that case remove them from the tray menu.