### PR TITLE
Use enum for notifications status

### DIFF
--- a/tray/notifications.go
+++ b/tray/notifications.go
@@ -15,9 +15,9 @@ import (
 func (ti *Instance) notify(text string, a ...any) {
 	text = fmt.Sprintf(text, a...)
 	ti.state.mu.RLock()
-	notifyEnabled := ti.state.notifyEnabled
+	notificationsStatus := ti.state.notificationsStatus
 	ti.state.mu.RUnlock()
-	if notifyEnabled {
+	if notificationsStatus == Enabled {
 		if err := ti.notifier.sendNotification("NordVPN", text); err != nil {
 			log.Println(internal.ErrorPrefix+" failed to send notification: ", err)
 		}

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -23,6 +23,14 @@ const (
 	AccountInfoUpdateInterval = 24 * time.Hour
 )
 
+type Status int
+
+const (
+	Invalid Status = iota
+	Enabled
+	Disabled
+)
+
 type accountInfo struct {
 	accountInfo *pb.AccountResponse
 	updateTime  time.Time
@@ -55,18 +63,18 @@ type Instance struct {
 }
 
 type trayState struct {
-	daemonAvailable bool
-	loggedIn        bool
-	vpnActive       bool
-	notifyEnabled   bool
-	daemonError     string
-	accountName     string
-	vpnStatus       string
-	vpnName         string
-	vpnHostname     string
-	vpnCity         string
-	vpnCountry      string
-	mu              sync.RWMutex
+	daemonAvailable     bool
+	loggedIn            bool
+	vpnActive           bool
+	notificationsStatus Status
+	daemonError         string
+	accountName         string
+	vpnStatus           string
+	vpnName             string
+	vpnHostname         string
+	vpnCity             string
+	vpnCountry          string
+	mu                  sync.RWMutex
 }
 
 func NewTrayInstance(client pb.DaemonClient, quitChan chan<- norduser.StopRequest) *Instance {
@@ -97,7 +105,7 @@ func OnReady(ti *Instance) {
 
 	systray.SetIconName(ti.iconDisconnected)
 	ti.state.vpnStatus = "Disconnected"
-	ti.state.notifyEnabled = false
+	ti.state.notificationsStatus = Invalid
 	ti.redrawChan = make(chan struct{})
 	ti.updateChan = make(chan bool)
 


### PR DESCRIPTION
Convert notifications status from bool into an enum to be able to differentiate between notifications status from the daemon and that the value is not initialized.