### PR TITLE
Handle virtual servers at VPN connect

### DIFF
--- a/core/models.go
+++ b/core/models.go
@@ -3,10 +3,13 @@ package core
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/netip"
 	"strings"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/nstrings"
 	"golang.org/x/exp/slices"
 )
 
@@ -298,12 +301,38 @@ func IsConnectableWithProtocol(tech config.Technology, proto config.Protocol) Pr
 }
 
 func (s *Server) Version() string {
-	for _, spec := range s.Specifications {
-		if spec.Identifier == "version" {
-			return spec.Identifier
-		}
+	version := s.getSpecificationsForIdentifier("version")
+
+	if len(version) > 0 {
+		return version[0]
 	}
 	return ""
+}
+
+func (s *Server) IsVirtualLocation() bool {
+	virtualLocation := s.getSpecificationsForIdentifier("virtual_location")
+
+	if len(virtualLocation) > 0 {
+		value, err := nstrings.BoolFromString(virtualLocation[0])
+		if err == nil {
+			return value
+		}
+		log.Println(internal.DebugPrefix, "cannot convert server virtual location", s.Hostname, virtualLocation, err)
+	}
+	return false
+}
+
+func (s *Server) getSpecificationsForIdentifier(identifier string) []string {
+	for _, spec := range s.Specifications {
+		if spec.Identifier == identifier {
+			values := []string{}
+			for _, value := range spec.Values {
+				values = append(values, value.Value)
+			}
+			return values
+		}
+	}
+	return nil
 }
 
 func (s *Server) SupportsIPv6() bool {

--- a/core/models_test.go
+++ b/core/models_test.go
@@ -684,7 +684,7 @@ func TestServerVersion(t *testing.T) {
 	var server Server
 	err := json.Unmarshal([]byte(inputTest), &server)
 	assert.NoError(t, err)
-	assert.Equal(t, "version", server.Version())
+	assert.Equal(t, "2.1.0", server.Version())
 }
 
 func TestLocationsCountry(t *testing.T) {

--- a/daemon/job_servers.go
+++ b/daemon/job_servers.go
@@ -18,7 +18,7 @@ import (
 var alphanumeric = regexp.MustCompile(`[^0-9a-zA-Z ]+`)
 
 // JobServers is responsible for population of local server cache which is needed
-// to avoid excees requests to the backend API.
+// to avoid excess requests to the backend API.
 func JobServers(dm *DataManager, cm config.Manager, api core.ServersAPI, validate bool) func() error {
 	return func() error {
 		var cfg config.Config

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -20,4 +20,6 @@ var (
 	// ErrNotLoggedIn is returned when the caller is expected to be logged in
 	// but is not
 	ErrNotLoggedIn = errors.New("you are not logged in")
+	// Error returned when user specifies a server that is virtual, but virtual location is off
+	ErrVirtualServer = errors.New("TODO: A virtual server is specified, but virtual location is off")
 )


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* Detect server type from `Specifications` tag. Virtual servers have `virtual_location=true`.
* At connect if virtual servers are not allowed return an error to enable the option if only virtual servers are found.