### PR TITLE
Add suggestions to CLI commands

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -306,6 +306,7 @@ func NewApp(version, environment, hash, salt string,
 
 	app := cli.NewApp()
 	app.EnableBashCompletion = true
+	app.Suggest = true
 	status.Code(err)
 	cmd.loaderInterceptor = loaderInterceptor
 	app.After = func(*cli.Context) error {
@@ -536,11 +537,6 @@ func NewApp(version, environment, hash, salt string,
 	}
 
 	app.Commands = addLoaderToActions(cmd, pingErr, app.Commands)
-	// Unknown command handler
-	app.CommandNotFound = func(c *cli.Context, command string) {
-		color.Red(fmt.Sprintf(NoSuchCommand, command))
-		os.Exit(1)
-	}
 
 	return app, nil
 }


### PR DESCRIPTION
This PR enables CLI suggestions. When users make a typo, CLI will suggest the closer (in terms of word similarity) subcommand / flag. Example below
![image](https://github.com/NordSecurity/nordvpn-linux/assets/50180524/d450d9b4-da1a-49a0-9bd9-56248fcd1189)

