### PR TITLE
Use sudo to execute ldconfig for deb postinst script

### DIFF
--- a/contrib/scriptlets/deb/postinst
+++ b/contrib/scriptlets/deb/postinst
@@ -26,7 +26,8 @@ helpMessage="If you need help using the app, use the command 'nordvpn --help'."
 
 # update configuration and shared library cache for linker to find .so files
 echo "/usr/lib/nordvpn" > /etc/ld.so.conf.d/nordvpn.conf
-ldconfig
+# NOTE: sudo is required here even though the script is run with EUID 0
+sudo ldconfig
 
 mkdir -m 0750 -p "$LOG_DIR"
 chown root:$NORDVPN_GROUP "$LOG_DIR"

--- a/contrib/scriptlets/deb/postrm
+++ b/contrib/scriptlets/deb/postrm
@@ -22,7 +22,7 @@ case "$1" in
         rm -rf /var/{lib,log}/nordvpn
         rm -rf /run/nordvpn
         rm -rf /etc/ld.so.conf.d/nordvpn.conf
-        ldconfig
+        sudo ldconfig
     ;;
     disappear|upgrade|failed-upgrade|abort-install|abort-upgrade)
     ;;


### PR DESCRIPTION
The whole script is run with Effective User ID 0, but the sudo was required to be used to refresh linker cache in deb postinstall script. It was not needed for rpm package.