### PR TITLE
Fix tests because app returns server name instead

### DIFF
--- a/test/qa/lib/notify.py
+++ b/test/qa/lib/notify.py
@@ -64,14 +64,15 @@ def connect_and_capture_notifications(tech, proto, obfuscated) -> NotificationCa
     """Returns [True, True, True] if notification with all expected contents from NordVPN was captured while connecting to VPN server."""
 
     # Choose server for test, so we know the full expected message
-    name, hostname = server.get_hostname_by(tech, proto, obfuscated)
-    expected_msg = f"You are connected to {name} ({hostname})!"
+
+    server_info = server.get_hostname_by(tech, proto, obfuscated)
+    expected_msg = f"You are connected to {server_info.name} ({server_info.hostname})!"
 
     # We try to capture notifications using other thread when connecting to NordVPN server
     t_connect = NotificationCaptureThread(expected_msg)
     t_connect.start()
 
-    sh.nordvpn.connect(hostname.split(".")[0])
+    sh.nordvpn.connect(server_info.hostname.split(".")[0])
 
     t_connect.join()
 

--- a/test/qa/lib/notify.py
+++ b/test/qa/lib/notify.py
@@ -64,7 +64,6 @@ def connect_and_capture_notifications(tech, proto, obfuscated) -> NotificationCa
     """Returns [True, True, True] if notification with all expected contents from NordVPN was captured while connecting to VPN server."""
 
     # Choose server for test, so we know the full expected message
-
     server_info = server.get_hostname_by(tech, proto, obfuscated)
     expected_msg = f"You are connected to {server_info.name} ({server_info.hostname})!"
 

--- a/test/qa/lib/server.py
+++ b/test/qa/lib/server.py
@@ -4,6 +4,14 @@ from urllib.parse import quote
 
 import requests
 
+class ServerInfo:
+    def __init__(self, server_info):
+        self.name = server_info["name"]
+        self.hostname = server_info["hostname"]
+        self.city = server_info["locations"][0]["country"]["city"]["name"]
+        self.country = server_info["locations"][0]["country"]["name"]
+
+
 
 def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
     """Returns server name and hostname from core API."""
@@ -48,8 +56,8 @@ def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
     time.sleep(2)
     url = f"https://api.nordvpn.com/v1/servers?limit=10&filters[servers.status]=online&filters[servers_technologies]={tech_id}&filters[servers_groups]={group_id}"
     logging.debug(url)
-    server = requests.get(url, timeout=5).json()[0]
-    return server["name"], server["hostname"]
+    server_info = requests.get(url, timeout=5).json()[0]
+    return ServerInfo(server_info=server_info)
 
 
 def get_server_info(server_name):

--- a/test/qa/lib/server.py
+++ b/test/qa/lib/server.py
@@ -4,13 +4,13 @@ from urllib.parse import quote
 
 import requests
 
+
 class ServerInfo:
     def __init__(self, server_info):
         self.name = server_info["name"]
         self.hostname = server_info["hostname"]
         self.city = server_info["locations"][0]["country"]["city"]["name"]
         self.country = server_info["locations"][0]["country"]["name"]
-
 
 
 def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
@@ -46,7 +46,7 @@ def get_hostname_by(technology="", protocol="", obfuscated="", group_id=""):
         "Europe": "19",
         "The_Americas": "21",
         "Asia_Pacific": "23",
-        "Africa_The_Middle_East_And_India": "25"
+        "Africa_The_Middle_East_And_India": "25",
     }
 
     if group_id != "":

--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -89,8 +89,8 @@ def test_autoconnect_to_city(tech, proto, obfuscated, group):
 def test_autoconnect_to_random_server_by_name(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    _, hostname = server.get_hostname_by(tech, proto, obfuscated)
-    name = hostname.split(".")[0]
+    server_info = server.get_hostname_by(tech, proto, obfuscated)
+    name = server_info.hostname.split(".")[0]
 
     autoconnect_base_test(name)
 

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -96,8 +96,8 @@ def test_mistype_connect(tech, proto, obfuscated):
 def test_connect_to_server_random_by_name(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    name, hostname = server.get_hostname_by(tech, proto, obfuscated)
-    connect_base_test((tech, proto, obfuscated), hostname.split(".")[0], name, hostname)
+    server_info = server.get_hostname_by(tech, proto, obfuscated)
+    connect_base_test((tech, proto, obfuscated), server_info.hostname.split(".")[0], server_info.name, server_info.hostname)
     disconnect_base_test()
 
 
@@ -108,8 +108,9 @@ def test_connect_to_server_random_by_name(tech, proto, obfuscated):
 def test_connect_to_group_random_server_by_name_additional(tech, proto, obfuscated, group):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    name, hostname = server.get_hostname_by(tech, proto, obfuscated, group)
-    connect_base_test((tech, proto, obfuscated), hostname.split(".")[0], name, hostname)
+    server_info = server.get_hostname_by(tech, proto, obfuscated, group)
+    connect_base_test((tech, proto, obfuscated), server_info.hostname.split(".")[0], server_info.name, server_info.hostname)
+
     disconnect_base_test()
 
 
@@ -120,8 +121,9 @@ def test_connect_to_group_random_server_by_name_additional(tech, proto, obfuscat
 def test_connect_to_group_random_server_by_name_standard(tech, proto, obfuscated, group):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    name, hostname = server.get_hostname_by(tech, proto, obfuscated, group)
-    connect_base_test((tech, proto, obfuscated), hostname.split(".")[0], name, hostname)
+    server_info = server.get_hostname_by(tech, proto, obfuscated, group)
+    connect_base_test((tech, proto, obfuscated), server_info.hostname.split(".")[0], server_info.name, server_info.hostname)
+
     disconnect_base_test()
 
 
@@ -132,8 +134,8 @@ def test_connect_to_group_random_server_by_name_standard(tech, proto, obfuscated
 def test_connect_to_group_random_server_by_name_ovpn(tech, proto, obfuscated, group):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    name, hostname = server.get_hostname_by(group_id=group)
-    connect_base_test((tech, proto, obfuscated), hostname.split(".")[0], name, hostname)
+    server_info = server.get_hostname_by(group_id=group)
+    connect_base_test((tech, proto, obfuscated), server_info.hostname.split(".")[0], server_info.name, server_info.hostname)
     disconnect_base_test()
 
 
@@ -144,8 +146,8 @@ def test_connect_to_group_random_server_by_name_ovpn(tech, proto, obfuscated, gr
 def test_connect_to_group_random_server_by_name_obfuscated(tech, proto, obfuscated, group):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    name, hostname = server.get_hostname_by(group_id=group)
-    connect_base_test((tech, proto, obfuscated), hostname.split(".")[0], name, hostname)
+    server_info = server.get_hostname_by(group_id=group)
+    connect_base_test((tech, proto, obfuscated), server_info.hostname.split(".")[0], server_info.name, server_info.hostname)
     disconnect_base_test()
 
 
@@ -407,7 +409,8 @@ def test_connect_to_unavailable_servers(tech, proto, obfuscated):
     unavailable_groups = daemon.get_unavailable_groups()
 
     for group in unavailable_groups:
-        name = server.get_hostname_by(group_id=group)[1].split(".")[0]
+        server_info = server.get_hostname_by(group_id=group)
+        name = server_info.hostname.split(".")[0]
 
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh.nordvpn.connect(name)
@@ -425,8 +428,8 @@ def test_status_connected(tech, proto, obfuscated):
     assert network.is_disconnected()
     assert "Disconnected" in sh.nordvpn.status()
 
-    name, hostname = server.get_hostname_by(technology=tech, protocol=proto, obfuscated=obfuscated)
-    sh.nordvpn.connect(hostname.split(".")[0])
+    server_info = server.get_hostname_by(technology=tech, protocol=proto, obfuscated=obfuscated)
+    sh.nordvpn.connect(server_info.hostname.split(".")[0])
 
     connect_time = time.monotonic()
 
@@ -441,13 +444,12 @@ def test_status_connected(tech, proto, obfuscated):
 
     assert "Connected" in status_info['status']
 
-    assert hostname in status_info['hostname']
+    assert server_info.name in status_info['hostname']
 
-    assert socket.gethostbyname(hostname) in status_info['ip']
+    assert socket.gethostbyname(server_info.hostname) in status_info['ip']
 
-    city, country = server.get_server_info(name)
-    assert country in status_info['country']
-    assert city in status_info['city']
+    assert server_info.country in status_info['country']
+    assert server_info.city in status_info['city']
 
     assert tech.upper() in status_info['current technology']
 


### PR DESCRIPTION
The app returns server name instead of hostname, update the tests to handle this.
Create a class to store the server info and use it in tests.