### PR TITLE
Fix allow routing when changing machine nickname

### DIFF
--- a/core/mesh.go
+++ b/core/mesh.go
@@ -152,13 +152,14 @@ func (api *DefaultAPI) Register(token string, peer mesh.Machine) (*mesh.Machine,
 	}
 
 	return &mesh.Machine{
-		ID:        raw.Identifier,
-		Hostname:  raw.Hostname,
-		OS:        peer.OS,
-		PublicKey: peer.PublicKey,
-		Endpoints: raw.Endpoints,
-		Address:   addr,
-		Nickname:  raw.Nickname,
+		ID:              raw.Identifier,
+		Hostname:        raw.Hostname,
+		OS:              peer.OS,
+		PublicKey:       peer.PublicKey,
+		Endpoints:       raw.Endpoints,
+		Address:         addr,
+		Nickname:        raw.Nickname,
+		SupportsRouting: raw.SupportsRouting,
 	}, nil
 }
 
@@ -337,12 +338,13 @@ func (api *DefaultAPI) Map(token string, self uuid.UUID) (*mesh.MachineMap, erro
 
 	return &mesh.MachineMap{
 		Machine: mesh.Machine{
-			ID:        raw.ID,
-			Hostname:  raw.Hostname,
-			PublicKey: raw.PublicKey,
-			Endpoints: raw.Endpoints,
-			Address:   addr,
-			Nickname:  raw.Nickname,
+			ID:              raw.ID,
+			Hostname:        raw.Hostname,
+			PublicKey:       raw.PublicKey,
+			Endpoints:       raw.Endpoints,
+			Address:         addr,
+			Nickname:        raw.Nickname,
+			SupportsRouting: raw.SupportsRouting,
 		},
 		Hosts: raw.DNS.Hosts,
 		Peers: peers,

--- a/core/mesh_test.go
+++ b/core/mesh_test.go
@@ -37,15 +37,19 @@ func TestMeshAPI_Register(t *testing.T) {
 				http.DefaultClient,
 				response.NoopValidator{},
 			)
-			_, err := api.Register("bearer", mesh.Machine{
+			machine, err := api.Register("bearer", mesh.Machine{
 				ID:        uuid.New(),
 				PublicKey: uuid.New().String(),
 				OS: mesh.OperatingSystem{
 					Name:   "linux",
 					Distro: "Arch",
 				},
+				SupportsRouting: true,
 			})
 			assert.ErrorIs(t, err, test.err)
+			if err == nil {
+				assert.True(t, machine.SupportsRouting)
+			}
 		})
 	}
 }

--- a/core/testdata/mesh_register_200.json
+++ b/core/testdata/mesh_register_200.json
@@ -11,5 +11,6 @@
   "os": "android",
   "os_version": "Arch Linux; kernel=5.11.13-arch1-1",
   "public_key": "YyeQW3xNdTHUa3ip8wt0ksiw8HJh3c3u4hsuDVK9mS0=",
-  "relay_address": "disco.nordmesh:12345"
+  "relay_address": "disco.nordmesh:12345",
+  "traffic_routing_supported": true
 }

--- a/meshnet/server.go
+++ b/meshnet/server.go
@@ -1523,7 +1523,7 @@ func (s *Server) ChangeMachineNickname(
 	// TODO: sometimes IsRegistrationInfoCorrect() re-registers the device => cfg.MeshDevice.ID can be different.
 	info := mesh.MachineUpdateRequest{
 		Nickname:        req.Nickname,
-		SupportsRouting: cfg.MeshDevice.SupportsRouting,
+		SupportsRouting: true,
 		Endpoints:       cfg.MeshDevice.Endpoints,
 	}
 

--- a/meshnet/server_test.go
+++ b/meshnet/server_test.go
@@ -1679,19 +1679,19 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:             "set nickname successfully",
 			isMeshOn:         true,
 			newNickname:      machineNickname,
-			machine:          mesh.Machine{},
+			machine:          mesh.Machine{SupportsRouting: true},
 			expectedResponse: changedSuccessfully,
 		},
 		{
 			name:             "clear nickname",
 			isMeshOn:         true,
-			machine:          mesh.Machine{Nickname: strings.ToUpper(machineNickname)},
+			machine:          mesh.Machine{SupportsRouting: true, Nickname: strings.ToUpper(machineNickname)},
 			expectedResponse: changedSuccessfully,
 		},
 		{
 			name:     "clear nickname, when is already empty",
 			isMeshOn: true,
-			machine:  mesh.Machine{},
+			machine:  mesh.Machine{SupportsRouting: true},
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
 					ChangeNicknameErrorCode: pb.ChangeNicknameErrorCode_NICKNAME_ALREADY_EMPTY,
@@ -1745,7 +1745,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "set same nickname",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{Nickname: machineNickname},
+			machine:     mesh.Machine{SupportsRouting: true, Nickname: machineNickname},
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
 					ChangeNicknameErrorCode: pb.ChangeNicknameErrorCode_SAME_NICKNAME,
@@ -1756,14 +1756,14 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:             "set same nickname, but different caps",
 			isMeshOn:         true,
 			newNickname:      strings.ToUpper(machineNickname),
-			machine:          mesh.Machine{Nickname: machineNickname},
+			machine:          mesh.Machine{SupportsRouting: true, Nickname: machineNickname},
 			expectedResponse: changedSuccessfully,
 		},
 		{
 			name:        "update API fails with ErrUnauthorized",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrUnauthorized,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ServiceErrorCode{
@@ -1775,7 +1775,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "update API fails",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   fmt.Errorf("error"),
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ServiceErrorCode{
@@ -1787,7 +1787,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:          "config save fails",
 			isMeshOn:      true,
 			newNickname:   machineNickname,
-			machine:       mesh.Machine{},
+			machine:       mesh.Machine{SupportsRouting: true},
 			saveConfigErr: fmt.Errorf("error"),
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ServiceErrorCode{
@@ -1799,7 +1799,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:             "fails to register because of DNS conflict",
 			isMeshOn:         true,
 			newNickname:      "peer1",
-			machine:          mesh.Machine{},
+			machine:          mesh.Machine{SupportsRouting: true},
 			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.IPv4bcast}},
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1811,7 +1811,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "generic API error",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   fmt.Errorf("error"),
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ServiceErrorCode{
@@ -1823,7 +1823,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "API returns error rate limit reach",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrRateLimitReach,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1835,7 +1835,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "API returns error nickname too long",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrNicknameTooLong,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1847,7 +1847,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "API returns error duplicate nickname",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrDuplicateNickname,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1859,7 +1859,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "API returns forbidden word",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrContainsForbiddenWord,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1871,7 +1871,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "API returns invalid suffix or prefix",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrInvalidPrefixOrSuffix,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1883,7 +1883,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "API error double hyphens",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrNicknameWithDoubleHyphens,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1895,7 +1895,7 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			name:        "API error nickname contains invalid chars",
 			isMeshOn:    true,
 			newNickname: machineNickname,
-			machine:     mesh.Machine{},
+			machine:     mesh.Machine{SupportsRouting: true},
 			updateErr:   core.ErrContainsInvalidChars,
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
@@ -1960,6 +1960,8 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 				}
 			} else {
 				assert.Equal(t, test.newNickname, registryApi.CurrentMachine.Nickname)
+				assert.True(t, configManager.Cfg.MeshDevice.SupportsRouting)
+				assert.True(t, registryApi.CurrentMachine.SupportsRouting)
 			}
 		})
 	}


### PR DESCRIPTION
* Set `Machine.SupportsRouting` otherwise it is false by default and when used can disable the allow routing for current machine
* Always set allow routing to `true` at nickname change, in case config doesn't have the correct value
* Update tests to check if `SupportsRouting` is set to the correct value