### PR TITLE
Fix fileshare monitoring test

### DIFF
--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -918,7 +918,7 @@ def test_fileshare_process_monitoring():
     rules = os.popen("sudo iptables -S").read()
     assert "49111 -m comment --comment nordvpn -j ACCEPT" in rules
 
-    sh.pkill("nordfileshare")
+    sh.pkill("-SIGKILL", "nordfileshare")
     # at the time of writing, the monitoring job is executed periodically every 5 seconds,
     # wait for 10 to be sure the job executed
     time.sleep(10)


### PR DESCRIPTION
This PR fixes the test of nordfileshare process monitoring. `pkill` by default sends `SIGTERM` which is handled by the app and sometimes it happens that the process is finished with cleanup before the assertion starts in the test. Now process will be killed with `SIGKILL` which kills it immediately