### PR TITLE
Change the logic for fetching data from the daemon

### DIFF
--- a/cli/cli_mesh_peers.go
+++ b/cli/cli_mesh_peers.go
@@ -557,14 +557,18 @@ func (c *cmd) MeshPeerConnect(ctx *cli.Context) error {
 	if err != nil {
 		return formatError(err)
 	}
+	peerName := peer.Nickname
+	if peerName == "" {
+		peerName = peer.Hostname
+	}
 	if err := connectResponseToError(
 		removeResp,
-		peer.Hostname,
+		peerName,
 	); err != nil {
 		return formatError(err)
 	}
 
-	color.Green(MsgMeshnetPeerConnectSuccess, peer.Hostname)
+	color.Green(MsgMeshnetPeerConnectSuccess, peerName)
 	return nil
 }
 

--- a/cli/cli_status.go
+++ b/cli/cli_status.go
@@ -29,8 +29,13 @@ func Status(resp *pb.StatusResponse) string {
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("Status: %s\n", resp.State))
 
-	if resp.Hostname != "" {
-		b.WriteString(fmt.Sprintf("Hostname: %s\n", resp.Hostname))
+	hostname := resp.Name
+	if hostname == "" {
+		hostname = resp.Hostname
+	}
+
+	if hostname != "" {
+		b.WriteString(fmt.Sprintf("Hostname: %s\n", hostname))
 	}
 
 	if resp.Ip != "" {

--- a/test/qa/lib/meshnet.py
+++ b/test/qa/lib/meshnet.py
@@ -207,6 +207,12 @@ class Peer:
 
         return output
 
+    def name(self) -> str:
+        ''' Returns nickname if not empty and hostname otherwise. '''
+        if not self.nickname:
+            return self.nickname
+        
+        return self.hostname
 
 class PeerList:
     def __init__(self):

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -174,9 +174,6 @@ def test_route_to_nonexistant_node():
 
     assert expected_message in str(ex)
 
-
-@pytest.mark.flaky(reruns=2, reruns_delay=90)
-@timeout_decorator.timeout(90)
 def test_route_to_peer_status_valid():
     peer_hostname = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list()).get_external_peer().hostname
 
@@ -186,7 +183,7 @@ def test_route_to_peer_status_valid():
     peer_nick = "a-A-a"
     sh.nordvpn.mesh.peer.nick.set(peer_hostname, peer_nick)
     output = sh.nordvpn.mesh.peer.connect(peer_nick)
-    assert meshnet.is_connect_successful(output, peer_hostname)
+    assert meshnet.is_connect_successful(output, peer_nick)
 
     connect_time = time.monotonic()
 
@@ -210,8 +207,8 @@ def test_route_to_peer_status_valid():
     logging.log("status_info: " + str(sh.nordvpn.status()))
 
     assert "Connected" in status_info['status']
-    assert peer_hostname in status_info['hostname']
-    assert socket.gethostbyname(peer_hostname) in status_info['ip']
+    assert peer_nick in status_info['hostname']
+    assert socket.gethostbyname(peer_nick) in status_info['ip']
     assert "NORDLYNX" in status_info['current technology']
     assert "UDP" in status_info['current protocol']
 
@@ -235,7 +232,7 @@ def test_route_to_peer_status_valid():
 
 @pytest.mark.skip(reason="Test suit exits, before test can be completed.")
 def test_route_to_peer_that_is_disconnected():
-    peer_hostname = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list()).get_external_peer().hostname
+    peer_hostname = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list()).get_external_peer().name()
 
     ssh_client.exec_command("nordvpn set mesh off")
 
@@ -255,7 +252,7 @@ def test_route_to_peer_that_is_disconnected():
 def test_route_traffic_to_peer_wrong_tech(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    peer_hostname = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list()).get_external_peer().hostname
+    peer_hostname = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list()).get_external_peer().name()
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.mesh.peer.connect(peer_hostname)

--- a/tray/menu.go
+++ b/tray/menu.go
@@ -84,8 +84,12 @@ func addVpnSection(ti *Instance) {
 	mStatus.Disable()
 
 	if ti.state.vpnStatus == "Connected" {
-		if ti.state.vpnHostname != "" {
-			mHostname := systray.AddMenuItem("Server: "+ti.state.vpnHostname, "Server: "+ti.state.vpnHostname)
+		vpnServerName := ti.state.vpnName
+		if vpnServerName == "" {
+			vpnServerName = ti.state.vpnHostname
+		}
+		if vpnServerName != "" {
+			mHostname := systray.AddMenuItem("Server: "+vpnServerName, "Server: "+vpnServerName)
 			mHostname.Disable()
 		}
 
@@ -127,14 +131,16 @@ func addVpnSection(ti *Instance) {
 }
 
 func addAccountSection(ti *Instance) {
-	systray.AddSeparator()
-
 	if ti.state.loggedIn {
-		m := systray.AddMenuItem("Logged in as:", "Logged in as:")
-		m.Disable()
+		systray.AddSeparator()
 
-		mName := systray.AddMenuItem(ti.state.accountName, ti.state.accountName)
-		mName.Disable()
+		if ti.state.accountName != "" {
+			m := systray.AddMenuItem("Logged in as:", "Logged in as:")
+			m.Disable()
+
+			mName := systray.AddMenuItem(ti.state.accountName, ti.state.accountName)
+			mName.Disable()
+		}
 
 		mLogout := systray.AddMenuItem("Log out", "Log out")
 

--- a/tray/menu.go
+++ b/tray/menu.go
@@ -83,7 +83,7 @@ func addVpnSection(ti *Instance) {
 	mStatus := systray.AddMenuItem("VPN "+strings.ToLower(ti.state.vpnStatus), "VPN "+strings.ToLower(ti.state.vpnStatus))
 	mStatus.Disable()
 
-	if ti.state.vpnStatus == "Connected" {
+	if ti.state.vpnStatus == ConnectedString {
 		vpnServerName := ti.state.vpnName
 		if vpnServerName == "" {
 			vpnServerName = ti.state.vpnHostname

--- a/tray/monitor.go
+++ b/tray/monitor.go
@@ -20,8 +20,6 @@ import (
 
 // The pattern is to return 'true' if something has changed and 'false' when no changes were detected
 func (ti *Instance) ping() bool {
-	changed := false
-	daemonAvailable := false
 	daemonError := ""
 
 	resp, err := ti.client.Ping(context.Background(), &pb.Empty{})
@@ -38,35 +36,17 @@ func (ti *Instance) ping() bool {
 		}
 	}
 
-	if daemonError == "" {
-		daemonAvailable = true
-	}
-
-	ti.state.mu.Lock()
-
-	if ti.state.daemonAvailable != daemonAvailable {
-		ti.state.daemonAvailable = daemonAvailable
-		changed = true
-		if daemonAvailable {
-			defer ti.notify("Connected to NordVPN daemon")
-		} else {
-			defer ti.notify("Disconnected from NordVPN daemon")
-		}
-	}
-
-	if ti.state.daemonError != daemonError {
-		ti.state.daemonError = daemonError
-		changed = true
-	}
-
-	ti.state.mu.Unlock()
-	return changed
+	return ti.updateDaemonConnectionStatus(daemonError)
 }
 
 func (ti *Instance) updateLoginStatus() bool {
 	changed := false
 	resp, err := ti.client.IsLoggedIn(context.Background(), &pb.Empty{})
-	loggedIn := err == nil && resp.GetValue()
+	if err != nil {
+		return ti.updateDaemonConnectionStatus(messageForDaemonError(err))
+	}
+
+	loggedIn := resp.GetValue()
 
 	ti.state.mu.Lock()
 
@@ -76,6 +56,8 @@ func (ti *Instance) updateLoginStatus() bool {
 		defer ti.notify("Logged in")
 	} else if ti.state.loggedIn && !loggedIn {
 		ti.state.loggedIn = false
+		ti.accountInfo.reset()
+		ti.state.accountName = ""
 		changed = true
 		defer ti.notify("Logged out")
 	}
@@ -84,23 +66,28 @@ func (ti *Instance) updateLoginStatus() bool {
 	return changed
 }
 
-func (ti *Instance) updateVpnStatus() bool {
+func (ti *Instance) updateVpnStatus(fullUpdate bool) bool {
 	changed := false
-	vpnStatus := ""
-	vpnHostname := ""
-	vpnName := ""
-	vpnCity := ""
-	vpnCountry := ""
 	resp, err := ti.client.Status(context.Background(), &pb.Empty{})
-	if err == nil {
-		vpnStatus = resp.State
-		vpnHostname = resp.Hostname
-		vpnName = resp.Name
-		if vpnName == "" {
-			vpnName = vpnHostname
-		}
-		vpnCity = resp.City
-		vpnCountry = resp.Country
+	if err != nil {
+		return ti.updateDaemonConnectionStatus(messageForDaemonError(err))
+	}
+
+	vpnStatus := resp.State
+	vpnHostname := resp.Hostname
+	vpnCity := resp.City
+	vpnCountry := resp.Country
+	vpnName := resp.Name
+	if vpnName == "" {
+		vpnName = vpnHostname
+	}
+
+	shouldDisplayNotification := (ti.state.vpnStatus != vpnStatus) || (ti.state.vpnHostname != vpnHostname)
+
+	if fullUpdate || shouldDisplayNotification {
+		// update daemon settings before notifications are shown
+		changed = ti.updateAccountInfo()
+		changed = ti.updateSettings() || changed
 	}
 
 	ti.state.mu.Lock()
@@ -118,6 +105,9 @@ func (ti *Instance) updateVpnStatus() bool {
 	}
 
 	if ti.state.vpnHostname != vpnHostname {
+		if ti.state.vpnHostname != "" && vpnHostname != "" {
+			defer ti.notify("Connected to %s", vpnName)
+		}
 		ti.state.vpnHostname = vpnHostname
 		changed = true
 	}
@@ -172,7 +162,7 @@ func (ti *Instance) updateSettings() bool {
 		ti.state.notificationsStatus = newNotificationsStatus
 
 		if newNotificationsStatus == Enabled {
-			defer ti.notify("Notifications enabled")
+			defer log.Println(internal.InfoPrefix, " Notifications enabled")
 		} else {
 			defer log.Println(internal.InfoPrefix, " Notifications disabled")
 		}
@@ -183,50 +173,41 @@ func (ti *Instance) updateSettings() bool {
 }
 
 func (ti *Instance) updateAccountInfo() bool {
-	changed := false
-	loggedIn := ti.state.loggedIn
-	vpnActive := ti.state.vpnActive
-	accountName := ti.state.accountName
-
 	payload, err := ti.accountInfo.getAccountInfo(ti.client)
 	if err != nil {
-		if status.Convert(err).Message() != internal.ErrNotLoggedIn.Error() {
-			log.Println(internal.ErrorPrefix+" Error retrieving account info: ", err)
-			return false
+		if errMessage := messageForDaemonError(err); errMessage != internal.ErrDaemonConnectionRefused.Error() {
+			ti.updateDaemonConnectionStatus(errMessage)
 		}
-		loggedIn = false
+		log.Println(internal.ErrorPrefix+" Error retrieving account info: ", err)
+		return true
+	}
+	changed := false
+	vpnActive := ti.state.vpnActive
+	var accountName string
+
+	switch payload.Type {
+	case internal.CodeUnauthorized:
+		log.Println(internal.ErrorPrefix + " " + cli.AccountTokenUnauthorizedError)
+	case internal.CodeExpiredRenewToken:
+		log.Println(internal.ErrorPrefix + " CodeExpiredRenewToken")
+	case internal.CodeTokenRenewError:
+		log.Println(internal.ErrorPrefix + " CodeTokenRenewError")
+	}
+
+	if payload.Username != "" {
+		accountName = payload.Username
 	} else {
-		switch payload.Type {
-		case internal.CodeUnauthorized:
-			log.Println(internal.ErrorPrefix + " " + cli.AccountTokenUnauthorizedError)
-		case internal.CodeExpiredRenewToken:
-			log.Println(internal.ErrorPrefix + " CodeExpiredRenewToken")
-		case internal.CodeTokenRenewError:
-			log.Println(internal.ErrorPrefix + " CodeTokenRenewError")
-		default:
-			loggedIn = true
-		}
+		accountName = payload.Email
+	}
 
-		if payload.Username != "" {
-			accountName = payload.Username
-		} else {
-			accountName = payload.Email
-		}
-
-		switch payload.Type {
-		case internal.CodeSuccess:
-			vpnActive = true
-		case internal.CodeNoVPNService:
-			vpnActive = false
-		}
+	switch payload.Type {
+	case internal.CodeSuccess:
+		vpnActive = true
+	case internal.CodeNoVPNService:
+		vpnActive = false
 	}
 
 	ti.state.mu.Lock()
-
-	if ti.state.loggedIn != loggedIn {
-		ti.state.loggedIn = loggedIn
-		changed = true
-	}
 
 	if ti.state.vpnActive != vpnActive {
 		ti.state.vpnActive = vpnActive
@@ -242,11 +223,10 @@ func (ti *Instance) updateAccountInfo() bool {
 	return changed
 }
 
-func (ti *Instance) maybeRedraw(result bool, previous bool) bool {
+func (ti *Instance) redraw(result bool) {
 	if result {
 		ti.redrawChan <- struct{}{}
 	}
-	return result || previous
 }
 
 func (ti *Instance) pollingMonitor() {
@@ -256,33 +236,23 @@ func (ti *Instance) pollingMonitor() {
 	fullUpdate := true
 	fullUpdateLast := time.Time{}
 	for {
-		changed := false
-		fullUpdate = ti.maybeRedraw(ti.ping(), fullUpdate)
+		ti.redraw(ti.ping())
 		if ti.state.daemonAvailable {
-			fullUpdate = ti.maybeRedraw(ti.updateLoginStatus(), fullUpdate)
+			ti.redraw(ti.updateLoginStatus())
 			if ti.state.loggedIn {
-				fullUpdate = ti.maybeRedraw(ti.updateVpnStatus(), fullUpdate)
+				ti.redraw(ti.updateVpnStatus(fullUpdate))
 				if fullUpdate {
-					changed = ti.updateAccountInfo()
-					changed = ti.updateSettings() || changed
 					fullUpdateLast = time.Now()
 				}
 			}
 		}
 
-		if changed {
-			ti.redrawChan <- struct{}{}
-		}
 		select {
 		case fullUpdate = <-ti.updateChan:
 		case <-systray.TrayOpenedCh:
 			fullUpdate = true
 		case ts := <-ticker.C:
-			if ts.Sub(fullUpdateLast) >= PollingFullUpdateInterval {
-				fullUpdate = true
-			} else {
-				fullUpdate = false
-			}
+			fullUpdate = (ts.Sub(fullUpdateLast) >= PollingFullUpdateInterval)
 		}
 		if ti.debugMode {
 			if fullUpdate {
@@ -299,7 +269,17 @@ func messageForDaemonError(err error) string {
 		return ""
 	}
 
-	errorMessage := err.Error()
+	statusError, ok := status.FromError(err)
+	if !ok {
+		return ""
+	}
+	errorMessage := statusError.Message()
+
+	if errorMessage == internal.ErrNotLoggedIn.Error() {
+		// no error needs to be displayed in this case
+		// the user is not logged in and will be handled when fetching the login status
+		return ""
+	}
 
 	if strings.Contains(errorMessage, "no such file or directory") {
 		message := "Nordvpn daemon is not running\n\n"
@@ -315,9 +295,37 @@ func messageForDaemonError(err error) string {
 		return "Add the user to the nordvpn group and reboot the system\n\nsudo usermod -aG nordvpn $USER"
 	}
 
-	if snapErr := cli.RetrieveSnapConnsError(err); snapErr != nil {
-		return fmt.Sprintf(cli.MsgSnapPermissionsErrorForTray, cli.JoinSnapMissingPermissions(snapErr))
+	if snapconf.IsUnderSnap() {
+		if snapErr := cli.RetrieveSnapConnsError(err); snapErr != nil {
+			return fmt.Sprintf(cli.MsgSnapPermissionsErrorForTray, cli.JoinSnapMissingPermissions(snapErr))
+		}
 	}
 
 	return internal.ErrDaemonConnectionRefused.Error()
+}
+
+func (ti *Instance) updateDaemonConnectionStatus(errorMessage string) bool {
+	changed := false
+
+	daemonAvailable := (errorMessage == "")
+
+	ti.state.mu.Lock()
+
+	if ti.state.daemonAvailable != daemonAvailable {
+		changed = true
+		ti.state.daemonAvailable = daemonAvailable
+		if daemonAvailable {
+			defer ti.notify("Connected to NordVPN daemon")
+		} else {
+			defer ti.notify("Disconnected from NordVPN daemon")
+		}
+	}
+
+	if ti.state.daemonError != errorMessage {
+		ti.state.daemonError = errorMessage
+		changed = true
+	}
+
+	ti.state.mu.Unlock()
+	return changed
 }

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -2,7 +2,6 @@ package tray
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -42,11 +41,16 @@ func (ai *accountInfo) getAccountInfo(client pb.DaemonClient) (*pb.AccountRespon
 		var err error
 		ai.accountInfo, err = client.AccountInfo(context.Background(), &pb.Empty{})
 		if err != nil {
-			return &pb.AccountResponse{}, fmt.Errorf("retrvieving account info: %w", err)
+			return nil, err
 		}
 		ai.updateTime = time.Now()
 	}
 	return ai.accountInfo, nil
+}
+
+func (ai *accountInfo) reset() {
+	ai.updateTime = time.Time{}
+	ai.accountInfo = nil
 }
 
 type Instance struct {

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -20,6 +20,7 @@ const (
 	PollingUpdateInterval     = 5 * time.Second
 	PollingFullUpdateInterval = 60 * time.Second
 	AccountInfoUpdateInterval = 24 * time.Hour
+	ConnectedString           = "Connected"
 )
 
 type Status int


### PR DESCRIPTION
For tray:
* When the VPN status changes, before displaying notifications, fetch the app settings to have the current notifications settings. Otherwise some notifications might not be displayed.
* Remove the system notification for when the notifications are enabled
* At user logout invalidate account information
* Display notification when connected server changes
* Handle gRPC errors also for other requests, not only for ping

For tray and CLI:
* display VPN server name or meshnet nickname instead of hostname. If they are empty display the hostname