### PR TITLE
Add flag to fail fast when downloading .so during build

### DIFF
--- a/ci/check_dependencies.sh
+++ b/ci/check_dependencies.sh
@@ -43,6 +43,7 @@ function fetch_gitlab_artifact() {
   curl \
     --retry 3 \
     --retry-delay 2 \
+    --fail \
     --header "PRIVATE-TOKEN: ${GL_ACCESS_TOKEN}" \
     -o "${out_file}" \
     -L "${artifact_url}"


### PR DESCRIPTION
Changes:
- add `--fail-with-body` to fail fast when downloading dependencies