### PR TITLE
Fix aarch64 path in snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -171,10 +171,10 @@ parts:
     plugin: dump
     source-type: local
     source:
-      - on amd64: ./bin/deps/lib/amd64/
-      - on arm64: ./bin/deps/lib/arm64/
-      - on armhf: ./bin/deps/lib/armhf/
       - on i386: ./bin/deps/lib/i386/
+      - on amd64: ./bin/deps/lib/amd64/
+      - on armhf: ./bin/deps/lib/armhf/
+      - on arm64: ./bin/deps/lib/aarch64/
     organize:
       latest/*: usr/lib/
     stage:


### PR DESCRIPTION
Changes:
- reorder of the architectures to make it consistent
- change of  `- on arm64: ./bin/deps/lib/arm64/` to  `- on arm64: ./bin/deps/lib/aarch64/` 