### PR TITLE
Change string functions used for servers keys

### DIFF
--- a/daemon/helper_test.go
+++ b/daemon/helper_test.go
@@ -377,27 +377,7 @@ func serversList() core.Servers {
 	}
 
 	for i, server := range servers {
-		loweredHostnameID := strings.ToLower(strings.Split(server.Hostname, ".")[0])
-		loweredCountryName := strings.ToLower(strings.Join(strings.Split(server.Locations[0].Country.Name, " "), "_"))
-		loweredCountryCode := strings.ToLower(strings.Join(strings.Split(server.Locations[0].Country.Code, " "), "_"))
-		loweredCityName := strings.ToLower(strings.Join(strings.Split(server.Locations[0].Country.City.Name, " "), "_"))
-		loweredGroupTitles := make([]string, len(server.Groups))
-		for idx, group := range server.Groups {
-			loweredGroupTitles[idx] = strings.ToLower(strings.Join(strings.Split(group.Title, " "), "_"))
-		}
-
-		if loweredCountryCode == "gb" {
-			loweredCountryCode = "uk"
-		}
-
-		servers[i].Keys = append([]string{
-			loweredCountryName,
-			loweredCountryCode,
-			loweredCountryName + loweredCityName,
-			loweredCountryCode + loweredCityName,
-			loweredCityName,
-			loweredHostnameID,
-		}, loweredGroupTitles...)
+		servers[i].Keys = generateKeys(server)
 	}
 
 	return servers

--- a/daemon/job_servers.go
+++ b/daemon/job_servers.go
@@ -68,12 +68,13 @@ func JobServers(dm *DataManager, cm config.Manager, api core.ServersAPI, validat
 		for idx, server := range servers {
 			// store keys to find server easier
 			loweredHostnameID := strings.ToLower(strings.Split(server.Hostname, ".")[0])
-			loweredCountryName := strings.ToLower(strings.Join(strings.Split(server.Locations[0].Country.Name, " "), "_"))
-			loweredCountryCode := strings.ToLower(strings.Join(strings.Split(server.Locations[0].Country.Code, " "), "_"))
-			loweredCityName := strings.ToLower(strings.Join(strings.Split(server.Locations[0].Country.City.Name, " "), "_"))
+			country := server.Country()
+			loweredCountryName := internal.SnakeCase(country.Name)
+			loweredCountryCode := internal.SnakeCase(country.Code)
+			loweredCityName := internal.SnakeCase(country.City.Name)
 			loweredGroupTitles := make([]string, len(server.Groups))
 			for idx, group := range server.Groups {
-				loweredGroupTitles[idx] = strings.ToLower(strings.Join(strings.Split(group.Title, " "), "_"))
+				loweredGroupTitles[idx] = internal.SnakeCase(group.Title)
 			}
 
 			if loweredCountryCode == "gb" {
@@ -98,8 +99,8 @@ func JobServers(dm *DataManager, cm config.Manager, api core.ServersAPI, validat
 			dist := distance(
 				geoInfoData.Insights.Latitude,
 				geoInfoData.Insights.Longitude,
-				server.Locations[0].Country.City.Latitude,
-				server.Locations[0].Country.City.Longitude,
+				country.City.Latitude,
+				country.City.Longitude,
 			)
 			servers[idx].Timestamp = timestamp
 			servers[idx].Distance = dist

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -78,8 +78,7 @@ func (r *RPC) Connect(in *pb.ConnectRequest, srv pb.Daemon_ConnectServer) (retEr
 		}
 	}()
 
-	inputServerTag := internal.SnakeCase(in.GetServerTag())
-	inputServerGroup := internal.SnakeCase(in.GetServerGroup())
+	inputServerTag := internal.RemoveNonAlphanumeric(in.GetServerTag())
 
 	log.Println(internal.DebugPrefix, "picking servers for", cfg.Technology, "technology", "input",
 		in.GetServerTag(), in.GetServerGroup())
@@ -93,7 +92,7 @@ func (r *RPC) Connect(in *pb.ConnectRequest, srv pb.Daemon_ConnectServer) (retEr
 		cfg.AutoConnectData.Protocol,
 		cfg.AutoConnectData.Obfuscate,
 		inputServerTag,
-		inputServerGroup,
+		in.GetServerGroup(),
 		cfg.VirtualLocation.Get(),
 	)
 

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -78,7 +78,11 @@ func (r *RPC) Connect(in *pb.ConnectRequest, srv pb.Daemon_ConnectServer) (retEr
 		}
 	}()
 
-	log.Println(internal.DebugPrefix, "picking servers for", cfg.Technology, "technology")
+	inputServerTag := internal.SnakeCase(in.GetServerTag())
+	inputServerGroup := internal.SnakeCase(in.GetServerGroup())
+
+	log.Println(internal.DebugPrefix, "picking servers for", cfg.Technology, "technology", "input",
+		in.GetServerTag(), in.GetServerGroup())
 	server, remote, err := PickServer(
 		r.serversAPI,
 		r.dm.GetCountryData().Countries,
@@ -88,8 +92,8 @@ func (r *RPC) Connect(in *pb.ConnectRequest, srv pb.Daemon_ConnectServer) (retEr
 		cfg.Technology,
 		cfg.AutoConnectData.Protocol,
 		cfg.AutoConnectData.Obfuscate,
-		in.GetServerTag(),
-		in.GetServerGroup(),
+		inputServerTag,
+		inputServerGroup,
 		cfg.VirtualLocation.Get(),
 	)
 

--- a/daemon/servers.go
+++ b/daemon/servers.go
@@ -300,13 +300,17 @@ func serverTagFromString(
 		}
 	}
 	for _, country := range countries {
-		if strings.EqualFold(serverTag, internal.SnakeCase(country.Name)) || strings.EqualFold(serverTag, country.Code) {
+		countryName := internal.SnakeCase(country.Name)
+		countryCode := internal.SnakeCase(country.Code)
+
+		if strings.EqualFold(serverTag, countryName) || strings.EqualFold(serverTag, countryCode) {
 			return core.ServerTag{Action: core.ServerByCountry, ID: country.ID}, nil
 		}
 		for _, city := range country.Cities {
-			if strings.EqualFold(serverTag, internal.SnakeCase(city.Name)) ||
-				strings.EqualFold(serverTag, internal.SnakeCase(country.Name)+" "+internal.SnakeCase(city.Name)) ||
-				strings.EqualFold(serverTag, internal.SnakeCase(country.Code)+" "+internal.SnakeCase(city.Name)) {
+			cityName := internal.SnakeCase(city.Name)
+			if strings.EqualFold(serverTag, cityName) ||
+				strings.EqualFold(serverTag, countryName+" "+cityName) ||
+				strings.EqualFold(serverTag, countryCode+" "+cityName) {
 				return core.ServerTag{Action: core.ServerByCity, ID: city.ID}, nil
 			}
 		}

--- a/internal/string.go
+++ b/internal/string.go
@@ -20,14 +20,14 @@ func StringsToInterfaces(strings []string) []interface{} {
 }
 
 func Title(name string) string {
-	name = notAlphanumeric.ReplaceAllString(name, "")
+	name = RemoveNonAlphanumeric(name)
 	name = strings.Join(strings.Fields(name), " ")
 	titled := cases.Title(language.English, cases.NoLower).String(name)
 	return strings.ReplaceAll(titled, " ", "_")
 }
 
 func SnakeCase(name string) string {
-	name = notAlphanumeric.ReplaceAllString(name, "")
+	name = RemoveNonAlphanumeric(name)
 	splits := strings.Split(name, " ")
 	lower := ""
 	for _, v := range splits {
@@ -37,6 +37,10 @@ func SnakeCase(name string) string {
 		lower += strings.ToLower(v) + "_"
 	}
 	return strings.TrimRight(lower, "_")
+}
+
+func RemoveNonAlphanumeric(name string) string {
+	return notAlphanumeric.ReplaceAllString(name, "")
 }
 
 func StringsContains(haystack []string, needle string) bool {

--- a/internal/string.go
+++ b/internal/string.go
@@ -27,6 +27,7 @@ func Title(name string) string {
 }
 
 func SnakeCase(name string) string {
+	name = notAlphanumeric.ReplaceAllString(name, "")
 	splits := strings.Split(name, " ")
 	lower := ""
 	for _, v := range splits {

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -20,11 +20,6 @@ class Settings:
         key = key.lower()
         return self.settings.get(key, "")
 
-    # convenient to get a value from settings only once
-    @staticmethod
-    def get_value(key: str) -> str:
-        return Settings().get(key)
-
 
 def get_server_ip() -> str:
     """Returns str with IP Address of the server from `nordvpn status`, that NordVPN client is currently connected to."""
@@ -42,63 +37,63 @@ def get_current_connection_protocol():
 
 def is_obfuscated_enabled():
     """Returns True, if Obfuscate is enabled in application settings."""
-    return Settings.get_value("Obfuscate") == "enabled"
+    return Settings().get("Obfuscate") == "enabled"
 
 
 def is_meshnet_enabled():
     """Return True when Meshnet is enabled."""
-    return Settings.get_value("Meshnet") == "enabled"
+    return Settings().get("Meshnet") == "enabled"
 
 
 def dns_visible_in_settings(dns: list) -> bool:
     """Return True, if DNS that were passed as parameter are visible in app settings."""
-    current_dns_settings = Settings.get_value("DNS")
+    current_dns_settings = Settings().get("DNS")
     return all(entry in current_dns_settings for entry in dns)
 
 
 def is_tpl_enabled():
     """Returns True, if Threat Protection Lite is enabled in application settings."""
-    return Settings.get_value("Threat Protection Lite") == "enabled"
+    return Settings().get("Threat Protection Lite") == "enabled"
 
 
 def is_notify_enabled():
     """Returns True, if Threat Protection Lite is enabled in application settings."""
-    return Settings.get_value("Notify") == "enabled"
+    return Settings().get("Notify") == "enabled"
 
 
 def is_routing_enabled():
     """Returns True, if Routing is enabled in application settings."""
-    return Settings.get_value("Routing") == "enabled"
+    return Settings().get("Routing") == "enabled"
 
 
 def is_autoconnect_enabled():
     """Returns True, if Auto-connect is enabled in application settings."""
-    return Settings.get_value("Auto-connect") == "enabled"
+    return Settings().get("Auto-connect") == "enabled"
 
 
 def is_lan_discovery_enabled():
     """Returns True, if LAN Discovery is enabled in application settings."""
-    return Settings.get_value("LAN Discovery") == "enabled"
+    return Settings().get("LAN Discovery") == "enabled"
 
 
 def is_firewall_enabled():
     """Returns True, if Firewall is enabled in application settings."""
-    return Settings.get_value("Firewall") == "enabled"
+    return Settings().get("Firewall") == "enabled"
 
 
 def is_dns_disabled():
     """Returns True, if DNS is disabled in application settings."""
-    return Settings.get_value("DNS") == "disabled"
+    return Settings().get("DNS") == "disabled"
 
 
 def are_analytics_enabled():
     """Returns True, if Analytics are enabled in application settings."""
-    return Settings.get_value("Analytics") == "enabled"
+    return Settings().get("Analytics") == "enabled"
 
 
 def is_ipv6_enabled():
     """Returns True, if IPv6 is enabled in application settings."""
-    return Settings.get_value("IPv6") == "enabled"
+    return Settings().get("IPv6") == "enabled"
 
 
 def app_has_defaults_settings():

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -1,6 +1,31 @@
 import sh
 
 
+class Settings:
+    def __init__(self):
+        output = sh.nordvpn("settings").strip(" \r-\n")
+
+        self.settings={}
+        previous_key=""
+        for line in output.split("\n"):
+            values = line.split(":")
+            if len(values) == 2:
+                previous_key = values[0].lower().strip()
+                self.settings[previous_key] = values[1].strip()
+            elif len(previous_key) > 0:
+                # for allow list the values are on a different line
+                self.settings[previous_key] += line.strip() + " "
+
+    def get(self, key: str) -> str:
+        key = key.lower()
+        return self.settings.get(key, "")
+
+    # convenient to get a value from settings only once
+    @staticmethod
+    def get_value(key: str) -> str:
+        return Settings().get(key)
+
+
 def get_server_ip() -> str:
     """Returns str with IP Address of the server from `nordvpn status`, that NordVPN client is currently connected to."""
     return sh.nordvpn.status().split('\n')[3].replace('IP: ', '')
@@ -8,79 +33,72 @@ def get_server_ip() -> str:
 
 def get_current_connection_protocol():
     """Returns str current connection protocol from `nordvpn settings`."""
-    current_protocol = sh.nordvpn("settings").split('\n')[1]
-
-    if "UDP" in current_protocol:
-        return "udp"
-    elif "TCP" in current_protocol:
-        return "tcp"
-    else:
+    settings = Settings()
+    if settings.get("Technology") == "NORDLYNX":
         return "nordlynx"
+
+    return settings.get("Protocol").lower()
 
 
 def is_obfuscated_enabled():
     """Returns True, if Obfuscate is enabled in application settings."""
-    return "Obfuscate: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("Obfuscate") == "enabled"
 
 
 def is_meshnet_enabled():
     """Return True when Meshnet is enabled."""
-    try:
-        return "Meshnet: enabled" in sh.nordvpn.settings()
-    except sh.ErrorReturnCode:
-        return False
+    return Settings.get_value("Meshnet") == "enabled"
 
 
 def dns_visible_in_settings(dns: list) -> bool:
     """Return True, if DNS that were passed as parameter are visible in app settings."""
-    current_dns_settings = sh.nordvpn("settings").split('\n')[-3]
-
+    current_dns_settings = Settings.get_value("DNS")
     return all(entry in current_dns_settings for entry in dns)
 
 
 def is_tpl_enabled():
     """Returns True, if Threat Protection Lite is enabled in application settings."""
-    return "Threat Protection Lite: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("Threat Protection Lite") == "enabled"
 
 
 def is_notify_enabled():
     """Returns True, if Threat Protection Lite is enabled in application settings."""
-    return "Notify: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("Notify") == "enabled"
 
 
 def is_routing_enabled():
     """Returns True, if Routing is enabled in application settings."""
-    return "Routing: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("Routing") == "enabled"
 
 
 def is_autoconnect_enabled():
     """Returns True, if Auto-connect is enabled in application settings."""
-    return "Auto-connect: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("Auto-connect") == "enabled"
 
 
 def is_lan_discovery_enabled():
     """Returns True, if LAN Discovery is enabled in application settings."""
-    return "LAN Discovery: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("LAN Discovery") == "enabled"
 
 
 def is_firewall_enabled():
     """Returns True, if Firewall is enabled in application settings."""
-    return "Firewall: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("Firewall") == "enabled"
 
 
 def is_dns_disabled():
     """Returns True, if DNS is disabled in application settings."""
-    return "DNS: disabled" in sh.nordvpn.settings()
+    return Settings.get_value("DNS") == "disabled"
 
 
 def are_analytics_enabled():
     """Returns True, if Analytics are enabled in application settings."""
-    return "Analytics: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("Analytics") == "enabled"
 
 
 def is_ipv6_enabled():
     """Returns True, if IPv6 is enabled in application settings."""
-    return "IPv6: enabled" in sh.nordvpn.settings()
+    return Settings.get_value("IPv6") == "enabled"
 
 
 def app_has_defaults_settings():
@@ -99,5 +117,6 @@ def app_has_defaults_settings():
         "IPv6: disabled" in settings and
         "Meshnet: disabled" in settings and
         "DNS: disabled" in settings and
-        "LAN Discovery: disabled" in settings
+        "LAN Discovery: disabled" in settings and
+        "Virtual Location: enabled" in settings
     )


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* Each server has a list of strings computed to faster pick the server when connecting, aka keys. Change functions used to convert the string for keys to be in sync with what is used for user input.
* Keep `string.SnakeCase` function in sync with `string.Title` to remove non-alphanumeric chars from the input.

For testing:
`Lao People's Democratic Republic` contains a `'` in its name. It is displayed `Lao_Peoples_Democratic_Republic ` and connect must work with the displayed name, but also with `Lao_People\'s_Democratic_Republic` so it is backward compatible.