### PR TITLE
Updates for autoconnect

### DIFF
--- a/cli/cli_set_autoconnect.go
+++ b/cli/cli_set_autoconnect.go
@@ -121,6 +121,12 @@ func (c *cmd) SetAutoConnectAutoComplete(ctx *cli.Context) {
 			}
 
 			groupName, hasGroupFlag := getFlagValue(flagGroup, ctx)
+
+			if !hasGroupFlag && strings.HasPrefix(args.Get(args.Len()-1), "-") {
+				// if the group flag is not set, but the last argument starts with "-" then give as suggestions --group
+				fmt.Println("--" + flagGroup)
+				return
+			}
 			c.printServersForAutoComplete(args.Get(1), hasGroupFlag, groupName)
 		}
 	}

--- a/cli/cli_set_autoconnect.go
+++ b/cli/cli_set_autoconnect.go
@@ -50,9 +50,16 @@ func (c *cmd) SetAutoConnect(ctx *cli.Context) error {
 	// generate server tag from given args
 	var serverTag string
 	if args.Len() > 1 {
-		serverTag = strings.Join(args.Slice()[1:], "")
-		serverTag = strings.Trim(serverTag, " ")
-		serverTag = strings.ToLower(serverTag)
+		groupName, hasGroupFlag := getFlagValue(flagGroup, ctx)
+		if hasGroupFlag {
+			if groupName == "" {
+				return formatError(argsCountError(ctx))
+			}
+			serverTag = groupName
+		} else {
+			serverTag = strings.Join(args.Slice()[1:], " ")
+			serverTag = strings.ToLower(serverTag)
+		}
 	}
 
 	settings, err := c.getSettings()

--- a/cli/cli_set_autoconnect_test.go
+++ b/cli/cli_set_autoconnect_test.go
@@ -57,6 +57,14 @@ func TestAutoConnectAutoComplete(t *testing.T) {
 			expected:  "",
 		},
 		{
+			name:      "autocomplete works for groups",
+			cities:    []*pb.ServerGroup{{Name: "Paris", VirtualLocation: false}},
+			countries: []*pb.ServerGroup{{Name: "France", VirtualLocation: false}},
+			groups:    []*pb.ServerGroup{{Name: "P2P", VirtualLocation: false}},
+			input:     []string{"1", "--group", "P2"},
+			expected:  "P2P",
+		},
+		{
 			name:      "give bool suggestions for no parameters",
 			cities:    []*pb.ServerGroup{{Name: "Paris", VirtualLocation: false}},
 			countries: []*pb.ServerGroup{{Name: "France", VirtualLocation: false}},

--- a/daemon/helper_test.go
+++ b/daemon/helper_test.go
@@ -294,6 +294,8 @@ func serversList() core.Servers {
 			Hostname:     "fr1.nordvpn.com",
 			Status:       core.Online,
 			Technologies: technologies,
+			CreatedAt:    "2006-01-02 15:04:05",
+			Station:      "127.0.0.1",
 			Locations: core.Locations{
 				core.Location{
 					Country: core.Country{Name: "France",
@@ -310,6 +312,8 @@ func serversList() core.Servers {
 			Hostname:     "de3.nordvpn.com",
 			Status:       core.Online,
 			Technologies: technologies,
+			CreatedAt:    "2006-01-02 15:04:05",
+			Station:      "127.0.0.1",
 			Locations: core.Locations{
 				core.Location{
 					Country: core.Country{Name: "Germany",
@@ -322,8 +326,10 @@ func serversList() core.Servers {
 			Specifications: virtualServer,
 		},
 		core.Server{
-			ID:       3,
-			Hostname: "lt16.nordvpn.com",
+			ID:        3,
+			Hostname:  "lt16.nordvpn.com",
+			CreatedAt: "2006-01-02 15:04:05",
+			Station:   "127.0.0.1",
 			Technologies: core.Technologies{
 				core.Technology{
 					ID:    core.WireguardTech,
@@ -347,6 +353,8 @@ func serversList() core.Servers {
 			Hostname:     "lt15.nordvpn.com",
 			Status:       core.Online,
 			Technologies: technologies,
+			CreatedAt:    "2006-01-02 15:04:05",
+			Station:      "127.0.0.1",
 			Locations: core.Locations{
 				core.Location{
 					Country: core.Country{Name: "Lithuania",
@@ -363,6 +371,8 @@ func serversList() core.Servers {
 			Hostname:     "lt17.nordvpn.com",
 			Status:       core.Online,
 			Technologies: obfuscatedTechnologies,
+			CreatedAt:    "2006-01-02 15:04:05",
+			Station:      "127.0.0.1",
 			Locations: core.Locations{
 				core.Location{
 					Country: core.Country{Name: "Lithuania",
@@ -379,6 +389,8 @@ func serversList() core.Servers {
 			Hostname:     "ca944.nordvpn.com",
 			Status:       core.Offline,
 			Technologies: obfuscatedTechnologies,
+			CreatedAt:    "2006-01-02 15:04:05",
+			Station:      "127.0.0.1",
 			Locations: core.Locations{
 				core.Location{
 					Country: core.Country{Name: "Canada",

--- a/daemon/helper_test.go
+++ b/daemon/helper_test.go
@@ -248,7 +248,7 @@ func serversList() core.Servers {
 
 	technologies := core.Technologies{
 		core.Technology{
-			ID:    core.OpenVPNUDP,
+			ID:    core.OpenVPNTCP,
 			Pivot: core.Pivot{Status: core.Online},
 		},
 		core.Technology{
@@ -305,7 +305,7 @@ func serversList() core.Servers {
 			Groups: groups,
 		},
 		core.Server{
-			ID:           3,
+			ID:           2,
 			Name:         "Germany #3",
 			Hostname:     "de3.nordvpn.com",
 			Status:       core.Online,
@@ -322,7 +322,7 @@ func serversList() core.Servers {
 			Specifications: virtualServer,
 		},
 		core.Server{
-			ID:       2,
+			ID:       3,
 			Hostname: "lt16.nordvpn.com",
 			Technologies: core.Technologies{
 				core.Technology{
@@ -343,7 +343,7 @@ func serversList() core.Servers {
 			Groups:         groups,
 		},
 		core.Server{
-			ID:           3,
+			ID:           4,
 			Hostname:     "lt15.nordvpn.com",
 			Status:       core.Online,
 			Technologies: technologies,
@@ -359,7 +359,22 @@ func serversList() core.Servers {
 			Groups:         groups,
 		},
 		core.Server{
-			ID:           929912,
+			ID:           5,
+			Hostname:     "lt17.nordvpn.com",
+			Status:       core.Online,
+			Technologies: obfuscatedTechnologies,
+			Locations: core.Locations{
+				core.Location{
+					Country: core.Country{Name: "Lithuania",
+						Code: "LT",
+						City: core.City{Name: "Vilnius"},
+					},
+				},
+			},
+			Groups: groups,
+		},
+		core.Server{
+			ID:           6,
 			Name:         "Canada #944",
 			Hostname:     "ca944.nordvpn.com",
 			Status:       core.Offline,


### PR DESCRIPTION
* Fix parsing `--group` parameter. `urfave` package doesn't parse flags after the first parameter. In this case for autoconnect would not work because it is specified after `1`, e.g. `nordvpn set autoconnect 1 --group Double_VPN`
* Check the parameter from autoconnect and verify if a server with the specified name can be found. When it doesn't exist and error message is returned.
* Fix unit-tests