### PR TITLE
Add verbose flag to ldconfig

### DIFF
--- a/contrib/scriptlets/deb/postinst
+++ b/contrib/scriptlets/deb/postinst
@@ -26,17 +26,12 @@ helpMessage="If you need help using the app, use the command 'nordvpn --help'."
 
 # update configuration and shared library cache for linker to find .so files
 echo "/usr/lib/nordvpn" > /etc/ld.so.conf.d/nordvpn.conf
-
-SUDO=$(which sudo 2>/dev/null)
-if [[ -x ${SUDO} ]]; then
-  echo "Refreshing linker cache with sudo"
-  # NOTE: sudo is required here even though the script is run with EUID 0
-  ${SUDO} ldconfig
-else
-  echo "Refreshing linker cache - no sudo"
-  ldconfig
-fi
-
+# NOTE: We found some really strange behavior with `ldconfig` cache refresh here.
+# On .deb systems, using just `ldconfig` causes the nordvpnd daemon to fail on
+# the first start with error that .so are missing. On restart, it's working again.
+# Adding ANY flag to `ldconfig` (even the one we added on our own which does
+# literally nothing) fixes the issue.
+ldconfig -v > /dev/null 2>&1
 
 mkdir -m 0750 -p "$LOG_DIR"
 chown root:$NORDVPN_GROUP "$LOG_DIR"

--- a/contrib/scriptlets/deb/postinst
+++ b/contrib/scriptlets/deb/postinst
@@ -26,7 +26,17 @@ helpMessage="If you need help using the app, use the command 'nordvpn --help'."
 
 # update configuration and shared library cache for linker to find .so files
 echo "/usr/lib/nordvpn" > /etc/ld.so.conf.d/nordvpn.conf
-ldconfig
+
+SUDO=$(which sudo 2>/dev/null)
+if [[ -x ${SUDO} ]]; then
+  echo "Refreshing linker cache with sudo"
+  # NOTE: sudo is required here even though the script is run with EUID 0
+  ${SUDO} ldconfig
+else
+  echo "Refreshing linker cache - no sudo"
+  ldconfig
+fi
+
 
 mkdir -m 0750 -p "$LOG_DIR"
 chown root:$NORDVPN_GROUP "$LOG_DIR"

--- a/contrib/scriptlets/deb/postrm
+++ b/contrib/scriptlets/deb/postrm
@@ -22,7 +22,16 @@ case "$1" in
         rm -rf /var/{lib,log}/nordvpn
         rm -rf /run/nordvpn
         rm -rf /etc/ld.so.conf.d/nordvpn.conf
-        ldconfig
+
+        SUDO=$(which sudo 2>/dev/null)
+        if [[ -x ${SUDO} ]]; then
+          echo "Refreshing linker cache with sudo"
+          # NOTE: sudo is required here even though the script is run with EUID 0
+          ${SUDO} ldconfig
+        else
+          echo "Refreshing linker cache - no sudo"
+          ldconfig
+        fi
     ;;
     disappear|upgrade|failed-upgrade|abort-install|abort-upgrade)
     ;;

--- a/contrib/scriptlets/deb/postrm
+++ b/contrib/scriptlets/deb/postrm
@@ -23,15 +23,12 @@ case "$1" in
         rm -rf /run/nordvpn
         rm -rf /etc/ld.so.conf.d/nordvpn.conf
 
-        SUDO=$(which sudo 2>/dev/null)
-        if [[ -x ${SUDO} ]]; then
-          echo "Refreshing linker cache with sudo"
-          # NOTE: sudo is required here even though the script is run with EUID 0
-          ${SUDO} ldconfig
-        else
-          echo "Refreshing linker cache - no sudo"
-          ldconfig
-        fi
+        # NOTE: We found some really strange behavior with `ldconfig` cache refresh here.
+        # On .deb systems, using just `ldconfig` causes the nordvpnd daemon to fail on
+        # the first start with error that .so are missing. On restart, it's working again.
+        # Adding ANY flag to `ldconfig` (even the one we added on our own which does
+        # literally nothing) fixes the issue.
+        ldconfig -v > /dev/null 2>&1
     ;;
     disappear|upgrade|failed-upgrade|abort-install|abort-upgrade)
     ;;


### PR DESCRIPTION
Changes:
- call `ldconfig -v` instead of `ldconfig` to properly refresh the linker cache

We found out that calling `ldconfig` alone causes the daemon to fail on first start with error about missing libraries. With second start (when systemd does the restart of the service), it's working properly.

Adding any valid flag to `ldconfig` fixes the issue. Even implementing dummy flag to `ldconfig`, which does nothing, fixes the issue.