### PR TITLE
Fix issue with cleaning environment when switching user

### DIFF
--- a/build/foss/Cargo.lock
+++ b/build/foss/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "drop-analytics"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/libdrop?tag=v5.4.0_moose_backport#bc7d2cffb9483bc85f501d5725e12cdea0bf48a6"
+source = "git+https://github.com/NordSecurity/libdrop?tag=v5.5.0-moose-with-context#b95303810701c225d01ea44c4176701ea5e18c27"
 dependencies = [
  "anyhow",
  "serde",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "drop-auth"
 version = "0.1.0"
-source = "git+https://github.com/NordSecurity/libdrop?tag=v5.4.0_moose_backport#bc7d2cffb9483bc85f501d5725e12cdea0bf48a6"
+source = "git+https://github.com/NordSecurity/libdrop?tag=v5.5.0-moose-with-context#b95303810701c225d01ea44c4176701ea5e18c27"
 dependencies = [
  "base64 0.21.7",
  "hmac",
@@ -705,12 +705,12 @@ dependencies = [
 [[package]]
 name = "drop-config"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/libdrop?tag=v5.4.0_moose_backport#bc7d2cffb9483bc85f501d5725e12cdea0bf48a6"
+source = "git+https://github.com/NordSecurity/libdrop?tag=v5.5.0-moose-with-context#b95303810701c225d01ea44c4176701ea5e18c27"
 
 [[package]]
 name = "drop-core"
 version = "0.1.0"
-source = "git+https://github.com/NordSecurity/libdrop?tag=v5.4.0_moose_backport#bc7d2cffb9483bc85f501d5725e12cdea0bf48a6"
+source = "git+https://github.com/NordSecurity/libdrop?tag=v5.5.0-moose-with-context#b95303810701c225d01ea44c4176701ea5e18c27"
 dependencies = [
  "serde",
 ]
@@ -718,7 +718,7 @@ dependencies = [
 [[package]]
 name = "drop-storage"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/libdrop?tag=v5.4.0_moose_backport#bc7d2cffb9483bc85f501d5725e12cdea0bf48a6"
+source = "git+https://github.com/NordSecurity/libdrop?tag=v5.5.0-moose-with-context#b95303810701c225d01ea44c4176701ea5e18c27"
 dependencies = [
  "chrono",
  "include_dir",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "drop-transfer"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/libdrop?tag=v5.4.0_moose_backport#bc7d2cffb9483bc85f501d5725e12cdea0bf48a6"
+source = "git+https://github.com/NordSecurity/libdrop?tag=v5.5.0-moose-with-context#b95303810701c225d01ea44c4176701ea5e18c27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 [[package]]
 name = "norddrop"
 version = "0.1.0"
-source = "git+https://github.com/NordSecurity/libdrop?tag=v5.4.0_moose_backport#bc7d2cffb9483bc85f501d5725e12cdea0bf48a6"
+source = "git+https://github.com/NordSecurity/libdrop?tag=v5.5.0-moose-with-context#b95303810701c225d01ea44c4176701ea5e18c27"
 dependencies = [
  "async-trait",
  "cc",


### PR DESCRIPTION
This PR fixes https://github.com/NordSecurity/nordvpn-linux/issues/550

The issue was that when switching a user with `su` the environment gets cleared, including PATH, so `cargo` was not available for the user script switches to