### PR TITLE
Improve autoconnect

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -589,9 +589,6 @@ func main() {
 	s.GracefulStop()
 	norduserService.StopAll()
 
-	if err := dnsSetter.Unset(""); err != nil {
-		log.Printf("unsetting dns: %s", err)
-	}
 	if err := notificationClient.Stop(); err != nil {
 		log.Println(internal.ErrorPrefix, "stopping NC:", err)
 	}

--- a/daemon/jobs.go
+++ b/daemon/jobs.go
@@ -181,8 +181,7 @@ func (a *autoconnectServer) Send(data *pb.Payload) error {
 type GetTimeoutFunc func(tries int) time.Duration
 
 func connectErrorCheck(err error) bool {
-	return err == nil ||
-		errors.Is(err, internal.ErrNotLoggedIn)
+	return err == nil
 }
 
 // StartAutoConnect connect to VPN server if autoconnect is enabled
@@ -207,7 +206,7 @@ func (r *RPC) StartAutoConnect(timeoutFn GetTimeoutFunc) error {
 			log.Println(internal.InfoPrefix, "auto-connect success")
 			return nil
 		}
-		log.Println(internal.ErrorPrefix, "err1:", server.err, "| err2:", err)
+		log.Println(internal.ErrorPrefix, "auto-connect failed, err1:", server.err, "| err2:", err)
 		tryAfterDuration := timeoutFn(tries)
 		tries++
 		log.Println(internal.WarningPrefix, "will retry(", tries, ") auto-connect after:", tryAfterDuration)

--- a/daemon/jobs.go
+++ b/daemon/jobs.go
@@ -196,7 +196,7 @@ func (r *RPC) StartAutoConnect(timeoutFn GetTimeoutFunc) error {
 		var cfg config.Config
 		err := r.cm.Load(&cfg)
 		if err != nil {
-			log.Println(internal.ErrorPrefix, "auto-connect failed with error:", err)
+			log.Println(internal.ErrorPrefix, "auto-connect failed:", err)
 			return err
 		}
 


### PR DESCRIPTION
- Improve Autoconnect report/log that it failed because user is not logged in.
- Improve DNS handling on daemon exit - there was attempt to unset DNS without Network interface which does not make sense and produces error in the log. DNS is being set/unset in Networker with known interface.