### PR TITLE
Remove ! from message checking

### DIFF
--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -293,7 +293,7 @@ def is_connect_successful(output: str, name: str = "", hostname: str = ""):
     else:
             return (
         f"Connecting to {name} ({hostname})" in output
-        and f"You are connected to {name} ({hostname})!" in output
+        and f"You are connected to {name} ({hostname})" in output
         )
 
 

--- a/test/qa/lib/notify.py
+++ b/test/qa/lib/notify.py
@@ -65,7 +65,7 @@ def connect_and_capture_notifications(tech, proto, obfuscated) -> NotificationCa
 
     # Choose server for test, so we know the full expected message
     server_info = server.get_hostname_by(tech, proto, obfuscated)
-    expected_msg = f"You are connected to {server_info.name} ({server_info.hostname})!"
+    expected_msg = f"You are connected to {server_info.name} ({server_info.hostname})"
 
     # We try to capture notifications using other thread when connecting to NordVPN server
     t_connect = NotificationCaptureThread(expected_msg)


### PR DESCRIPTION
When the application connects to a virtual server it will contain `Virtual` in its connected message, before exclamation point. 
For the moment remove the exclamation point from the message and improve checking when writing tests for virtual servers(there is a separate ticket).