### PR TITLE
Improve allowlist routing

### DIFF
--- a/daemon/routes/norule/norule.go
+++ b/daemon/routes/norule/norule.go
@@ -3,6 +3,6 @@ package norule
 
 type Facade struct{}
 
-func (*Facade) SetupRoutingRules(bool, bool, bool) error { return nil }
-func (*Facade) CleanupRouting() error                    { return nil }
-func (*Facade) TableID() uint                            { return 0 }
+func (*Facade) SetupRoutingRules(bool, bool, bool, []string) error { return nil }
+func (*Facade) CleanupRouting() error                              { return nil }
+func (*Facade) TableID() uint                                      { return 0 }

--- a/internal/string.go
+++ b/internal/string.go
@@ -74,5 +74,5 @@ func IntsToStrings(numbers []int) []string {
 }
 
 func CopyStringSlice(src []string) []string {
-	return append(make([]string, 0), src...)
+	return append(make([]string, 0, len(src)), src...)
 }

--- a/internal/string.go
+++ b/internal/string.go
@@ -72,3 +72,7 @@ func IntsToStrings(numbers []int) []string {
 	}
 	return strs
 }
+
+func CopyStringSlice(src []string) []string {
+	return append(make([]string, 0), src...)
+}

--- a/internal/string_test.go
+++ b/internal/string_test.go
@@ -111,3 +111,34 @@ func TestIntsToStrings(t *testing.T) {
 	assert.Nil(t, IntsToStrings([]int{}))
 	assert.Nil(t, IntsToStrings(nil))
 }
+
+func TestCopyStringSlice(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	s1 := []string{"32", "56565656", "0", "1", "-1"}
+	assert.Equal(t, s1, CopyStringSlice(s1))
+
+	tests := []struct {
+		input []string
+	}{
+		{
+			input: []string{},
+		},
+		{
+			input: []string{"", ""},
+		},
+		{
+			input: []string{"32", "56565656", "0", "1", "-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		copy1 := CopyStringSlice(tt.input)
+		assert.Equal(t, tt.input, copy1)
+		if len(copy1) > 0 {
+			// modify copy, source should stay unmodified
+			copy1[0] = "a!a#a$"
+			assert.NotEqual(t, tt.input, copy1)
+		}
+	}
+}

--- a/networker/networker_test.go
+++ b/networker/networker_test.go
@@ -165,7 +165,7 @@ type workingRoutingSetup struct {
 	EnableLocalTraffic bool
 }
 
-func (r *workingRoutingSetup) SetupRoutingRules(_ bool, enableLan bool, _ bool) error {
+func (r *workingRoutingSetup) SetupRoutingRules(_ bool, enableLan bool, _ bool, _ []string) error {
 	r.EnableLocalTraffic = enableLan
 	return nil
 }
@@ -246,7 +246,6 @@ func (h *workingHostSetter) UnsetHosts() error {
 
 func TestCombined_Start(t *testing.T) {
 	category.Set(t, category.Unit)
-
 	tests := []struct {
 		name            string
 		gateway         routes.GatewayRetriever

--- a/test/qa/lib/allowlist.py
+++ b/test/qa/lib/allowlist.py
@@ -1,6 +1,6 @@
 import sh
 
-from . import Port, Protocol, daemon, firewall
+from . import Port, Protocol, daemon
 
 MSG_ALLOWLIST_SUBNET_ADD_SUCCESS = "Subnet %s is allowlisted successfully."
 MSG_ALLOWLIST_SUBNET_ADD_ERROR = "Subnet %s is already allowlisted."
@@ -94,8 +94,8 @@ def add_subnet_to_allowlist(subnet_list: list[str], allowlist_alias="allowlist")
             subnet = subnet.replace("/32", "")  # noqa: PLW2901
 
         if daemon.is_connected():
-            assert subnet in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE), \
-                f"Subnet {subnet} not found in `ip route show table {firewall.IP_ROUTE_TABLE}`\n{sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)}"
+            iprules = sh.ip.rule.show()
+            assert subnet in iprules, f"Subnet {subnet} not found in `ip rule show`"
 
 
 def remove_subnet_from_allowlist(subnet_list: list[str], allowlist_alias="allowlist"):
@@ -113,5 +113,5 @@ def remove_subnet_from_allowlist(subnet_list: list[str], allowlist_alias="allowl
         if "/32" in subnet:
             subnet = subnet.replace("/32", "")  # noqa: PLW2901
 
-        assert subnet not in sh.ip.route.show.table(firewall.IP_ROUTE_TABLE), \
-            f"Subnet found in `ip route show table {firewall.IP_ROUTE_TABLE}`"
+        iprules = sh.ip.rule.show()
+        assert subnet not in iprules, "Subnet found in `ip rule show`"

--- a/test/qa/test_routing.py
+++ b/test/qa/test_routing.py
@@ -51,11 +51,13 @@ def test_routing_enabled_connect(tech, proto, obfuscated):
     assert network.is_available()
 
     assert "fwmark" in sh.ip.rule.show.table(firewall.IP_ROUTE_TABLE)
-    policy_routes = sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
-    assert SUBNET_1 in policy_routes
-    assert SUBNET_2 in policy_routes
-    assert SUBNET_3 in policy_routes
 
+    policy_rules = sh.ip.rule.show()
+    assert SUBNET_1 in policy_rules
+    assert SUBNET_2 in policy_rules
+    assert SUBNET_3 in policy_rules
+
+    policy_routes = sh.ip.route.show.table(firewall.IP_ROUTE_TABLE)
     network_interface = "nordtun" if tech == "openvpn" else "nordlynx"
     assert network_interface in policy_routes
 


### PR DESCRIPTION
Changed allow subnet routing rules to be added as pre-routing and make route decision based on `main` routing table, instead of adding them to table 205 and trying to guess how to route them.