### PR TITLE
feat: non-blocking libdrop event handling

### DIFF
--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -146,12 +146,14 @@ func main() {
 		defaultDownloadDirectory = ""
 	}
 
+	ch := make(chan fileshare.Event, 100)
 	eventManager := fileshare.NewEventManager(
 		internal.IsProdEnv(Environment),
 		meshClient,
 		fileshare.StdOsInfo{},
 		fileshare.NewStdFilesystem("/"),
 		defaultDownloadDirectory,
+		ch,
 	)
 
 	privKeyResponse, err := meshClient.GetPrivateKey(context.Background(), &meshpb.Empty{})
@@ -186,6 +188,7 @@ func main() {
 		fileshare.NewPubkeyProvider(meshClient).PubkeyFunc,
 		string(meshPrivKey),
 		storagePath,
+		ch,
 	)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "can't create fileshare implementation:", err)

--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -146,14 +146,12 @@ func main() {
 		defaultDownloadDirectory = ""
 	}
 
-	ch := make(chan fileshare.Event, 100)
 	eventManager := fileshare.NewEventManager(
 		internal.IsProdEnv(Environment),
 		meshClient,
 		fileshare.StdOsInfo{},
 		fileshare.NewStdFilesystem("/"),
 		defaultDownloadDirectory,
-		ch,
 	)
 
 	privKeyResponse, err := meshClient.GetPrivateKey(context.Background(), &meshpb.Empty{})
@@ -188,7 +186,6 @@ func main() {
 		fileshare.NewPubkeyProvider(meshClient).PubkeyFunc,
 		string(meshPrivKey),
 		storagePath,
-		ch,
 	)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "can't create fileshare implementation:", err)

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -264,13 +264,8 @@ func (em *EventManager) handleFileProgressEvent(event EventKindFileProgress) {
 		return
 	}
 
-	fmt.Printf("total transferred b4: %d\n", transfer.TotalTransferred)
 	transfer.TotalTransferred += event.Transferred - file.Transferred // add only delta
 	file.Transferred = event.Transferred
-	fmt.Printf("event.Transferred: %d\n", event.Transferred)
-	fmt.Printf("file.Transferred: %d\n", file.Transferred)
-	fmt.Printf("transfer.TotalTransferred: %d\n", transfer.TotalTransferred)
-	fmt.Printf("\n\n\n")
 
 	if progressCh, ok := em.transferSubscriptions[transfer.ID]; ok {
 		var progressPercent uint32

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -115,9 +115,9 @@ func (em *EventManager) process() {
 	}
 }
 
-// sends an event to the event manager
-// the event manager will process it asynchronously and return immediately
+// AsyncEvent sends an event to the event manager in an asynchronous manner
 //
+// This function should return immediately,
 // unless the asyncEvents channel is full, in which case it will block until there is space
 func (em *EventManager) AsyncEvent(event ...Event) {
 	select {
@@ -128,8 +128,7 @@ func (em *EventManager) AsyncEvent(event ...Event) {
 	}
 }
 
-// sends an event to the event manager
-// the event manager will process is synchronously and return after the event is fully processed
+// SyncEvent sends an event to the event manager in a synchronous manner, and waits for the event to be fully processed
 func (em *EventManager) SyncEvent(event ...Event) {
 	em.syncEvents <- event
 	<-em.syncDoneCh

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -110,7 +110,7 @@ func (em *EventManager) Event(event ...Event) {
 	select {
 	case em.events <- event:
 	default:
-		log.Println(internal.WarningPrefix, " async events channel is full. Event() will block until there is space")
+		log.Println(internal.WarningPrefix, "async events channel is full. Event() will block until there is space")
 		em.events <- event
 	}
 }

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -115,6 +115,10 @@ func (em *EventManager) process() {
 	}
 }
 
+// sends an event to the event manager
+// the event manager will process it asynchronously and return immediately
+//
+// unless the asyncEvents channel is full, in which case it will block until there is space
 func (em *EventManager) AsyncEvent(event ...Event) {
 	select {
 	case em.asyncEvents <- event:
@@ -124,6 +128,8 @@ func (em *EventManager) AsyncEvent(event ...Event) {
 	}
 }
 
+// sends an event to the event manager
+// the event manager will process is synchronously and return after the event is fully processed
 func (em *EventManager) SyncEvent(event ...Event) {
 	em.syncEvents <- event
 	<-em.syncDoneCh

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -116,7 +116,12 @@ func (em *EventManager) process() {
 }
 
 func (em *EventManager) AsyncEvent(event ...Event) {
-	em.asyncEvents <- event
+	select {
+	case em.asyncEvents <- event:
+	default:
+		log.Println(internal.WarningPrefix, " async events channel is full. AsyncEvent() will block until there is space")
+		em.asyncEvents <- event
+	}
 }
 
 func (em *EventManager) SyncEvent(event ...Event) {

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -80,7 +80,7 @@ func NewEventManager(
 		defaultDownloadDir:    defaultDownloadDir,
 		syncEvents:            make(chan []Event),
 		syncDoneCh:            make(chan struct{}),
-		asyncEvents:           make(chan []Event, 2048),
+		asyncEvents:           make(chan []Event, 32),
 	}
 	go em.process()
 

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -77,8 +77,7 @@ func NewEventManager(
 		defaultDownloadDir:    defaultDownloadDir,
 	}
 	go func() {
-		for {
-			event := <-ch
+		for event := range ch {
 			em.mutex.Lock()
 			em.OnEvent(event)
 			em.mutex.Unlock()

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -645,7 +645,7 @@ func (em *EventManager) Subscribe(id string) <-chan TransferProgressInfo {
 	em.mutex.Lock()
 	defer em.mutex.Unlock()
 
-	em.transferSubscriptions[id] = make(chan TransferProgressInfo)
+	em.transferSubscriptions[id] = make(chan TransferProgressInfo, 32) // use buffered channels, because we don't want to block the event processing
 
 	return em.transferSubscriptions[id]
 }

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -100,13 +100,13 @@ func (em *EventManager) process() {
 		select {
 		case e, ok := <-em.asyncEvents:
 			if !ok {
-				log.Println(internal.WarningPrefix + " asyncEvents channel closed")
+				log.Println(internal.WarningPrefix, "asyncEvents channel closed")
 				return
 			}
 			fn(e)
 		case e, ok := <-em.syncEvents:
 			if !ok {
-				log.Println(internal.WarningPrefix + " syncEvents channel closed")
+				log.Println(internal.WarningPrefix, "syncEvents channel closed")
 				return
 			}
 			fn(e)

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -173,7 +173,6 @@ func (em *EventManager) DisableNotifications() error {
 	return nil
 }
 
-// OnEvent processes events and handles live transfer state.
 func (em *EventManager) handleEvent(event Event) {
 	if !em.isProd {
 		log.Printf(internal.InfoPrefix+" DROP EVENT: %s\n", EventToString(event))

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -1414,7 +1414,7 @@ func TestEventsFlow(t *testing.T) {
 
 	// subtract by the existing RequestQueued and FileStarted events
 	// to make sure we have the correct number of events
-	// otherwise it's not chunked properly, as the size is not disivable by chunkSize(1026 % 8 = 2)
+	// otherwise it's not chunked properly, as the size is not divisable by chunkSize(1026 % 8 = 2)
 	numProgressEvents := numEvents - uint64(len(events))
 
 	for i := uint64(0); i < numProgressEvents; i++ {

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -217,7 +217,8 @@ func (m *mockStorage) PurgeTransfersUntil(until time.Time) error {
 func TestGetTransfers(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	eventManager := NewEventManager(false, &mockMeshClient{}, &mockEventManagerOsInfo{}, &mockEventManagerFilesystem{}, "")
+	eventManager := NewEventManager(false, &mockMeshClient{}, &mockEventManagerOsInfo{}, &mockEventManagerFilesystem{}, "", make(chan Event))
+
 	storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
 	eventManager.SetStorage(storage)
 
@@ -259,7 +260,7 @@ func TestGetTransfers(t *testing.T) {
 func TestGetTransfers_Fail(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	eventManager := NewEventManager(false, &mockMeshClient{}, &mockEventManagerOsInfo{}, &mockEventManagerFilesystem{}, "")
+	eventManager := NewEventManager(false, &mockMeshClient{}, &mockEventManagerOsInfo{}, &mockEventManagerFilesystem{}, "", make(chan Event))
 	eventManager.SetStorage(&mockStorage{err: errors.New("storage failure")})
 	_, err := eventManager.GetTransfers()
 	assert.ErrorContains(t, err, "storage failure")
@@ -268,7 +269,7 @@ func TestGetTransfers_Fail(t *testing.T) {
 func TestTransferProgress(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	eventManager := NewEventManager(false, &mockMeshClient{}, &mockEventManagerOsInfo{}, &mockEventManagerFilesystem{}, "")
+	eventManager := NewEventManager(false, &mockMeshClient{}, &mockEventManagerOsInfo{}, &mockEventManagerFilesystem{}, "", make(chan Event))
 	eventManager.SetFileshare(&mockEventManagerFileshare{})
 	storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
 	eventManager.SetStorage(storage)
@@ -502,7 +503,7 @@ func TestAcceptTransfer(t *testing.T) {
 			&mockMeshClient{},
 			&mockSystemEnvironment.mockEventManagerOsInfo,
 			&mockSystemEnvironment.mockEventManagerFilesystem,
-			"")
+			"", make(chan Event))
 		storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
 		eventManager.SetStorage(storage)
 		storage.transfers[transferID] = &pb.Transfer{
@@ -534,7 +535,7 @@ func TestAcceptTransfer_Outgoing(t *testing.T) {
 		&mockMeshClient{},
 		&mockSystemEnvironment.mockEventManagerOsInfo,
 		&mockSystemEnvironment.mockEventManagerFilesystem,
-		"")
+		"", make(chan Event))
 	storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
 	eventManager.SetStorage(storage)
 	transferID := exampleUUID
@@ -557,7 +558,7 @@ func TestAcceptTransfer_AlreadyAccepted(t *testing.T) {
 		&mockMeshClient{},
 		&mockSystemEnvironment.mockEventManagerOsInfo,
 		&mockSystemEnvironment.mockEventManagerFilesystem,
-		"")
+		"", make(chan Event))
 	storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
 	eventManager.SetStorage(storage)
 	transferID := exampleUUID
@@ -588,7 +589,7 @@ func TestTransferFinishedNotifications(t *testing.T) {
 			&mockMeshClient{},
 			&mockEventManagerOsInfo{},
 			&mockEventManagerFilesystem{},
-			"")
+			"", make(chan Event))
 		eventManager.notificationManager = &notificationManager
 		eventManager.SetFileshare(&mockEventManagerFileshare{})
 		storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
@@ -724,7 +725,7 @@ func TestTransferFinishedNotificationsOpenFile(t *testing.T) {
 		&mockMeshClient{},
 		&mockEventManagerOsInfo{},
 		&mockEventManagerFilesystem{},
-		"")
+		"", make(chan Event))
 	eventManager.notificationManager = &notificationManager
 	eventManager.SetFileshare(&mockEventManagerFileshare{})
 	storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
@@ -779,7 +780,7 @@ func TestTransferRequestNotification(t *testing.T) {
 		&mockMeshClient{},
 		&mockEventManagerOsInfo{},
 		&mockEventManagerFilesystem{},
-		"")
+		"", make(chan Event))
 	eventManager.notificationManager = &notificationManager
 	eventManager.SetFileshare(&mockEventManagerFileshare{})
 
@@ -890,7 +891,7 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 			&mockMeshClient{},
 			&osInfo,
 			&filesystem,
-			"")
+			"", make(chan Event))
 		storage := &mockStorage{}
 		eventManager.SetStorage(storage)
 		storage.transfers = map[string]*pb.Transfer{
@@ -1054,7 +1055,7 @@ func TestTransterRequestNotificationAcceptInvalidTransfer(t *testing.T) {
 		&mockMeshClient{},
 		&mockOsEnvironment.mockEventManagerOsInfo,
 		&mockOsEnvironment.mockEventManagerFilesystem,
-		mockOsEnvironment.destinationDirectory)
+		mockOsEnvironment.destinationDirectory, make(chan Event))
 	eventManager.notificationManager = &notificationManager
 	eventManager.SetStorage(&mockStorage{})
 
@@ -1119,7 +1120,7 @@ func TestTransferRequestNotificationCancel(t *testing.T) {
 			&mockMeshClient{},
 			&mockEventManagerOsInfo{},
 			&mockEventManagerFilesystem{},
-			"")
+			"", make(chan Event))
 		eventManager.notificationManager = &notificationManager
 		eventManager.SetFileshare(&mockEventManagerFileshare{})
 
@@ -1238,7 +1239,7 @@ func TestAutoaccept(t *testing.T) {
 		&mockMeshClient{},
 		&mockOsEnvironment.mockEventManagerOsInfo,
 		&mockOsEnvironment.mockEventManagerFilesystem,
-		mockOsEnvironment.destinationDirectory)
+		mockOsEnvironment.destinationDirectory, make(chan Event))
 	eventManager.notificationManager = &notificationManager
 	storage := &mockStorage{transfers: map[string]*pb.Transfer{}}
 	eventManager.SetStorage(storage)

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -1429,6 +1429,10 @@ func TestEventsFlow(t *testing.T) {
 		)
 	}
 
+	if uint64(len(events))%chunkSize != 0 {
+		panic("events size is not divisible by chunkSize")
+	}
+
 	chunks := make([][]Event, chunkCount)
 	for i := uint64(0); i < chunkCount; i++ {
 		chunks[i] = make([]Event, chunkSize)

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -1115,7 +1115,6 @@ func TestTransferRequestNotificationCancel(t *testing.T) {
 		notifier := mockNotifier{
 			notifications: []mockNotification{},
 			nextID:        pendingTransferNotificationID,
-			// updateCh:      make(chan struct{}),
 		}
 
 		notificationManager := NewMockNotificationManager(&mockEventManagerOsInfo{})

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -68,7 +68,6 @@ func (mn *mockNotifier) SendNotification(summary string, body string, actions []
 		default:
 			<-mn.updateCh
 			mn.updateCh <- struct{}{}
-
 		}
 	}
 	return notificationID, nil
@@ -433,7 +432,7 @@ func TestTransferProgress(t *testing.T) {
 	assert.Equal(t, pb.Status_SUCCESS, progressEvent.Status)
 
 	waitGroup.Wait()
-	eventManager.mutex.Lock() // required so that go test -race doesn't fail, normally it's not needed
+	eventManager.mutex.Lock() // required so that go test -race doesn't fail, normal functions used in production use mutex anyways
 	_, ok := eventManager.transferSubscriptions[transferID]
 	assert.False(t, ok) // expect subscriber to be removed
 	_, ok = eventManager.liveTransfers[transferID]

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -433,10 +433,12 @@ func TestTransferProgress(t *testing.T) {
 	assert.Equal(t, pb.Status_SUCCESS, progressEvent.Status)
 
 	waitGroup.Wait()
+	eventManager.mutex.Lock() // required so that go test -race doesn't fail, normally it's not needed
 	_, ok := eventManager.transferSubscriptions[transferID]
 	assert.False(t, ok) // expect subscriber to be removed
 	_, ok = eventManager.liveTransfers[transferID]
 	assert.False(t, ok) // expect transfer not to be tracked anymore
+	eventManager.mutex.Unlock()
 }
 
 func TestAcceptTransfer(t *testing.T) {

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -1433,13 +1433,13 @@ func TestEventsFlow(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		progChSize int
-		fn         func(t *testing.T, em *EventManager, progCh chan TransferProgressInfo)
+		name                string
+		progressChannelSize int
+		fn                  func(t *testing.T, em *EventManager, progCh chan TransferProgressInfo)
 	}{
 		{
-			name:       "Event() should not block with progCh buffer = 1 and 1024 events",
-			progChSize: 32,
+			name:                "Event() should not block with progCh buffer = 1 and 1024 events",
+			progressChannelSize: 32,
 			fn: func(t *testing.T, em *EventManager, progCh chan TransferProgressInfo) {
 				for _, chunk := range chunks {
 					em.Event(chunk...)
@@ -1447,8 +1447,8 @@ func TestEventsFlow(t *testing.T) {
 			},
 		},
 		{
-			name:       "Event() events should be in order & all received",
-			progChSize: int(numEvents * 2),
+			name:                "Event() events should be in order & all received",
+			progressChannelSize: int(numEvents * 2),
 			fn: func(t *testing.T, em *EventManager, progCh chan TransferProgressInfo) {
 				for _, chunk := range chunks {
 					em.Event(chunk...)
@@ -1492,7 +1492,7 @@ func TestEventsFlow(t *testing.T) {
 				},
 			}
 
-			progCh := make(chan TransferProgressInfo, test.progChSize)
+			progCh := make(chan TransferProgressInfo, test.progressChannelSize)
 			em.transferSubscriptions[transferID] = progCh
 			test.fn(t, em, progCh)
 		})

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -45,14 +45,8 @@ type mockNotifier struct {
 }
 
 func (mn *mockNotifier) Wait() {
-	timeout := make(chan bool, 1)
-	go func() {
-		time.Sleep(1 * time.Second)
-		timeout <- true
-	}()
-
 	select {
-	case <-timeout:
+	case <-time.After(1 * time.Second):
 	case <-mn.updateCh:
 	}
 }

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -1412,7 +1412,12 @@ func TestEventsFlow(t *testing.T) {
 		},
 	}
 
-	for i := uint64(0); i < numEvents; i++ {
+	// subtract by the existing RequestQueued and FileStarted events
+	// to make sure we have the correct number of events
+	// otherwise it's not chunked properly, as the size is not disivable by chunkSize(1026 % 8 = 2)
+	numProgressEvents := numEvents - uint64(len(events))
+
+	for i := uint64(0); i < numProgressEvents; i++ {
 		events = append(events,
 			Event{
 				Kind: EventKindFileProgress{
@@ -1454,7 +1459,7 @@ func TestEventsFlow(t *testing.T) {
 					em.Event(chunk...)
 				}
 				lastProgress := uint32(0)
-				for i := uint64(0); i < numEvents-2; i++ {
+				for i := uint64(0); i < numProgressEvents; i++ {
 					prog := <-progCh
 					if prog.Transferred < lastProgress {
 						t.Fatalf("unexpected `lastProgress` bigger than new `progress.Transferred`. it doesn't go in order: %d > %d", lastProgress, prog.Transferred)

--- a/fileshare/events.go
+++ b/fileshare/events.go
@@ -9,8 +9,7 @@ import (
 )
 
 type EventCallback interface {
-	AsyncEvent(event ...Event)
-	SyncEvent(event ...Event)
+	Event(event ...Event)
 }
 
 type Event struct {

--- a/fileshare/events.go
+++ b/fileshare/events.go
@@ -9,7 +9,8 @@ import (
 )
 
 type EventCallback interface {
-	OnEvent(event Event)
+	AsyncEvent(event ...Event)
+	SyncEvent(event ...Event)
 }
 
 type Event struct {

--- a/fileshare/libdrop/libdrop.go
+++ b/fileshare/libdrop/libdrop.go
@@ -73,13 +73,11 @@ func (dl defaultLogger) Level() norddrop.LogLevel {
 
 type libdropEventCallback struct {
 	eventCallback fileshare.EventCallback
-	ch            chan<- fileshare.Event
 }
 
 func (lec libdropEventCallback) OnEvent(nev norddrop.Event) {
 	ev := libdropEventToInternalEvent(nev)
-	lec.ch <- ev
-	// lec.eventCallback.OnEvent(ev)
+	lec.eventCallback.AsyncEvent(ev)
 }
 
 func libdropEventToInternalEvent(nev norddrop.Event) fileshare.Event {
@@ -193,7 +191,6 @@ func New(
 	pubkeyFunc func(string) []byte,
 	privKey string,
 	storagePath string,
-	ch chan<- fileshare.Event,
 ) (*Fileshare, error) {
 	keyStore := defaultKeyStore{
 		pubkeyFunc: pubkeyFunc,
@@ -206,7 +203,7 @@ func New(
 
 	logger := defaultLogger{logLevel}
 
-	eventCallback := libdropEventCallback{eventCb, ch}
+	eventCallback := libdropEventCallback{eventCb}
 	norddrop, err := norddrop.NewNordDrop(eventCallback, keyStore, logger)
 	if err != nil {
 		return nil, fmt.Errorf("creating norddrop instance: %w", err)

--- a/fileshare/libdrop/libdrop.go
+++ b/fileshare/libdrop/libdrop.go
@@ -77,7 +77,7 @@ type libdropEventCallback struct {
 
 func (lec libdropEventCallback) OnEvent(nev norddrop.Event) {
 	ev := libdropEventToInternalEvent(nev)
-	lec.eventCallback.AsyncEvent(ev)
+	lec.eventCallback.Event(ev)
 }
 
 func libdropEventToInternalEvent(nev norddrop.Event) fileshare.Event {

--- a/fileshare/libdrop/libdrop.go
+++ b/fileshare/libdrop/libdrop.go
@@ -77,7 +77,7 @@ type libdropEventCallback struct {
 
 func (nec libdropEventCallback) OnEvent(nev norddrop.Event) {
 	ev := libdropEventToInternalEvent(nev)
-	nec.eventCallback.OnEvent(ev)
+	go nec.eventCallback.OnEvent(ev)
 }
 
 func libdropEventToInternalEvent(nev norddrop.Event) fileshare.Event {


### PR DESCRIPTION

~~I saw some ideas to implement a channel, but is it actually necessary?~~

~~The implementation of OnEvent() is using a mutex anyways, so no data races should be happening, and Go-routines seem to be light enough to handle this without overusing resources.~~