### PR TITLE
Strip core.CombinedAPI

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -32,6 +32,7 @@ type CredentialsAPI interface {
 	DeleteToken(string) error
 	TrustedPassToken(string) (*TrustedPassTokenResponse, error)
 	MultifactorAuthStatus(string) (*MultifactorAuthStatusResponse, error)
+	Logout(token string) error
 }
 
 type InsightsAPI interface {
@@ -46,12 +47,9 @@ type ServersAPI interface {
 }
 
 type CombinedAPI interface {
-	CredentialsAPI
 	InsightsAPI
-	ServersAPI
 	Base() string
 	Plans() (*Plans, error)
-	Logout(token string) error
 	CreateUser(email, password string) (*UserCreateResponse, error)
 }
 

--- a/daemon/job_server_check.go
+++ b/daemon/job_server_check.go
@@ -8,7 +8,7 @@ import (
 // JobServerCheck marks servers as offline if connection to them drops
 func JobServerCheck(
 	dm *DataManager,
-	api core.CombinedAPI,
+	api core.ServersAPI,
 	netw networker.Networker,
 	server core.Server,
 ) func() {

--- a/daemon/jobs.go
+++ b/daemon/jobs.go
@@ -25,7 +25,7 @@ func (r *RPC) StartJobs(statePublisher *state.StatePublisher) {
 	// order of the jobs below matters
 	// servers job requires geo info and configs data to create server list
 	// TODO what if configs file is deleted just before servers job or disk is full?
-	if _, err := r.scheduler.NewJob(gocron.DurationJob(6*time.Hour), gocron.NewTask(JobCountries(r.dm, r.api)), gocron.WithName("job countries")); err != nil {
+	if _, err := r.scheduler.NewJob(gocron.DurationJob(6*time.Hour), gocron.NewTask(JobCountries(r.dm, r.serversAPI)), gocron.WithName("job countries")); err != nil {
 		log.Println(internal.WarningPrefix, "job countries schedule error:", err)
 	}
 
@@ -34,12 +34,12 @@ func (r *RPC) StartJobs(statePublisher *state.StatePublisher) {
 		log.Println(internal.WarningPrefix, "job insights schedule error:", err)
 	}
 
-	if _, err := r.scheduler.NewJob(gocron.DurationJob(1*time.Hour), gocron.NewTask(JobServers(r.dm, r.cm, r.api, true)), gocron.WithName("job servers")); err != nil {
+	if _, err := r.scheduler.NewJob(gocron.DurationJob(1*time.Hour), gocron.NewTask(JobServers(r.dm, r.cm, r.serversAPI, true)), gocron.WithName("job servers")); err != nil {
 		log.Println(internal.WarningPrefix, "job servers schedule error:", err)
 	}
 	// TODO if autoconnect runs before servers job, it will return zero servers list
 
-	if _, err := r.scheduler.NewJob(gocron.DurationJob(15*time.Minute), gocron.NewTask(JobServerCheck(r.dm, r.api, r.netw, r.lastServer)), gocron.WithName("job servers check")); err != nil {
+	if _, err := r.scheduler.NewJob(gocron.DurationJob(15*time.Minute), gocron.NewTask(JobServerCheck(r.dm, r.serversAPI, r.netw, r.lastServer)), gocron.WithName("job servers check")); err != nil {
 		log.Println(internal.WarningPrefix, "job servers check schedule error:", err)
 	}
 

--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/sharedctx"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	testcore "github.com/NordSecurity/nordvpn-linux/test/mock/core"
 	testfirewall "github.com/NordSecurity/nordvpn-linux/test/mock/firewall"
 	testnetworker "github.com/NordSecurity/nordvpn-linux/test/mock/networker"
 	testnorduser "github.com/NordSecurity/nordvpn-linux/test/mock/norduser/service"
@@ -103,7 +104,7 @@ func TestStartAutoConnect(t *testing.T) {
 				dm,
 				api,
 				test.serversAPI,
-				&validCredentialsAPI{},
+				&testcore.CredentialsAPIMock{},
 				testNewCDNAPI(),
 				testNewRepoAPI(),
 				&mockAuthenticationAPI{},
@@ -270,7 +271,7 @@ func TestStartAutoMeshnet(t *testing.T) {
 				testNewDataManager(),
 				api,
 				test.serversAPI,
-				&validCredentialsAPI{},
+				&testcore.CredentialsAPIMock{},
 				testNewCDNAPI(),
 				testNewRepoAPI(),
 				&mockAuthenticationAPI{},

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/sharedctx"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	testcore "github.com/NordSecurity/nordvpn-linux/test/mock/core"
 	testfirewall "github.com/NordSecurity/nordvpn-linux/test/mock/firewall"
 	testnetworker "github.com/NordSecurity/nordvpn-linux/test/mock/networker"
 	testnorduser "github.com/NordSecurity/nordvpn-linux/test/mock/norduser/service"
@@ -42,57 +43,6 @@ func (mockAuthenticationAPI) Login() (string, error) {
 }
 
 func (mockAuthenticationAPI) Token(string) (*core.LoginResponse, error) {
-	return nil, nil
-}
-
-type validCredentialsAPI struct {
-	renewToken string
-}
-
-func (validCredentialsAPI) NotificationCredentials(token, appUserID string) (core.NotificationCredentialsResponse, error) {
-	return core.NotificationCredentialsResponse{}, nil
-}
-
-func (v validCredentialsAPI) NotificationCredentialsRevoke(token, appUserID string, purgeSession bool) (core.NotificationCredentialsRevokeResponse, error) {
-	return core.NotificationCredentialsRevokeResponse{}, nil
-}
-
-func (validCredentialsAPI) ServiceCredentials(string) (*core.CredentialsResponse, error) {
-	return &core.CredentialsResponse{
-		NordlynxPrivateKey: "nordpriv",
-		Username:           "elite",
-		Password:           "hacker",
-	}, nil
-}
-
-func (v validCredentialsAPI) TokenRenew(renewToken string) (*core.TokenRenewResponse, error) {
-	return &core.TokenRenewResponse{
-		RenewToken: v.renewToken,
-	}, nil
-}
-
-func (validCredentialsAPI) DeleteToken(token string) error {
-	return nil
-}
-
-func (validCredentialsAPI) TrustedPassToken(token string) (*core.TrustedPassTokenResponse, error) {
-	return nil, nil
-}
-
-func (validCredentialsAPI) MultifactorAuthStatus(token string) (*core.MultifactorAuthStatusResponse, error) {
-	return nil, nil
-}
-
-func (validCredentialsAPI) Services(string) (core.ServicesResponse, error) {
-	return core.ServicesResponse{
-		{
-			ExpiresAt: "2029-12-27 00:00:00",
-			Service:   core.Service{ID: 1},
-		},
-	}, nil
-}
-
-func (validCredentialsAPI) CurrentUser(string) (*core.CurrentUserResponse, error) {
 	return nil, nil
 }
 
@@ -352,7 +302,7 @@ func TestRpcConnect(t *testing.T) {
 					dm,
 					api,
 					serversAPI,
-					&validCredentialsAPI{},
+					&testcore.CredentialsAPIMock{},
 					testNewCDNAPI(),
 					testNewRepoAPI(),
 					&mockAuthenticationAPI{},
@@ -414,7 +364,7 @@ func TestRpcReconnect(t *testing.T) {
 		dm,
 		api,
 		&mockServersAPI{},
-		&validCredentialsAPI{},
+		&testcore.CredentialsAPIMock{},
 		testNewCDNAPI(),
 		testNewRepoAPI(),
 		&mockAuthenticationAPI{},

--- a/daemon/rpc_login.go
+++ b/daemon/rpc_login.go
@@ -74,7 +74,7 @@ func (r *RPC) loginCommon(customCB customCallbackType) (payload *pb.LoginRespons
 		return pbresp, nil
 	}
 
-	credentials, err := r.api.ServiceCredentials(resp.Token)
+	credentials, err := r.credentialsAPI.ServiceCredentials(resp.Token)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "retrieving credentials:", err)
 		if errors.Is(err, core.ErrServerInternal) {
@@ -171,7 +171,7 @@ func (r *RPC) LoginOAuth2Callback(ctx context.Context, in *pb.String) (payload *
 		return &pb.Empty{}, err
 	}
 
-	credentials, err := r.api.ServiceCredentials(resp.Token)
+	credentials, err := r.credentialsAPI.ServiceCredentials(resp.Token)
 	if err != nil {
 		r.publisher.Publish(err.Error())
 		return &pb.Empty{}, err

--- a/daemon/rpc_logout.go
+++ b/daemon/rpc_logout.go
@@ -62,7 +62,7 @@ func (r *RPC) Logout(ctx context.Context, in *pb.LogoutRequest) (payload *pb.Pay
 			log.Println(internal.WarningPrefix, "error revoking NC token")
 		}
 
-		if err := r.api.DeleteToken(tokenData.Token); err != nil {
+		if err := r.credentialsAPI.DeleteToken(tokenData.Token); err != nil {
 			log.Println(internal.ErrorPrefix, "deleting token: ", err)
 			switch {
 			// This means that token is invalid anyway
@@ -79,7 +79,7 @@ func (r *RPC) Logout(ctx context.Context, in *pb.LogoutRequest) (payload *pb.Pay
 			}
 		}
 
-		if err := r.api.Logout(tokenData.Token); err != nil {
+		if err := r.credentialsAPI.Logout(tokenData.Token); err != nil {
 			log.Println(internal.ErrorPrefix, "logging out: ", err)
 			switch {
 			// This means that token is invalid anyway

--- a/daemon/rpc_logout_test.go
+++ b/daemon/rpc_logout_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/events/subs"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/nc"
+	testcore "github.com/NordSecurity/nordvpn-linux/test/mock/core"
 	"github.com/NordSecurity/nordvpn-linux/test/mock/networker"
 	testnorduser "github.com/NordSecurity/nordvpn-linux/test/mock/norduser/service"
 )
@@ -34,14 +35,14 @@ func (mockApi) Logout(token string) error      { return nil }
 
 func TestLogout_Token(t *testing.T) {
 	rpc := RPC{
-		ac:        &workingLoginChecker{},
-		cm:        newMockConfigManager(),
-		norduser:  &testnorduser.MockNorduserCombinedService{},
-		netw:      &networker.Mock{},
-		ncClient:  mockNC{},
-		publisher: &subs.Subject[string]{},
-		api:       mockApi{},
-		events:    &daemonevents.Events{User: &daemonevents.LoginEvents{Logout: &daemonevents.MockPublisherSubscriber[events.DataAuthorization]{}}},
+		ac:             &workingLoginChecker{},
+		cm:             newMockConfigManager(),
+		norduser:       &testnorduser.MockNorduserCombinedService{},
+		netw:           &networker.Mock{},
+		ncClient:       mockNC{},
+		publisher:      &subs.Subject[string]{},
+		credentialsAPI: &testcore.CredentialsAPIMock{},
+		events:         &daemonevents.Events{User: &daemonevents.LoginEvents{Logout: &daemonevents.MockPublisherSubscriber[events.DataAuthorization]{}}},
 	}
 
 	tests := []struct {

--- a/test/mock/core/core.go
+++ b/test/mock/core/core.go
@@ -45,3 +45,7 @@ func (*CredentialsAPIMock) DeleteToken(string) error {
 func (*CredentialsAPIMock) TrustedPassToken(string) (*core.TrustedPassTokenResponse, error) {
 	return nil, nil
 }
+
+func (*CredentialsAPIMock) Logout(string) error {
+	return nil
+}


### PR DESCRIPTION
In some cases abstract CombinedAPI were used when some specific functions were needed and they were already available in RPC