### PR TITLE
Reset allowlist at network changes

### DIFF
--- a/networker/vpn.go
+++ b/networker/vpn.go
@@ -56,6 +56,13 @@ func (netw *Combined) handleNetworkChanged() error {
 		if err := netw.fixForLinuxMint20(); err != nil {
 			return err
 		}
+
+		// at network changes, even if the same interfaces still exist in the system,
+		// the routes might not be configured anymore, because the OS will delete them when interfaces are gone.
+		// Reset the allow list to be sure that allowed routes still work.
+		if err := netw.resetAllowlist(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

Reset the allowlist at network changes because the OS deletes them when the interface is removed from the system.