### PR TITLE
Remove calls to column command

### DIFF
--- a/cli/cli_cities.go
+++ b/cli/cli_cities.go
@@ -48,7 +48,7 @@ func (c *cmd) Cities(ctx *cli.Context) error {
 		return formatError(errors.New(CitiesNotFoundError))
 	}
 
-	formattedList, err := internal.Columns(resp.Data)
+	formattedList, err := columns(resp.Data)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, err)
 		fmt.Println(strings.Join(resp.Data, ", "))

--- a/cli/cli_connect.go
+++ b/cli/cli_connect.go
@@ -154,7 +154,7 @@ func (c *cmd) ConnectAutoComplete(ctx *cli.Context) {
 		if err != nil {
 			return
 		}
-		groupList, err := internal.Columns(resp.Data)
+		groupList, err := columns(resp.Data)
 		if err != nil {
 			log.Println(err)
 		}
@@ -162,7 +162,7 @@ func (c *cmd) ConnectAutoComplete(ctx *cli.Context) {
 		if err != nil {
 			return
 		}
-		countryList, err := internal.Columns(resp.Data)
+		countryList, err := columns(resp.Data)
 		if err != nil {
 			log.Println(err)
 		}
@@ -174,7 +174,7 @@ func (c *cmd) ConnectAutoComplete(ctx *cli.Context) {
 		if err != nil {
 			return
 		}
-		cityList, err := internal.Columns(resp.Data)
+		cityList, err := columns(resp.Data)
 		if err != nil {
 			log.Println(err)
 		}

--- a/cli/cli_connect_test.go
+++ b/cli/cli_connect_test.go
@@ -140,7 +140,7 @@ func TestConnectAutoComplete(t *testing.T) {
 
 			assert.Nil(t, err)
 
-			list, _ := internal.Columns(test.expected)
+			list, _ := columns(test.expected)
 			assert.NotEmpty(t, list)
 			assert.Equal(t, list, result)
 		})

--- a/cli/cli_countries.go
+++ b/cli/cli_countries.go
@@ -28,7 +28,7 @@ func (c *cmd) Countries(ctx *cli.Context) error {
 		return formatError(err)
 	}
 
-	countryList, err := internal.Columns(resp.Data)
+	countryList, err := columns(resp.Data)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, err)
 		fmt.Println(strings.Join(resp.Data, ", "))

--- a/cli/cli_groups.go
+++ b/cli/cli_groups.go
@@ -25,7 +25,7 @@ func (c *cmd) Groups(ctx *cli.Context) error {
 		return formatError(fmt.Errorf(MsgListIsEmpty, "server groups"))
 	}
 
-	groupList, err := internal.Columns(resp.Data)
+	groupList, err := columns(resp.Data)
 
 	if err != nil {
 		log.Println(err)

--- a/cli/terminal.go
+++ b/cli/terminal.go
@@ -1,15 +1,19 @@
 package cli
 
 import (
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/NordSecurity/nordvpn-linux/internal"
-
 	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func checkUsernamePasswordIsEmpty(username, password string) error {
@@ -32,7 +36,7 @@ func ReadCredentialsFromTerminal() (string, string, error) {
 		password string
 	)
 
-	if !terminal.IsTerminal(0) || !terminal.IsTerminal(1) {
+	if !term.IsTerminal(0) || !term.IsTerminal(1) {
 		return username, password, fmt.Errorf("Stdin/Stdout should be terminal")
 	}
 	oldState, err := terminal.MakeRaw(0)
@@ -117,4 +121,91 @@ func ReadPlanFromTerminal() (int, error) {
 		break
 	}
 	return planID, nil
+}
+
+// formats a list of strings to a tidy column representation
+func columns(data []string) (string, error) {
+	width, _, err := cliDimensions()
+	if err != nil {
+		// workaround for tests because terminal size cannot be calculated
+		if flag.Lookup("test.v") != nil {
+			return strings.Join(data, " "), err
+		}
+		return "", err
+	}
+
+	return formatTable(data, width)
+}
+
+func formatTable(data []string, width int) (string, error) {
+	if width <= 0 {
+		return "", fmt.Errorf("invalid width size")
+	}
+
+	if len(data) == 0 {
+		return "", nil
+	}
+
+	// Calculate the maximum width of an item
+	maxItemWidth := 0
+	for _, item := range data {
+		if len(item) > maxItemWidth {
+			maxItemWidth = len(item)
+		}
+	}
+
+	// Calculate the number of columns that can fit in the terminal width
+	columnWidth := min(width, maxItemWidth+4)
+	columns := width / columnWidth
+
+	if columns < 1 {
+		// if the width is very small then display everything in one column
+		columns = 1
+	}
+
+	var builder strings.Builder
+	for i, value := range data {
+		itemWidth := columnWidth
+		isLastElementOnLine := ((i+1)%columns == 0)
+		isLast := (i == len(data)-1)
+		if isLastElementOnLine || isLast {
+			// don't add extra space for the last item on the row
+			itemWidth = 0
+		}
+
+		builder.WriteString(fmt.Sprintf("%-*s", itemWidth, value))
+
+		if isLastElementOnLine && !isLast {
+			// add new line for rows, except last one
+			builder.WriteString("\n")
+		}
+	}
+
+	return builder.String(), nil
+}
+
+// Gets the size of CLI window
+func cliDimensions() (int, int, error) {
+	width, height, err := term.GetSize(int(os.Stdout.Fd()))
+	if err == nil {
+		return width, height, nil
+	}
+
+	log.Println(internal.InfoPrefix, "failed to get windows size, try stty")
+
+	// if getting the window size from stdout fails, usually when piped, try to execute stty
+	cmd := exec.Command(internal.SttyExec, "size")
+	cmd.Stdin = os.Stdin
+
+	out, errStty := cmd.CombinedOutput()
+	if errStty != nil {
+		return 0, 0, errors.Join(err, errStty)
+	}
+
+	n, errScanf := fmt.Sscanf(string(out), "%d %d", &height, &width)
+	if n != 2 || errScanf != nil {
+		return 0, 0, errors.Join(err, errScanf)
+	}
+
+	return width, height, nil
 }

--- a/cli/terminal_test.go
+++ b/cli/terminal_test.go
@@ -48,3 +48,62 @@ func TestCheckUsernamePasswordIsEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitDataInColumns(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name           string
+		data           []string
+		width          int
+		expectsError   bool
+		expectedOutput string
+	}{
+		{
+			name:         "returns error when width is zero",
+			data:         []string{"Berlin", "Paris"},
+			width:        0,
+			expectsError: true,
+		},
+		{
+			name:           "handle empty data",
+			data:           []string{},
+			width:          25,
+			expectsError:   false,
+			expectedOutput: "",
+		},
+		{
+			name:           "for small width return a single column",
+			data:           []string{"Berlin", "Paris"},
+			width:          1,
+			expectsError:   false,
+			expectedOutput: "Berlin\nParis",
+		},
+		{
+			name:           "for big width return one line",
+			data:           []string{"Berlin", "Paris"},
+			width:          100,
+			expectsError:   false,
+			expectedOutput: "Berlin    Paris",
+		},
+		{
+			name:           "split data in multiple rows and columns",
+			data:           []string{"Berlin", "Paris", "Vilnius", "Rome"},
+			width:          25,
+			expectsError:   false,
+			expectedOutput: "Berlin     Paris\nVilnius    Rome",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := formatTable(test.data, test.width)
+			if test.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -52,9 +52,6 @@ const (
 	// ChattrExec is the chattr command executable name
 	ChattrExec = "chattr"
 
-	// Column is a tool to format data into columns for neater display in CLI
-	ColumnExec = "column"
-
 	// SttyExec is a tool to change or print CLI settings
 	SttyExec = "stty"
 


### PR DESCRIPTION
* replace `column` command because it is not always available in the system and for snap it cannot be accessed. 
* try to first get the CLI windows size from stdout fd and if it fails try stty
