### PR TITLE
Use Stop instead of GracefulStop

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -590,7 +590,7 @@ func main() {
 	// Graceful stop
 
 	internal.WaitSignal()
-	s.GracefulStop()
+	s.Stop()
 	norduserService.StopAll()
 
 	if err := notificationClient.Stop(); err != nil {

--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -191,7 +191,7 @@ func waitForShutdown(stopChan <-chan norduser.StopRequest,
 		log.Println(internal.InfoPrefix, "User has logged out")
 	}
 
-	grpcServer.GracefulStop()
+	grpcServer.Stop()
 	fileshareManagementChan <- norduser.Shutdown
 	// shutdownChan will be closed once the shutdown operation is finished
 	<-fileshareShutdownChan

--- a/fileshare/fileshare_startup/startup.go
+++ b/fileshare/fileshare_startup/startup.go
@@ -32,7 +32,7 @@ func (f *FileshareHandle) GetShutdownChan() <-chan struct{} {
 func (f *FileshareHandle) Shutdown() {
 	f.eventManager.CancelLiveTransfers()
 
-	f.grpcServer.GracefulStop()
+	f.grpcServer.Stop()
 
 	if err := f.fileshareImplementation.Disable(); err != nil {
 		log.Println(internal.ErrorPrefix, "disabling fileshare:", err)


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

GracefulStop will wait for all the current clients to disconnect, otherwise daemon will be stuck there.
Since the daemon will provide a stream for state events, those connections will never close. In this case the daemon will be stuck.