### PR TITLE
Get dedicated IP servers from services data

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -132,10 +132,8 @@ func (r *RenewingChecker) GetDedicatedIPServices() ([]DedicatedIPService, error)
 	for _, service := range services {
 		if service.Service.ID == DedicatedIPServiceID && !r.expChecker.isExpired(service.ExpiresAt) {
 			noDIPServices = false
-			serversLen := len(service.Details.Servers)
-			if serversLen != 1 {
-				log.Println(internal.ErrorPrefix,
-					"unexpected number of dedicated ip servers in service, expected 1, is", serversLen)
+			if len(service.Details.Servers) < 1 {
+				log.Println(internal.ErrorPrefix, "no servers for the service found in the api response")
 				continue
 			}
 			noDIPServers = false

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -16,7 +16,7 @@ import (
 
 type DedicatedIPService struct {
 	ExpiresAt string
-	// ServerID will be set to -1 if server was not selected by the user
+	// ServerID will be set to NoServerSelected if server was not selected by the user
 	ServerID int64
 }
 
@@ -27,13 +27,14 @@ type Checker interface {
 	// IsVPNExpired is used to check whether the user is allowed to use VPN
 	IsVPNExpired() (bool, error)
 	// GetDedicatedIPServices returns all available server IDs, if server is not selected by the user it will set
-	// ServerID for that service to -1
+	// ServerID for that service to NoServerSelected
 	GetDedicatedIPServices() ([]DedicatedIPService, error)
 }
 
 const (
 	VPNServiceID         = 1
 	DedicatedIPServiceID = 11
+	NoServerSelected     = -1
 )
 
 type expirationChecker interface {
@@ -124,7 +125,7 @@ func (r *RenewingChecker) GetDedicatedIPServices() ([]DedicatedIPService, error)
 	dipServices := []DedicatedIPService{}
 	for _, service := range services {
 		if service.Service.ID == DedicatedIPServiceID && !r.expChecker.isExpired(service.ExpiresAt) {
-			var serverID int64 = -1
+			var serverID int64 = NoServerSelected
 			if len(service.Details.Servers) != 0 {
 				serverID = service.Details.Servers[0].ID
 			}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -180,7 +180,7 @@ func TestGetDedicatedIPServices(t *testing.T) {
 		},
 		Details: core.ServiceDetails{
 			Servers: []core.ServiceServer{
-				core.ServiceServer{ID: dipSercice2ServerID},
+				{ID: dipSercice2ServerID},
 			},
 		},
 	}
@@ -193,7 +193,7 @@ func TestGetDedicatedIPServices(t *testing.T) {
 		},
 		Details: core.ServiceDetails{
 			Servers: []core.ServiceServer{
-				core.ServiceServer{ID: 33333},
+				{ID: 33333},
 			},
 		},
 	}
@@ -260,7 +260,7 @@ func TestGetDedicatedIPServices(t *testing.T) {
 			},
 		},
 		{
-			name: "mutliple service types",
+			name: "multiple service types",
 			servicesResponse: []core.ServiceData{
 				vpnService,
 				unknownService,

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -304,7 +304,7 @@ func TestGetDedicatedIPServices(t *testing.T) {
 				dipServiceNoServer,
 			},
 			expectedDIPSerivces: []DedicatedIPService{
-				{ExpiresAt: dipServiceNoServerExpirationDate, ServerID: -1},
+				{ExpiresAt: dipServiceNoServerExpirationDate, ServerID: NoServerSelected},
 			},
 		},
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -198,8 +198,9 @@ func TestGetDedicatedIPServices(t *testing.T) {
 		},
 	}
 
+	dipServiceNoServerExpirationDate := "2050-08-22 00:00:00"
 	dipServiceNoServer := core.ServiceData{
-		ExpiresAt: "2050-08-22 00:00:00",
+		ExpiresAt: dipServiceNoServerExpirationDate,
 		Service: core.Service{
 			ID: DedicatedIPServiceID,
 		},
@@ -302,8 +303,9 @@ func TestGetDedicatedIPServices(t *testing.T) {
 			servicesResponse: []core.ServiceData{
 				dipServiceNoServer,
 			},
-			expectedDIPSerivces: []DedicatedIPService{},
-			shouldBeErr:         true,
+			expectedDIPSerivces: []DedicatedIPService{
+				{ExpiresAt: dipServiceNoServerExpirationDate, ServerID: -1},
+			},
 		},
 	}
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -198,6 +198,13 @@ func TestGetDedicatedIPServices(t *testing.T) {
 		},
 	}
 
+	dipServiceNoServer := core.ServiceData{
+		ExpiresAt: "2050-08-22 00:00:00",
+		Service: core.Service{
+			ID: DedicatedIPServiceID,
+		},
+	}
+
 	vpnService := core.ServiceData{
 		ExpiresAt: "2050-08-22 00:00:00",
 		Service: core.Service{
@@ -287,6 +294,14 @@ func TestGetDedicatedIPServices(t *testing.T) {
 		{
 			name:                "config error",
 			configLoadErr:       fmt.Errorf("config load error"),
+			expectedDIPSerivces: []DedicatedIPService{},
+			shouldBeErr:         true,
+		},
+		{
+			name: "no server associated with DIP service",
+			servicesResponse: []core.ServiceData{
+				dipServiceNoServer,
+			},
 			expectedDIPSerivces: []DedicatedIPService{},
 			shouldBeErr:         true,
 		},

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -92,12 +92,12 @@ func TestIsVPNExpired(t *testing.T) {
 		{
 			name: "update successful",
 			cm:   &authConfigManager{serviceExpiry: "1990-01-01 09:18:53"},
-			api:  &authAPI{resp: []core.ServiceData{{Service: core.Service{ID: 1}, ExpiresAt: "2990-01-01 09:18:53"}}},
+			api:  &authAPI{resp: []config.ServiceData{{Service: config.Service{ID: 1}, ExpiresAt: "2990-01-01 09:18:53"}}},
 		},
 		{
 			name:      "expired",
 			cm:        &authConfigManager{serviceExpiry: "1990-01-01 09:18:53"},
-			api:       &authAPI{resp: []core.ServiceData{{Service: core.Service{ID: 1}, ExpiresAt: "1990-01-01 09:18:53"}}},
+			api:       &authAPI{resp: []config.ServiceData{{Service: config.Service{ID: 1}, ExpiresAt: "1990-01-01 09:18:53"}}},
 			isExpired: true,
 		},
 		{

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"errors"
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -37,7 +39,8 @@ func TestIsTokenExpired(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := isTokenExpired(tt.input)
+		expirationChecker := systemTimeExpirationChecker{}
+		got := expirationChecker.isExpired(tt.input)
 		assert.Equal(t, tt.expected, got)
 	}
 }
@@ -73,6 +76,23 @@ func (api *authAPI) Services(string) (core.ServicesResponse, error) {
 	return api.resp, api.err
 }
 
+type mockExpirationChecker struct {
+	expiredDates []string
+}
+
+func newMockExpirationChecker(expiredDates ...string) mockExpirationChecker {
+	return mockExpirationChecker{
+		expiredDates: expiredDates,
+	}
+}
+
+func (m mockExpirationChecker) isExpired(expiryTime string) bool {
+	if idx := slices.Index(m.expiredDates, expiryTime); idx != -1 {
+		return true
+	}
+	return false
+}
+
 func TestIsVPNExpired(t *testing.T) {
 	category.Set(t, category.Unit)
 
@@ -92,12 +112,12 @@ func TestIsVPNExpired(t *testing.T) {
 		{
 			name: "update successful",
 			cm:   &authConfigManager{serviceExpiry: "1990-01-01 09:18:53"},
-			api:  &authAPI{resp: []config.ServiceData{{Service: config.Service{ID: 1}, ExpiresAt: "2990-01-01 09:18:53"}}},
+			api:  &authAPI{resp: []core.ServiceData{{Service: core.Service{ID: 1}, ExpiresAt: "2990-01-01 09:18:53"}}},
 		},
 		{
 			name:      "expired",
 			cm:        &authConfigManager{serviceExpiry: "1990-01-01 09:18:53"},
-			api:       &authAPI{resp: []config.ServiceData{{Service: config.Service{ID: 1}, ExpiresAt: "1990-01-01 09:18:53"}}},
+			api:       &authAPI{resp: []core.ServiceData{{Service: core.Service{ID: 1}, ExpiresAt: "1990-01-01 09:18:53"}}},
 			isExpired: true,
 		},
 		{
@@ -130,6 +150,172 @@ func TestIsVPNExpired(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, test.isExpired, expired)
 			}
+		})
+	}
+}
+
+func TestGetDedicatedIPServices(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	dipService1ExpDate := "2050-06-04 00:00:00"
+	var dipSercice1ServerID int64 = 11111
+	dipService1 := core.ServiceData{
+		ExpiresAt: dipService1ExpDate,
+		Service: core.Service{
+			ID: DedicatedIPServiceID,
+		},
+		Details: core.ServiceDetails{
+			Servers: []core.ServiceServer{
+				{ID: dipSercice1ServerID},
+			},
+		},
+	}
+
+	dipService2ExpDate := "2050-08-22 00:00:00"
+	var dipSercice2ServerID int64 = 11111
+	dipService2 := core.ServiceData{
+		ExpiresAt: dipService2ExpDate,
+		Service: core.Service{
+			ID: DedicatedIPServiceID,
+		},
+		Details: core.ServiceDetails{
+			Servers: []core.ServiceServer{
+				core.ServiceServer{ID: dipSercice2ServerID},
+			},
+		},
+	}
+
+	expiredDate := "2023-08-22 00:00:00"
+	expiredDIPService := core.ServiceData{
+		ExpiresAt: expiredDate,
+		Service: core.Service{
+			ID: DedicatedIPServiceID,
+		},
+		Details: core.ServiceDetails{
+			Servers: []core.ServiceServer{
+				core.ServiceServer{ID: 33333},
+			},
+		},
+	}
+
+	vpnService := core.ServiceData{
+		ExpiresAt: "2050-08-22 00:00:00",
+		Service: core.Service{
+			ID: VPNServiceID,
+		},
+	}
+
+	unknownService := core.ServiceData{
+		ExpiresAt: "2050-08-22 00:00:00",
+		Service: core.Service{
+			ID: 1111,
+		},
+	}
+
+	expirationChecker := newMockExpirationChecker(expiredDate)
+
+	test := []struct {
+		name                string
+		servicesResponse    []core.ServiceData
+		servicesErr         error
+		configLoadErr       error
+		expectedDIPSerivces []DedicatedIPService
+		shouldBeErr         bool
+	}{
+		{
+			name: "single dip service",
+			servicesResponse: []core.ServiceData{
+				dipService1,
+			},
+			expectedDIPSerivces: []DedicatedIPService{
+				{ExpiresAt: dipService1ExpDate, ServerID: dipSercice1ServerID},
+			},
+		},
+		{
+			name: "multiple dip services",
+			servicesResponse: []core.ServiceData{
+				dipService1,
+				dipService2,
+			},
+			expectedDIPSerivces: []DedicatedIPService{
+				{ExpiresAt: dipService1ExpDate, ServerID: dipSercice1ServerID},
+				{ExpiresAt: dipService2ExpDate, ServerID: dipSercice2ServerID},
+			},
+		},
+		{
+			name: "only expired dip services",
+			servicesResponse: []core.ServiceData{
+				expiredDIPService,
+			},
+			expectedDIPSerivces: []DedicatedIPService{},
+		},
+		{
+			name: "expired and unexpired dip services",
+			servicesResponse: []core.ServiceData{
+				expiredDIPService,
+				dipService1,
+			},
+			expectedDIPSerivces: []DedicatedIPService{
+				{ExpiresAt: dipService1ExpDate, ServerID: dipSercice1ServerID},
+			},
+		},
+		{
+			name: "mutliple service types",
+			servicesResponse: []core.ServiceData{
+				vpnService,
+				unknownService,
+				expiredDIPService,
+				dipService1,
+			},
+			expectedDIPSerivces: []DedicatedIPService{
+				{ExpiresAt: dipService1ExpDate, ServerID: dipSercice1ServerID},
+			},
+		},
+		{
+			name: "no dip services",
+			servicesResponse: []core.ServiceData{
+				unknownService,
+			},
+			expectedDIPSerivces: []DedicatedIPService{},
+		},
+		{
+			name:                "fetch services error",
+			servicesErr:         fmt.Errorf("failed to fetch new services"),
+			expectedDIPSerivces: []DedicatedIPService{},
+			shouldBeErr:         true,
+		},
+		{
+			name:                "config error",
+			configLoadErr:       fmt.Errorf("config load error"),
+			expectedDIPSerivces: []DedicatedIPService{},
+			shouldBeErr:         true,
+		},
+	}
+
+	for _, test := range test {
+		t.Run(test.name, func(t *testing.T) {
+			mockAPI := authAPI{
+				resp: test.servicesResponse,
+				err:  test.servicesErr,
+			}
+
+			configMock := authConfigManager{
+				loadErr: test.configLoadErr,
+			}
+
+			rc := RenewingChecker{
+				cm:         &configMock,
+				creds:      &mockAPI,
+				expChecker: expirationChecker,
+			}
+
+			dipServices, err := rc.GetDedicatedIPServices()
+			if test.shouldBeErr {
+				assert.NotNil(t, err, "GetDedicatedIPServices didn't return an error when errror was expected.")
+				return
+			}
+			assert.Equal(t, test.expectedDIPSerivces, dipServices,
+				"Invalid services returned by GetDedicatedIPServices.")
 		})
 	}
 }

--- a/cli/cli_connect.go
+++ b/cli/cli_connect.go
@@ -122,6 +122,10 @@ func (c *cmd) Connect(ctx *cli.Context) error {
 				link = fmt.Sprintf(client.SubscriptionDedicatedIPURLLogin, tokenData.token, tokenData.owner_id)
 			}
 			rpcErr = fmt.Errorf(NoDedicatedIPMessage, link)
+		case internal.CodeDedicatedIPNoServer:
+			rpcErr = errors.New(NoDedidcatedIPServerMessage)
+		case internal.CodeDedicatedIPServiceButNoServers:
+			rpcErr = errors.New(NoPreferredDedicatedIPLocationSelected)
 		case internal.CodeDisconnected:
 			rpcErr = errors.New(internal.DisconnectSuccess)
 		case internal.CodeTagNonexisting:

--- a/cli/messages.go
+++ b/cli/messages.go
@@ -114,11 +114,13 @@ Example: nordvpn set %s on`
 
 	CitiesNotFoundError = "Servers by city are not available for this country."
 
-	CheckYourInternetConnMessage = "Please check your internet connection and try again."
-	ExpiredAccountMessage        = "Your account has expired. Renew your subscription now to continue enjoying the ultimate privacy and security with NordVPN. %s" // TODO: update once we get new error message.
-	NoDedicatedIPMessage         = "You don’t have a dedicated IP subscription. To get a personal IP address that belongs only to you, continue in the browser: \n%s"
-	NoSuchCommand                = "Command '%s' doesn't exist."
-	MsgListIsEmpty               = "We couldn’t load the list of %s. Please try again later."
+	CheckYourInternetConnMessage           = "Please check your internet connection and try again."
+	ExpiredAccountMessage                  = "Your account has expired. Renew your subscription now to continue enjoying the ultimate privacy and security with NordVPN. %s" // TODO: update once we get new error message.
+	NoDedicatedIPMessage                   = "You don’t have a dedicated IP subscription. To get a personal IP address that belongs only to you, continue in the browser: \n%s"
+	NoDedidcatedIPServerMessage            = "This server isn't currently included in your dedicated IP subscription."
+	NoPreferredDedicatedIPLocationSelected = "It looks like you haven’t selected the preferred location for your dedicated IP. Please head over to Nord Account and set up your dedicated IP."
+	NoSuchCommand                          = "Command '%s' doesn't exist."
+	MsgListIsEmpty                         = "We couldn’t load the list of %s. Please try again later."
 
 	// Meshnet
 	MsgSetMeshnetUsage       = "Enables or disables Meshnet on this device."

--- a/config/config.go
+++ b/config/config.go
@@ -91,3 +91,30 @@ type meshnet struct {
 func (d *NCData) IsUserIDEmpty() bool {
 	return d.UserID == uuid.Nil
 }
+
+// TODO: the bellow structures need to be in core package,
+// but it would create circular dep. for now put them here are refactor project later
+type Services struct {
+	CachedDate   time.Time     `json:"cached_date,omitempty"`
+	ServicesData []ServiceData `json:"services_data,omitempty"`
+}
+
+type ServiceData struct {
+	ID        int64          `json:"ID"`
+	ExpiresAt string         `json:"expires_at"`
+	Service   Service        `json:"service"`
+	Details   ServiceDetails `json:"details,omitempty"`
+}
+
+type Service struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type ServiceDetails struct {
+	Servers []ServiceServer `json:"servers"`
+}
+
+type ServiceServer struct {
+	ID int64 `json:"id"`
+}

--- a/config/config.go
+++ b/config/config.go
@@ -91,30 +91,3 @@ type meshnet struct {
 func (d *NCData) IsUserIDEmpty() bool {
 	return d.UserID == uuid.Nil
 }
-
-// TODO: the bellow structures need to be in core package,
-// but it would create circular dep. for now put them here are refactor project later
-type Services struct {
-	CachedDate   time.Time     `json:"cached_date,omitempty"`
-	ServicesData []ServiceData `json:"services_data,omitempty"`
-}
-
-type ServiceData struct {
-	ID        int64          `json:"ID"`
-	ExpiresAt string         `json:"expires_at"`
-	Service   Service        `json:"service"`
-	Details   ServiceDetails `json:"details,omitempty"`
-}
-
-type Service struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
-}
-
-type ServiceDetails struct {
-	Servers []ServiceServer `json:"servers"`
-}
-
-type ServiceServer struct {
-	ID int64 `json:"id"`
-}

--- a/config/token.go
+++ b/config/token.go
@@ -1,17 +1,15 @@
 package config
 
 type TokenData struct {
-	Token              string   `json:"token,omitempty"`
-	TokenExpiry        string   `json:"token_expiry,omitempty"`
-	RenewToken         string   `json:"renew_token,omitempty"`
-	IsOAuth            bool     `json:"is_oauth,omitempty"`
-	TrustedPassToken   string   `json:"trusted_pass_token,omitempty"`
-	TrustedPassOwnerID string   `json:"trusted_pass_owner_id,omitempty"`
-	ServiceExpiry      string   `json:"service_expiry,omitempty"`
-	DedicatedIPExpiry  string   `json:"dedicated_ip_expiry,omitempty"`
-	NordLynxPrivateKey string   `json:"nordlynx_private_key"`
-	OpenVPNUsername    string   `json:"openvpn_username"`
-	OpenVPNPassword    string   `json:"openvpn_password"`
-	NCData             NCData   `json:"nc_data,omitempty"`
-	Services           Services `json:"services,omitempty"`
+	Token              string `json:"token,omitempty"`
+	TokenExpiry        string `json:"token_expiry,omitempty"`
+	RenewToken         string `json:"renew_token,omitempty"`
+	IsOAuth            bool   `json:"is_oauth,omitempty"`
+	TrustedPassToken   string `json:"trusted_pass_token,omitempty"`
+	TrustedPassOwnerID string `json:"trusted_pass_owner_id,omitempty"`
+	ServiceExpiry      string `json:"service_expiry,omitempty"`
+	NordLynxPrivateKey string `json:"nordlynx_private_key"`
+	OpenVPNUsername    string `json:"openvpn_username"`
+	OpenVPNPassword    string `json:"openvpn_password"`
+	NCData             NCData `json:"nc_data,omitempty"`
 }

--- a/config/token.go
+++ b/config/token.go
@@ -1,16 +1,17 @@
 package config
 
 type TokenData struct {
-	Token              string `json:"token,omitempty"`
-	TokenExpiry        string `json:"token_expiry,omitempty"`
-	RenewToken         string `json:"renew_token,omitempty"`
-	IsOAuth            bool   `json:"is_oauth,omitempty"`
-	TrustedPassToken   string `json:"trusted_pass_token,omitempty"`
-	TrustedPassOwnerID string `json:"trusted_pass_owner_id,omitempty"`
-	ServiceExpiry      string `json:"service_expiry,omitempty"`
-	DedicatedIPExpiry  string `json:"dedicated_ip_expiry,omitempty"`
-	NordLynxPrivateKey string `json:"nordlynx_private_key"`
-	OpenVPNUsername    string `json:"openvpn_username"`
-	OpenVPNPassword    string `json:"openvpn_password"`
-	NCData             NCData `json:"nc_data,omitempty"`
+	Token              string   `json:"token,omitempty"`
+	TokenExpiry        string   `json:"token_expiry,omitempty"`
+	RenewToken         string   `json:"renew_token,omitempty"`
+	IsOAuth            bool     `json:"is_oauth,omitempty"`
+	TrustedPassToken   string   `json:"trusted_pass_token,omitempty"`
+	TrustedPassOwnerID string   `json:"trusted_pass_owner_id,omitempty"`
+	ServiceExpiry      string   `json:"service_expiry,omitempty"`
+	DedicatedIPExpiry  string   `json:"dedicated_ip_expiry,omitempty"`
+	NordLynxPrivateKey string   `json:"nordlynx_private_key"`
+	OpenVPNUsername    string   `json:"openvpn_username"`
+	OpenVPNPassword    string   `json:"openvpn_password"`
+	NCData             NCData   `json:"nc_data,omitempty"`
+	Services           Services `json:"services,omitempty"`
 }

--- a/core/models.go
+++ b/core/models.go
@@ -115,18 +115,7 @@ type CredentialsResponse struct {
 	NordlynxPrivateKey string `json:"nordlynx_private_key"`
 }
 
-type ServicesResponse []ServiceData
-
-type ServiceData struct {
-	ID        int64   `json:"ID"`
-	ExpiresAt string  `json:"expires_at"`
-	Service   Service `json:"service"`
-}
-
-type Service struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
-}
+type ServicesResponse []config.ServiceData
 
 type CurrentUserResponse struct {
 	Username string `json:"username"`

--- a/core/models.go
+++ b/core/models.go
@@ -115,7 +115,27 @@ type CredentialsResponse struct {
 	NordlynxPrivateKey string `json:"nordlynx_private_key"`
 }
 
-type ServicesResponse []config.ServiceData
+type ServiceData struct {
+	ID        int64          `json:"ID"`
+	ExpiresAt string         `json:"expires_at"`
+	Service   Service        `json:"service"`
+	Details   ServiceDetails `json:"details,omitempty"`
+}
+
+type Service struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type ServiceServer struct {
+	ID int64 `json:"id"`
+}
+
+type ServiceDetails struct {
+	Servers []ServiceServer `json:"servers"`
+}
+
+type ServicesResponse []ServiceData
 
 type CurrentUserResponse struct {
 	Username string `json:"username"`

--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/netip"
 	"testing"
@@ -39,6 +40,9 @@ func (failingLoginChecker) IsVPNExpired() (bool, error) {
 }
 func (failingLoginChecker) IsDedicatedIPExpired() (bool, error) {
 	return true, errors.New("IsDedicatedIPExipred error")
+}
+func (failingLoginChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+	return nil, fmt.Errorf("Not implemented")
 }
 
 func TestStartAutoConnect(t *testing.T) {

--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -38,10 +38,7 @@ func (failingLoginChecker) IsLoggedIn() bool { return false }
 func (failingLoginChecker) IsVPNExpired() (bool, error) {
 	return true, errors.New("IsVPNExpired error")
 }
-func (failingLoginChecker) IsDedicatedIPExpired() (bool, error) {
-	return true, errors.New("IsDedicatedIPExipred error")
-}
-func (failingLoginChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+func (failingLoginChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
 

--- a/daemon/rpc_account.go
+++ b/daemon/rpc_account.go
@@ -3,7 +3,9 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/auth"
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -11,6 +13,31 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 )
+
+func findLatestDIPExpirationData(dipServices []auth.DedicatedIPService) (string, error) {
+	if len(dipServices) == 0 {
+		return "", fmt.Errorf("no dip services found")
+	}
+
+	layout := "2006-01-02 15:04:05"
+	latest, err := time.Parse(layout, dipServices[0].ExpiresAt)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse initial expiration date")
+	}
+
+	for _, dipService := range dipServices {
+		current, err := time.Parse(layout, dipService.ExpiresAt)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse expiration date")
+		}
+
+		if current.After(latest) {
+			latest = current
+		}
+	}
+
+	return latest.Format(layout), nil
+}
 
 // AccountInfo returns user account information.
 func (r *RPC) AccountInfo(ctx context.Context, _ *pb.Empty) (*pb.AccountResponse, error) {
@@ -30,14 +57,21 @@ func (r *RPC) AccountInfo(ctx context.Context, _ *pb.Empty) (*pb.AccountResponse
 		accountInfo.Type = internal.CodeSuccess
 	}
 
-	dedicatedIPExpired, err := r.ac.IsDedicatedIPExpired()
+	accountInfo.DedicatedIpStatus = internal.CodeSuccess
+	dipServices, err := r.ac.GetDedicatedIPServices()
 	if err != nil {
-		log.Println(internal.ErrorPrefix, "checking dedicated IP expiration: ", err)
+		log.Println(internal.ErrorPrefix, "getting dedicated ip services: %w", err)
 		return &pb.AccountResponse{Type: internal.CodeTokenRenewError}, nil
-	} else if dedicatedIPExpired {
+	}
+
+	if len(dipServices) == 0 {
 		accountInfo.DedicatedIpStatus = internal.CodeNoService
-	} else {
-		accountInfo.DedicatedIpStatus = internal.CodeSuccess
+	}
+
+	dedicatedIPExpirationDate, err := findLatestDIPExpirationData(dipServices)
+	if err != nil {
+		log.Println(internal.ErrorPrefix, "getting latest dedicated ip expiration date: %w", err)
+		return &pb.AccountResponse{Type: internal.CodeTokenRenewError}, nil
 	}
 
 	var cfg config.Config
@@ -49,7 +83,7 @@ func (r *RPC) AccountInfo(ctx context.Context, _ *pb.Empty) (*pb.AccountResponse
 
 	tokenData := cfg.TokensData[cfg.AutoConnectData.ID]
 	accountInfo.ExpiresAt = tokenData.ServiceExpiry
-	accountInfo.DedicatedIpExpiresAt = tokenData.DedicatedIPExpiry
+	accountInfo.DedicatedIpExpiresAt = dedicatedIPExpirationDate
 
 	currentUser, err := r.credentialsAPI.CurrentUser(tokenData.Token)
 	if err != nil {

--- a/daemon/rpc_account.go
+++ b/daemon/rpc_account.go
@@ -70,7 +70,7 @@ func (r *RPC) AccountInfo(ctx context.Context, _ *pb.Empty) (*pb.AccountResponse
 
 	dedicatedIPExpirationDate, err := findLatestDIPExpirationData(dipServices)
 	if err != nil {
-		log.Println(internal.ErrorPrefix, "getting latest dedicated ip expiration date: %w", err)
+		log.Println(internal.ErrorPrefix, "getting latest dedicated ip expiration date: ", err)
 		return &pb.AccountResponse{Type: internal.CodeTokenRenewError}, nil
 	}
 

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/netip"
 	"testing"
@@ -81,7 +82,7 @@ func (validCredentialsAPI) Services(string) (core.ServicesResponse, error) {
 	return core.ServicesResponse{
 		{
 			ExpiresAt: "2029-12-27 00:00:00",
-			Service:   core.Service{ID: 1},
+			Service:   config.Service{ID: 1},
 		},
 	}, nil
 }
@@ -101,6 +102,9 @@ func (*workingLoginChecker) IsLoggedIn() bool              { return true }
 func (c *workingLoginChecker) IsVPNExpired() (bool, error) { return c.isVPNExpired, c.vpnErr }
 func (c *workingLoginChecker) IsDedicatedIPExpired() (bool, error) {
 	return c.isDedicatedIPExpired, c.dedicatedIPErr
+}
+func (*workingLoginChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+	return nil, fmt.Errorf("Not implemented")
 }
 
 type mockAnalytics struct{}

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -82,7 +82,7 @@ func (validCredentialsAPI) Services(string) (core.ServicesResponse, error) {
 	return core.ServicesResponse{
 		{
 			ExpiresAt: "2029-12-27 00:00:00",
-			Service:   config.Service{ID: 1},
+			Service:   core.Service{ID: 1},
 		},
 	}, nil
 }
@@ -100,10 +100,7 @@ type workingLoginChecker struct {
 
 func (*workingLoginChecker) IsLoggedIn() bool              { return true }
 func (c *workingLoginChecker) IsVPNExpired() (bool, error) { return c.isVPNExpired, c.vpnErr }
-func (c *workingLoginChecker) IsDedicatedIPExpired() (bool, error) {
-	return c.isDedicatedIPExpired, c.dedicatedIPErr
-}
-func (*workingLoginChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+func (*workingLoginChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
 

--- a/daemon/rpc_set_autoconnect.go
+++ b/daemon/rpc_set_autoconnect.go
@@ -51,54 +51,20 @@ func (r *RPC) SetAutoConnect(ctx context.Context, in *pb.SetAutoconnectRequest) 
 		if in.GetServerTag() != "" {
 			insights := r.dm.GetInsightsData().Insights
 
-			server, _, err := PickServer(
-				r.serversAPI,
-				r.dm.GetCountryData().Countries,
-				r.dm.GetServersData().Servers,
-				insights.Longitude,
-				insights.Latitude,
-				cfg.Technology,
-				cfg.AutoConnectData.Protocol,
-				cfg.AutoConnectData.Obfuscate,
-				in.GetServerTag(),
-				"",
-				cfg.VirtualLocation.Get(),
-			)
+			server, _, err := selectServer(r, &insights, cfg, in.GetServerTag(), "")
 			if err != nil {
 				log.Println(internal.ErrorPrefix, "no server found for autoconnect", in.GetServerTag(), err)
-				switch {
-				case errors.Is(err, core.ErrUnauthorized):
-					return nil, internal.ErrNotLoggedIn
 
-				case errors.Is(err, internal.ErrTagDoesNotExist),
-					errors.Is(err, internal.ErrGroupDoesNotExist),
-					errors.Is(err, internal.ErrServerIsUnavailable),
-					errors.Is(err, internal.ErrDoubleGroup),
-					errors.Is(err, internal.ErrVirtualServerSelected):
-					return nil, err
-
-				default:
-					return nil, internal.ErrUnhandled
+				var errorCode *internal.ErrorWithCode
+				if errors.As(err, &errorCode) {
+					return &pb.Payload{
+						Type: errorCode.Code,
+					}, nil
 				}
-			}
 
+				return nil, err
+			}
 			log.Println(internal.InfoPrefix, "server for autoconnect found", server)
-
-			if isDedicatedIP(server) {
-				expired, err := r.ac.IsDedicatedIPExpired()
-				if err != nil {
-					log.Println(internal.ErrorPrefix, "checking dedicated IP expiration: ", err)
-					return &pb.Payload{
-						Type: internal.CodeDedicatedIPRenewError,
-					}, nil
-				}
-
-				if expired {
-					return &pb.Payload{
-						Type: internal.CodeDedicatedIPRenewError,
-					}, nil
-				}
-			}
 		}
 
 		if err := r.cm.SaveWith(func(c config.Config) config.Config {

--- a/daemon/rpc_set_autoconnect_test.go
+++ b/daemon/rpc_set_autoconnect_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -21,6 +22,9 @@ func (mockAutoconnectAuthChecker) IsLoggedIn() bool            { return true }
 func (mockAutoconnectAuthChecker) IsVPNExpired() (bool, error) { return false, nil }
 func (m mockAutoconnectAuthChecker) IsDedicatedIPExpired() (bool, error) {
 	return m.dedicatedIPExpired, nil
+}
+func (mockAutoconnectAuthChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+	return nil, fmt.Errorf("Not implemented")
 }
 
 func TestAutoconnect(t *testing.T) {

--- a/daemon/rpc_set_autoconnect_test.go
+++ b/daemon/rpc_set_autoconnect_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NordSecurity/nordvpn-linux/auth"
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/daemon/events"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
@@ -20,10 +21,7 @@ type mockAutoconnectAuthChecker struct {
 
 func (mockAutoconnectAuthChecker) IsLoggedIn() bool            { return true }
 func (mockAutoconnectAuthChecker) IsVPNExpired() (bool, error) { return false, nil }
-func (m mockAutoconnectAuthChecker) IsDedicatedIPExpired() (bool, error) {
-	return m.dedicatedIPExpired, nil
-}
-func (mockAutoconnectAuthChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+func (mockAutoconnectAuthChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
 

--- a/daemon/rpc_set_autoconnect_test.go
+++ b/daemon/rpc_set_autoconnect_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/auth"
@@ -16,13 +15,12 @@ import (
 )
 
 type mockAutoconnectAuthChecker struct {
-	dedicatedIPExpired bool
 }
 
 func (mockAutoconnectAuthChecker) IsLoggedIn() bool            { return true }
 func (mockAutoconnectAuthChecker) IsVPNExpired() (bool, error) { return false, nil }
 func (mockAutoconnectAuthChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
-	return nil, fmt.Errorf("Not implemented")
+	return []auth.DedicatedIPService{}, nil
 }
 
 func TestAutoconnect(t *testing.T) {
@@ -160,7 +158,7 @@ func TestAutoconnect(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mockAuthChecker := mockAutoconnectAuthChecker{dedicatedIPExpired: test.isDedicatedIPExpired}
+		mockAuthChecker := mockAutoconnectAuthChecker{}
 		mockConfigManager := newMockConfigManager()
 		mockPublisherSubscriber := events.MockPublisherSubscriber[bool]{}
 		mockEvents := events.Events{Settings: &events.SettingsEvents{Autoconnect: &mockPublisherSubscriber}}

--- a/daemon/servers.go
+++ b/daemon/servers.go
@@ -503,6 +503,10 @@ func selectDedicatedIPServer(authChecker auth.Checker, servers core.Servers) (*c
 		return nil, internal.ErrUnhandled
 	}
 
+	if len(dedicatedIPServices) == 0 {
+		return nil, internal.NewErrorWithCode(internal.CodeDedicatedIPRenewError)
+	}
+
 	service := dedicatedIPServices[rand.Intn(len(dedicatedIPServices))]
 	server, err := getServerByID(servers, service.ServerID)
 	if err != nil {

--- a/daemon/servers.go
+++ b/daemon/servers.go
@@ -473,7 +473,7 @@ func selectServer(r *RPC, insights *core.Insights, cfg config.Config, tag string
 			return s.ServerID == server.ID
 		})
 		if index == -1 {
-			log.Println(internal.ErrorPrefix, "server not into the DIP servers list")
+			log.Println(internal.ErrorPrefix, "server is not in the DIP servers list")
 			return nil, false, internal.NewErrorWithCode(internal.CodeDedicatedIPNoServer)
 		}
 	}

--- a/daemon/servers.go
+++ b/daemon/servers.go
@@ -413,7 +413,7 @@ func selectFilter(tag string, group config.ServerGroup, obfuscated bool) core.Pr
 // isAnyDIPServersAvailable returns true if dedicated IP server is selected for any of the provided services
 func isAnyDIPServersAvailable(dedicatedIPServices []auth.DedicatedIPService) bool {
 	index := slices.IndexFunc(dedicatedIPServices, func(dipService auth.DedicatedIPService) bool {
-		return dipService.ServerID != -1
+		return dipService.ServerID != auth.NoServerSelected
 	})
 
 	return index != -1

--- a/internal/codes.go
+++ b/internal/codes.go
@@ -53,6 +53,8 @@ const (
 	CodeTokenInvalid                   int64 = 3039
 	CodePrivateSubnetLANDiscovery      int64 = 3040
 	CodeDedicatedIPRenewError          int64 = 3041
+	CodeDedicatedIPNoServer            int64 = 3042
+	CodeDedicatedIPServiceButNoServers int64 = 3043
 )
 
 type ErrorWithCode struct {

--- a/internal/codes.go
+++ b/internal/codes.go
@@ -1,5 +1,7 @@
 package internal
 
+import "fmt"
+
 const (
 	// Success
 	CodeSuccess          int64 = 1000
@@ -52,3 +54,15 @@ const (
 	CodePrivateSubnetLANDiscovery      int64 = 3040
 	CodeDedicatedIPRenewError          int64 = 3041
 )
+
+type ErrorWithCode struct {
+	Code int64
+}
+
+func NewErrorWithCode(code int64) error {
+	return &ErrorWithCode{Code: code}
+}
+
+func (e *ErrorWithCode) Error() string {
+	return fmt.Sprintf("Error with code %d", e.Code)
+}

--- a/meshnet/server_test.go
+++ b/meshnet/server_test.go
@@ -43,9 +43,8 @@ type meshRenewChecker struct {
 func (m meshRenewChecker) IsLoggedIn() bool {
 	return !m.IsNotLoggedIn
 }
-func (meshRenewChecker) IsVPNExpired() (bool, error)         { return false, nil }
-func (meshRenewChecker) IsDedicatedIPExpired() (bool, error) { return false, nil }
-func (meshRenewChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+func (meshRenewChecker) IsVPNExpired() (bool, error) { return false, nil }
+func (meshRenewChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
 

--- a/meshnet/server_test.go
+++ b/meshnet/server_test.go
@@ -45,6 +45,9 @@ func (m meshRenewChecker) IsLoggedIn() bool {
 }
 func (meshRenewChecker) IsVPNExpired() (bool, error)         { return false, nil }
 func (meshRenewChecker) IsDedicatedIPExpired() (bool, error) { return false, nil }
+func (meshRenewChecker) ServiceData(serviceID int64) (*config.ServiceData, error) {
+	return nil, fmt.Errorf("Not implemented")
+}
 
 type registrationChecker struct {
 	registrationErr error

--- a/protobuf/daemon/account.proto
+++ b/protobuf/daemon/account.proto
@@ -4,6 +4,11 @@ package pb;
 
 option go_package = "github.com/NordSecurity/nordvpn-linux/daemon/pb";
 
+message DedidcatedIPServices {
+  int64 dedicated_ip_status = 5;
+  string dedicated_ip_expires_at = 6;
+}
+
 message AccountResponse {
   int64 type = 1;
   string username = 2;


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

The list of DIP servers available for a user are part of the DIP service data. At connect and autoconnect use this list instead of calling the servers API.
* Cache the services list for a user to prevent to often API calls [NOT]
* Because the servers list changes in time add a validity duration for DIP service
* If user has DIP subscription but no servers call the API