### PR TITLE
Fix how is checked server obfuscated support

### DIFF
--- a/ci/docker/tester/requirements.txt
+++ b/ci/docker/tester/requirements.txt
@@ -1,6 +1,6 @@
 pytest==8.3.3
 # Used for running tests with --timeout flag
-pytest-timeout==2.0.1
+pytest-timeout==2.3.1
 requests==2.32.3
 sh==1.14.1
 paramiko==3.5.0

--- a/core/models.go
+++ b/core/models.go
@@ -349,7 +349,7 @@ func IsConnectableVia(tech ServerTechnology) Predicate {
 // IsObfuscated returns a filter for keeping only obfuscated servers.
 func IsObfuscated() Predicate {
 	return func(s Server) bool {
-		return IsConnectableVia(OpenVPNUDPObfuscated)(s) &&
+		return IsConnectableVia(OpenVPNUDPObfuscated)(s) ||
 			IsConnectableVia(OpenVPNTCPObfuscated)(s)
 	}
 }

--- a/core/models_test.go
+++ b/core/models_test.go
@@ -378,7 +378,7 @@ func TestIsObfuscated(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "not obfuscated online technology with online server",

--- a/daemon/rpc_servers_test.go
+++ b/daemon/rpc_servers_test.go
@@ -212,10 +212,6 @@ func TestServers(t *testing.T) {
 			false,
 			core.Groups{
 				{
-					ID:    config.ServerGroup_OBFUSCATED,
-					Title: "Standard VPN",
-				},
-				{
 					ID:    config.ServerGroup_STANDARD_VPN_SERVERS,
 					Title: "Standard VPN",
 				},
@@ -231,7 +227,6 @@ func TestServers(t *testing.T) {
 			[]core.ServerTechnology{
 				core.L2TP,
 				core.HTTPProxy,
-				core.OpenVPNTCPObfuscated,
 				core.OpenVPNTCP,
 				core.WireguardTech,
 			}),
@@ -325,9 +320,8 @@ func TestServers(t *testing.T) {
 		Id:           int64(server3ID),
 		HostName:     server3Hostname,
 		Virtual:      false,
-		ServerGroups: []config.ServerGroup{config.ServerGroup_OBFUSCATED, config.ServerGroup_STANDARD_VPN_SERVERS},
+		ServerGroups: []config.ServerGroup{config.ServerGroup_STANDARD_VPN_SERVERS},
 		Technologies: []pb.Technology{
-			pb.Technology_OBFUSCATED_OPENVPN_TCP,
 			pb.Technology_OPENVPN_TCP,
 			pb.Technology_NORDLYNX,
 		},
@@ -385,9 +379,8 @@ func TestServers(t *testing.T) {
 			Id:           int64(server3ID),
 			HostName:     server3Hostname,
 			Virtual:      false,
-			ServerGroups: []config.ServerGroup{config.ServerGroup_OBFUSCATED, config.ServerGroup_STANDARD_VPN_SERVERS},
+			ServerGroups: []config.ServerGroup{config.ServerGroup_STANDARD_VPN_SERVERS},
 			Technologies: []pb.Technology{
-				pb.Technology_OBFUSCATED_OPENVPN_TCP,
 				pb.Technology_OPENVPN_TCP,
 				pb.Technology_NORDLYNX,
 			},

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -23,7 +23,7 @@ const (
 	imageSnapPackager      = registryPrefix + "snaper:0.0.4"
 	imageProtobufGenerator = registryPrefix + "generator:1.4.1"
 	imageScanner           = registryPrefix + "scanner:1.1.0"
-	imageTester            = registryPrefix + "tester:1.3.1"
+	imageTester            = registryPrefix + "tester:1.3.2"
 	imageQAPeer            = registryPrefix + "qa-peer:1.0.4"
 	imageRuster            = registryPrefix + "ruster:1.3.0"
 

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -377,11 +377,11 @@ def test_status_connected(tech, proto, obfuscated):
 
     connect_time = time.monotonic()
 
-    time.sleep(15)
+    time.sleep(5)
     sh.ping("-c", "1", "-w", "1", "1.1.1.1")
 
-    status_time = time.monotonic()
     status_info = daemon.get_status_data()
+    status_time = time.monotonic()
 
     print("status_info: " + str(status_info))
     print("actual_status: " + str(sh.nordvpn.status()))

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -157,11 +157,11 @@ def test_route_to_peer_status_valid():
 
     connect_time = time.monotonic()
 
-    time.sleep(15)
+    time.sleep(5)
     sh.ping("-c", "1", "-w", "1", "103.86.96.100")
 
-    status_time = time.monotonic()
     status_output = sh.nordvpn.status().lstrip("\r -")
+    status_time = time.monotonic()
 
     # Split the data into lines, filter out lines that don't contain ':',
     # split each line into key-value pairs, strip whitespace, and convert keys to lowercase


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* If a server supports one of the obfuscated protocols, TCP or UDP, then it is considered to be obfuscated. Because there can be servers that support only one protocol.
* Increase pytest-timeout to 2.3.1 to fix dependencies errors.
* Use tester image 1.3.2.