### PR TITLE
fix: with `io.ReadAll()` use `io.LimitReader()` for DoS prevention

### DIFF
--- a/core/authentication.go
+++ b/core/authentication.go
@@ -75,7 +75,7 @@ func (o *OAuth2) Login() (string, error) {
 		return "", err
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +123,7 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 		return nil, err
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}

--- a/core/authentication.go
+++ b/core/authentication.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -75,7 +74,7 @@ func (o *OAuth2) Login() (string, error) {
 		return "", err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(req.Body)
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +122,7 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 		return nil, err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/core/authentication.go
+++ b/core/authentication.go
@@ -74,7 +74,7 @@ func (o *OAuth2) Login() (string, error) {
 		return "", err
 	}
 
-	body, err := MaxBytesReadAll(req.Body)
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -122,7 +122,7 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 		return nil, err
 	}
 
-	body, err := MaxBytesReadAll(req.Body)
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/core/cdn.go
+++ b/core/cdn.go
@@ -77,7 +77,7 @@ func (api *CDNAPI) request(path, method string) (*CDNAPIResponse, error) {
 				reader = resp.Body
 			}
 		}
-		body, err = io.ReadAll(reader)
+		body, err = io.ReadAll(io.LimitReader(reader, ReaderLimit))
 		if err != nil {
 			return nil, err
 		}

--- a/core/cdn.go
+++ b/core/cdn.go
@@ -77,7 +77,7 @@ func (api *CDNAPI) request(path, method string) (*CDNAPIResponse, error) {
 				reader = resp.Body
 			}
 		}
-		body, err = io.ReadAll(io.LimitReader(reader, ReaderLimit))
+		body, err = MaxBytesReadAll(reader)
 		if err != nil {
 			return nil, err
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -568,6 +568,14 @@ func getData[T any](api *DefaultAPI, token string, url string) (T, error) {
 
 const maxBytesLimit int64 = 1024 * 1024 * 10 // 10MB
 
+type ErrMaxBytesLimit struct {
+	Limit int64
+}
+
+func (err *ErrMaxBytesLimit) Error() string {
+	return fmt.Sprintf("input exceeded the max limit of %d bytes", err.Limit)
+}
+
 // MaxBytesReadAll is a wrapper around io.ReadAll that limits the number of bytes read from the reader.
 //
 // If the reader exceeds the maxBytesLimit, the function returns an error.

--- a/core/core.go
+++ b/core/core.go
@@ -568,7 +568,9 @@ func getData[T any](api *DefaultAPI, token string, url string) (T, error) {
 
 const maxBytesLimit int64 = 1024 * 1024 * 10 // 10MB
 
-// re-implementation of io.ReadAll with max limit
+// MaxBytesReadAll is a wrapper around io.ReadAll that limits the number of bytes read from the reader.
+//
+// If the reader exceeds the maxBytesLimit, the function returns an error.
 func MaxBytesReadAll(r io.Reader) ([]byte, error) {
 	limitedReader := &io.LimitedReader{
 		R: r,

--- a/core/core.go
+++ b/core/core.go
@@ -21,6 +21,8 @@ import (
 const (
 	// linuxPlatformID defines the linux platform ID on the Notification Centre
 	linuxPlatformID = 500
+
+	ReaderLimit int64 = 1024 * 1024 * 10 // 10MB
 )
 
 type CredentialsAPI interface {
@@ -127,7 +129,7 @@ func (api *DefaultAPI) do(req *http.Request) (*http.Response, error) {
 	defer resp.Body.Close()
 
 	var body []byte
-	body, err = io.ReadAll(resp.Body)
+	body, err = io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +478,7 @@ func (api *DefaultAPI) NotificationCredentials(token, appUserID string) (Notific
 		return NotificationCredentialsResponse{}, fmt.Errorf("executing HTTP POST request: %w", err)
 	}
 	defer rawResp.Body.Close()
-	out, err := io.ReadAll(rawResp.Body)
+	out, err := io.ReadAll(io.LimitReader(rawResp.Body, ReaderLimit))
 	if err != nil {
 		return NotificationCredentialsResponse{}, fmt.Errorf("reading HTTP response body: %w", err)
 	}
@@ -520,7 +522,7 @@ func (api *DefaultAPI) NotificationCredentialsRevoke(token, appUserID string, pu
 		return NotificationCredentialsRevokeResponse{}, fmt.Errorf("executing HTTP POST request: %w", err)
 	}
 	defer rawResp.Body.Close()
-	out, err := io.ReadAll(rawResp.Body)
+	out, err := io.ReadAll(io.LimitReader(rawResp.Body, ReaderLimit))
 	if err != nil {
 		return NotificationCredentialsRevokeResponse{}, fmt.Errorf("reading HTTP response body: %w", err)
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -574,7 +574,7 @@ const maxBytesLimit int64 = 1024 * 1024 * 10 // 10MB
 func MaxBytesReadAll(r io.Reader) ([]byte, error) {
 	limitedReader := &io.LimitedReader{
 		R: r,
-		N: maxBytesLimit,
+		N: maxBytesLimit + 1, // + 1 because we allow for values which are equal to the limit
 	}
 	data, err := io.ReadAll(limitedReader)
 	if err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -589,7 +589,7 @@ func MaxBytesReadAll(r io.Reader) ([]byte, error) {
 		return nil, err
 	}
 	if limitedReader.N == 0 {
-		return nil, fmt.Errorf("input exceeded the max limit of %d bytes", maxBytesLimit)
+		return nil, &ErrMaxBytesLimit{Limit: maxBytesLimit}
 	}
 
 	return data, nil

--- a/core/core.go
+++ b/core/core.go
@@ -579,7 +579,7 @@ func MaxBytesReadAll(r io.Reader) ([]byte, error) {
 		return nil, err
 	}
 	if limitedReader.N == 0 {
-		return nil, fmt.Errorf("input exceeded the max limit")
+		return nil, fmt.Errorf("input exceeded the max limit of %d bytes", maxBytesLimit)
 	}
 
 	return data, nil

--- a/core/core.go
+++ b/core/core.go
@@ -588,6 +588,11 @@ func MaxBytesReadAll(r io.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// check whether the io.ReadAll() stopped because of EOF coming from io.Reader or because of the limit
+	//
+	// two cases can happen here:
+	// limit reached       - limitedReader.N <= 0
+	// io.Reader is empty  - limitedReader.N > 0
 	if limitedReader.N <= 0 {
 		return nil, &ErrMaxBytesLimit{Limit: maxBytesLimit}
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -588,7 +588,7 @@ func MaxBytesReadAll(r io.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if limitedReader.N == 0 {
+	if limitedReader.N <= 0 {
 		return nil, &ErrMaxBytesLimit{Limit: maxBytesLimit}
 	}
 

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -228,7 +228,6 @@ func TestDefaultAPI_ServiceCredentials(t *testing.T) {
 }
 
 func TestMaxBytes(t *testing.T) {
-
 	randomBytes := func(size int64) []byte {
 		data := make([]byte, size+1)
 		for i := int64(0); i < size; i++ {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -229,27 +229,37 @@ func TestDefaultAPI_ServiceCredentials(t *testing.T) {
 
 func TestMaxBytes(t *testing.T) {
 	randomBytes := func(size int64) []byte {
-		data := make([]byte, size+1)
-		for i := int64(0); i < size; i++ {
-			data[size] = byte(rand.Intn(255))
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte(rand.Intn(255))
 		}
 		return data
 	}
 
 	t.Run("too big input", func(t *testing.T) {
-		input := randomBytes(maxBytesLimit + 1024)
+		input := randomBytes(maxBytesLimit + 1)
 		rc := bytes.NewReader(input)
 		_, err := MaxBytesReadAll(rc)
 
 		assert.Error(t, err)
 	})
 
-	t.Run("input with okay size", func(t *testing.T) {
-		input := randomBytes(maxBytesLimit - 1024)
+	t.Run("input with size within limits", func(t *testing.T) {
+		input := randomBytes(maxBytesLimit - 1)
 		rc := bytes.NewReader(input)
 		output, err := MaxBytesReadAll(rc)
 
 		assert.Nil(t, err)
 		assert.Equal(t, input, output)
 	})
+
+	t.Run("input with exact limit size", func(t *testing.T) {
+		input := randomBytes(maxBytesLimit)
+		rc := bytes.NewReader(input)
+		output, err := MaxBytesReadAll(rc)
+
+		assert.Nil(t, err)
+		assert.Equal(t, input, output, "input and output should be equal")
+	})
+
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -256,5 +256,4 @@ func TestMaxBytes(t *testing.T) {
 	t.Run("input with exact limit size", func(t *testing.T) {
 		test(t, maxBytesLimit, nil)
 	})
-
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -223,4 +225,32 @@ func TestDefaultAPI_ServiceCredentials(t *testing.T) {
 			assert.True(t, errors.Is(err, test.err))
 		})
 	}
+}
+
+func TestMaxBytes(t *testing.T) {
+
+	randomBytes := func(size int64) []byte {
+		data := make([]byte, size+1)
+		for i := int64(0); i < size; i++ {
+			data[size] = byte(rand.Intn(255))
+		}
+		return data
+	}
+
+	t.Run("too big input", func(t *testing.T) {
+		input := randomBytes(maxBytesLimit + 1024)
+		rc := bytes.NewReader(input)
+		_, err := MaxBytesReadAll(rc)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("input with okay size", func(t *testing.T) {
+		input := randomBytes(maxBytesLimit - 1024)
+		rc := bytes.NewReader(input)
+		output, err := MaxBytesReadAll(rc)
+
+		assert.Nil(t, err)
+		assert.Equal(t, input, output)
+	})
 }

--- a/core/mesh.go
+++ b/core/mesh.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/netip"
 
@@ -132,7 +131,7 @@ func (api *DefaultAPI) Register(token string, peer mesh.Machine) (*mesh.Machine,
 	}
 
 	var raw mesh.MachineCreateResponse
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +282,7 @@ func (api *DefaultAPI) Local(token string) (mesh.Machines, error) {
 		return nil, err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +317,7 @@ func (api *DefaultAPI) Map(token string, self uuid.UUID) (*mesh.MachineMap, erro
 		return nil, err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +371,7 @@ func (api *DefaultAPI) List(token string, self uuid.UUID) (mesh.MachinePeers, er
 		return nil, err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +466,7 @@ func (api *DefaultAPI) Received(token string, self uuid.UUID) (mesh.Invitations,
 		return nil, err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +499,7 @@ func (api *DefaultAPI) Sent(token string, self uuid.UUID) (mesh.Invitations, err
 		return nil, err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
+	body, err := MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/core/mesh.go
+++ b/core/mesh.go
@@ -132,7 +132,7 @@ func (api *DefaultAPI) Register(token string, peer mesh.Machine) (*mesh.Machine,
 	}
 
 	var raw mesh.MachineCreateResponse
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +283,7 @@ func (api *DefaultAPI) Local(token string) (mesh.Machines, error) {
 		return nil, err
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +318,7 @@ func (api *DefaultAPI) Map(token string, self uuid.UUID) (*mesh.MachineMap, erro
 		return nil, err
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func (api *DefaultAPI) List(token string, self uuid.UUID) (mesh.MachinePeers, er
 		return nil, err
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +467,7 @@ func (api *DefaultAPI) Received(token string, self uuid.UUID) (mesh.Invitations,
 		return nil, err
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +500,7 @@ func (api *DefaultAPI) Sent(token string, self uuid.UUID) (mesh.Invitations, err
 		return nil, err
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ReaderLimit))
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/api_repo.go
+++ b/daemon/api_repo.go
@@ -57,7 +57,7 @@ func (api *RepoAPI) DebianFileList() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
+	body, err := core.MaxBytesReadAll(resp.Body)
 	if err != nil {
 		//log.Printf("DebianFileList failed to read fileinfo data. Error: %v.\n", err)
 		return nil, err
@@ -88,7 +88,7 @@ func (api *RepoAPI) RpmFileList() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
+	body, err := core.MaxBytesReadAll(resp.Body)
 	if err != nil {
 		//log.Printf("RpmFileList failed to read repomd data. Error: %v.\n", err)
 		return nil, err
@@ -104,7 +104,7 @@ func (api *RepoAPI) RpmFileList() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err = io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
+	body, err = core.MaxBytesReadAll(resp.Body)
 	if err != nil {
 		//log.Printf("RpmFileList failed to read fileinfo. Error: %v.\n", err)
 		return nil, err

--- a/daemon/api_repo.go
+++ b/daemon/api_repo.go
@@ -57,7 +57,7 @@ func (api *RepoAPI) DebianFileList() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
 	if err != nil {
 		//log.Printf("DebianFileList failed to read fileinfo data. Error: %v.\n", err)
 		return nil, err
@@ -88,7 +88,7 @@ func (api *RepoAPI) RpmFileList() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
 	if err != nil {
 		//log.Printf("RpmFileList failed to read repomd data. Error: %v.\n", err)
 		return nil, err
@@ -104,7 +104,7 @@ func (api *RepoAPI) RpmFileList() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err = io.ReadAll(resp.Body)
+	body, err = io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
 	if err != nil {
 		//log.Printf("RpmFileList failed to read fileinfo. Error: %v.\n", err)
 		return nil, err

--- a/pulp/pulp.go
+++ b/pulp/pulp.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -87,7 +86,7 @@ func Login(
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
+	data, err := core.MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}
@@ -209,7 +208,7 @@ func versions(
 		return nil, fmt.Errorf("post: %w", err)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
+	body, err := core.MaxBytesReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}

--- a/pulp/pulp.go
+++ b/pulp/pulp.go
@@ -12,6 +12,8 @@ import (
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/NordSecurity/nordvpn-linux/core"
 )
 
 const (
@@ -85,7 +87,7 @@ func Login(
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}

--- a/pulp/pulp.go
+++ b/pulp/pulp.go
@@ -209,7 +209,7 @@ func versions(
 		return nil, fmt.Errorf("post: %w", err)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, core.ReaderLimit))
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}


### PR DESCRIPTION
All occurences of `io.ReadAll()` now use `io.LimitReader()` before passing data to the former.
The limit for the reader has been set in [core.go](https://github.com/NordSecurity/nordvpn-linux/blob/a58ca400e7936c264438efa59413dbd455a85481/core/core.go#L24), after discussions the value has been set to `10MB`.


However, it is with some exceptions:
- [daemon/dns/hosts.go](https://github.com/NordSecurity/nordvpn-linux/blob/a58ca400e7936c264438efa59413dbd455a85481/daemon/dns/hosts.go#L88). Reading `/etc/hosts` should not be a subject to any attacks. As editing the file on it's own requires `root` access.
- [events/logger/logger.go NotifyRequestAPIVerbose()](https://github.com/NordSecurity/nordvpn-linux/blob/a58ca400e7936c264438efa59413dbd455a85481/events/logger/logger.go#L58). Marked as "Do not use in production builds"