### PR TITLE
When LAN discovery changes publish the event

### DIFF
--- a/daemon/mocks_test.go
+++ b/daemon/mocks_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/google/uuid"
 )
 
-type mockPublisherSubcriber struct {
+type mockPublisherSubscriber[T any] struct {
 	eventPublished bool
 }
 
-func (mp *mockPublisherSubcriber) Publish(message bool) {
+func (mp *mockPublisherSubscriber[T]) Publish(message T) {
 	mp.eventPublished = true
 }
-func (*mockPublisherSubcriber) Subscribe(handler events.Handler[bool]) {}
+func (*mockPublisherSubscriber[T]) Subscribe(handler events.Handler[T]) {}
 
 type filesystemMock struct {
 	files    map[string][]byte

--- a/daemon/rpc_set_autoconnect_test.go
+++ b/daemon/rpc_set_autoconnect_test.go
@@ -42,7 +42,7 @@ func TestAutoconnectObfuscateInteraction(t *testing.T) {
 
 	mockConfigManager := mockAutoconnectConfigManager{}
 
-	mockPublisherSubscriber := mockPublisherSubcriber{}
+	mockPublisherSubscriber := mockPublisherSubscriber[bool]{}
 	mockEvents := Events{Settings: &SettingsEvents{Autoconnect: &mockPublisherSubscriber}}
 
 	obfuscatedTechnologies := core.Technologies{

--- a/daemon/rpc_set_obfuscate_test.go
+++ b/daemon/rpc_set_obfuscate_test.go
@@ -35,7 +35,7 @@ func (*mockObfuscateConfigManager) Reset() error {
 func TestSetObfuscate(t *testing.T) {
 	mockConfigManager := mockObfuscateConfigManager{c: config.Config{AutoConnect: false}}
 
-	mockPublisherSubscriber := mockPublisherSubcriber{}
+	mockPublisherSubscriber := mockPublisherSubscriber[bool]{}
 	mockEvents := Events{Settings: &SettingsEvents{Obfuscate: &mockPublisherSubscriber}}
 
 	obfuscatedTechnologies := core.Technologies{

--- a/daemon/rpc_set_threat_protection_lite_test.go
+++ b/daemon/rpc_set_threat_protection_lite_test.go
@@ -96,7 +96,7 @@ func TestSetThreatProtectionLite_Success(t *testing.T) {
 
 			networker := networker.Mock{}
 			dnsGetter := mock.DNSGetter{}
-			tplPublisher := &mockPublisherSubcriber{}
+			tplPublisher := &mockPublisherSubscriber[bool]{}
 			publisher := SettingsEvents{ThreatProtectionLite: tplPublisher}
 
 			rpc := RPC{
@@ -198,7 +198,7 @@ func TestSetThreatProtectionLite_Error(t *testing.T) {
 				SetDNSErr: test.setDnsErr,
 			}
 			dnsGetter := mock.DNSGetter{}
-			tplPublisher := &mockPublisherSubcriber{}
+			tplPublisher := &mockPublisherSubscriber[bool]{}
 			publisher := SettingsEvents{ThreatProtectionLite: tplPublisher}
 
 			rpc := RPC{


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* Publish event when LAN discovery changes.
* If LAN discovery is turned on, publish event also that allow lists changed.