### PR TITLE
Improve fileshare monitoring job

### DIFF
--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -36,6 +36,7 @@ func (failingLoginChecker) IsMFAEnabled() (bool, error) { return false, nil }
 func (failingLoginChecker) IsVPNExpired() (bool, error) {
 	return true, errors.New("IsVPNExpired error")
 }
+
 func (failingLoginChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
@@ -128,6 +129,10 @@ func (n *meshNetworker) AllowFileshare(address meshnet.UniqueAddress) error {
 	return nil
 }
 
+func (n *meshNetworker) PermitFileshare() error {
+	return nil
+}
+
 func (n *meshNetworker) AllowIncoming(address meshnet.UniqueAddress, lanAllowed bool) error {
 	n.allowedIncoming = append(n.allowedIncoming, address)
 	return nil
@@ -135,6 +140,10 @@ func (n *meshNetworker) AllowIncoming(address meshnet.UniqueAddress, lanAllowed 
 
 func (n *meshNetworker) BlockIncoming(address meshnet.UniqueAddress) error {
 	n.blockedIncoming = append(n.blockedIncoming, address)
+	return nil
+}
+
+func (n *meshNetworker) ForbidFileshare() error {
 	return nil
 }
 

--- a/meshnet/jobs.go
+++ b/meshnet/jobs.go
@@ -15,7 +15,7 @@ func (s *Server) StartJobs() {
 	}
 
 	if _, err := s.scheduler.NewJob(
-		gocron.DurationJob(500*time.Millisecond),
+		gocron.DurationJob(1*time.Second),
 		gocron.NewTask(JobMonitorFileshareProcess(s)),
 		gocron.WithName("job monitor fileshare process")); err != nil {
 		log.Println(internal.WarningPrefix, "job monitor fileshare process schedule error:", err)

--- a/meshnet/jobs.go
+++ b/meshnet/jobs.go
@@ -15,7 +15,7 @@ func (s *Server) StartJobs() {
 	}
 
 	if _, err := s.scheduler.NewJob(
-		gocron.DurationJob(5*time.Second),
+		gocron.DurationJob(500*time.Millisecond),
 		gocron.NewTask(JobMonitorFileshareProcess(s)),
 		gocron.WithName("job monitor fileshare process")); err != nil {
 		log.Println(internal.WarningPrefix, "job monitor fileshare process schedule error:", err)
@@ -39,32 +39,16 @@ func JobRefreshMeshnet(s *Server) func() error {
 }
 
 func JobMonitorFileshareProcess(s *Server) func() error {
-	oldState := false
 	return func() error {
 		if !s.isMeshOn() {
 			return nil
 		}
-		newState := internal.IsProcessRunning(internal.FileshareBinaryPath)
-		if newState == oldState {
-			// only state change triggers the modifications
-			return nil
-		}
 
-		log.Println(internal.InfoPrefix, "fileshare change to running", newState)
-		peers, err := s.listPeers()
-		if err != nil {
-			return err
+		if internal.IsProcessRunning(internal.FileshareBinaryPath) {
+			s.netw.PermitFileshare()
+		} else {
+			s.netw.ForbidFileshare()
 		}
-
-		isFileshareUp := newState
-		for _, peer := range peers {
-			if !isFileshareUp {
-				s.netw.BlockFileshare(UniqueAddress{UID: peer.PublicKey, Address: peer.Address})
-			} else {
-				s.netw.AllowFileshare(UniqueAddress{UID: peer.PublicKey, Address: peer.Address})
-			}
-		}
-		oldState = newState
 
 		return nil
 	}

--- a/meshnet/jobs.go
+++ b/meshnet/jobs.go
@@ -39,15 +39,23 @@ func JobRefreshMeshnet(s *Server) func() error {
 }
 
 func JobMonitorFileshareProcess(s *Server) func() error {
+	isFileshareAllowed := false
 	return func() error {
 		if !s.isMeshOn() {
+			if isFileshareAllowed {
+				if err := s.netw.ForbidFileshare(); err == nil {
+					isFileshareAllowed = false
+				}
+			}
 			return nil
 		}
 
 		if internal.IsProcessRunning(internal.FileshareBinaryPath) {
 			s.netw.PermitFileshare()
+			isFileshareAllowed = true
 		} else {
 			s.netw.ForbidFileshare()
+			isFileshareAllowed = false
 		}
 
 		return nil

--- a/meshnet/jobs_test.go
+++ b/meshnet/jobs_test.go
@@ -1,0 +1,126 @@
+package meshnet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobMonitorFileshare(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name                        string
+		isFileshareInitiallyAllowed bool
+		meshChecker                 meshChecker
+		processChecker              processChecker
+		wasForbidCalled             bool
+		wasPermitCalled             bool
+		shouldRulesChangeFail       bool
+		isFileshareFinallyAllowed   bool
+	}{
+		{
+			name:                        "nothing happens with disabled meshnet",
+			meshChecker:                 meshCheckerStub{isMeshnetOn: false},
+			wasForbidCalled:             false,
+			wasPermitCalled:             false,
+			isFileshareInitiallyAllowed: false,
+			isFileshareFinallyAllowed:   false,
+		},
+		{
+			name:                        "fileshare is allowed when meshnet is on and process is running",
+			meshChecker:                 meshCheckerStub{isMeshnetOn: true},
+			processChecker:              processCheckerStub{isFileshareUp: true},
+			wasForbidCalled:             false,
+			wasPermitCalled:             true,
+			isFileshareInitiallyAllowed: false,
+			isFileshareFinallyAllowed:   true,
+		},
+		{
+			name:                        "fileshare is forbidden when meshnet is on process was stopped",
+			meshChecker:                 meshCheckerStub{isMeshnetOn: true},
+			processChecker:              processCheckerStub{isFileshareUp: false},
+			wasForbidCalled:             true,
+			wasPermitCalled:             false,
+			isFileshareInitiallyAllowed: true,
+			isFileshareFinallyAllowed:   false,
+		},
+		{
+			name:                        "when mesh is off, but fileshare was allowed in previous run, now it gets blocked",
+			meshChecker:                 meshCheckerStub{isMeshnetOn: false},
+			wasForbidCalled:             true,
+			wasPermitCalled:             false,
+			isFileshareInitiallyAllowed: true,
+			isFileshareFinallyAllowed:   false,
+		},
+		{
+			name:                        "when mesh is off, fileshare was allowed in previous run, the state does not change until block succeeds",
+			meshChecker:                 meshCheckerStub{isMeshnetOn: false},
+			wasForbidCalled:             true,
+			wasPermitCalled:             false,
+			shouldRulesChangeFail:       true,
+			isFileshareInitiallyAllowed: true,
+			isFileshareFinallyAllowed:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		rulesController := rulesControllerSpy{shouldFail: tt.shouldRulesChangeFail}
+		job := monitorFileshareProcessJob{
+			isFileshareAllowed: tt.isFileshareInitiallyAllowed,
+			meshChecker:        tt.meshChecker,
+			rulesController:    &rulesController,
+			processChecker:     tt.processChecker,
+		}
+		assert.Equal(t, tt.isFileshareInitiallyAllowed, job.isFileshareAllowed)
+		assert.False(t, rulesController.wasForbidCalled)
+		assert.False(t, rulesController.wasPermitCalled)
+
+		err := job.run()
+
+		assert.Nil(t, err)
+		assert.Equal(t, tt.isFileshareFinallyAllowed, job.isFileshareAllowed)
+		assert.Equal(t, tt.wasForbidCalled, rulesController.wasForbidCalled)
+		assert.Equal(t, tt.wasPermitCalled, rulesController.wasPermitCalled)
+	}
+}
+
+type meshCheckerStub struct {
+	isMeshnetOn bool
+}
+
+func (m meshCheckerStub) isMeshOn() bool {
+	return m.isMeshnetOn
+}
+
+type rulesControllerSpy struct {
+	wasForbidCalled bool
+	wasPermitCalled bool
+	shouldFail      bool
+}
+
+func (rc *rulesControllerSpy) ForbidFileshare() error {
+	rc.wasForbidCalled = true
+	if rc.shouldFail {
+		return errors.New("intentional failure for testing")
+	}
+	return nil
+}
+
+func (rc *rulesControllerSpy) PermitFileshare() error {
+	rc.wasPermitCalled = true
+	if rc.shouldFail {
+		return errors.New("intentional failure for testing")
+	}
+	return nil
+}
+
+type processCheckerStub struct {
+	isFileshareUp bool
+}
+
+func (m processCheckerStub) isFileshareRunning() bool {
+	return m.isFileshareUp
+}

--- a/meshnet/networker.go
+++ b/meshnet/networker.go
@@ -28,8 +28,12 @@ type Networker interface {
 	BlockIncoming(UniqueAddress) error
 	// AllowFileshare creates a rule enabling fileshare port for the given address
 	AllowFileshare(UniqueAddress) error
+	// PermitFileshare creates a rules enabling fileshare port for all available peers and sets fileshare as permitted
+	PermitFileshare() error
 	// BlockFileshare removes a rule enabling fileshare port for the given address if it exists
 	BlockFileshare(UniqueAddress) error
+	// ForbidFileshare removes a rules enabling fileshare port for all available peers and sets fileshare as forbidden
+	ForbidFileshare() error
 	// ResetRouting is used when there are routing setting changes,
 	// except when routing is denied - then BlockRouting must be used. changedPeer is the peer whose routing settings
 	// changed, peers is the map of all the machine peers(including the changed peer).

--- a/meshnet/server_test.go
+++ b/meshnet/server_test.go
@@ -44,6 +44,7 @@ type meshRenewChecker struct {
 func (m meshRenewChecker) IsLoggedIn() bool {
 	return !m.IsNotLoggedIn
 }
+
 func (m meshRenewChecker) IsMFAEnabled() (bool, error) {
 	return false, nil
 }
@@ -92,6 +93,10 @@ func (n *workingNetworker) AllowFileshare(address UniqueAddress) error {
 	return nil
 }
 
+func (n *workingNetworker) PermitFileshare() error {
+	return nil
+}
+
 func (n *workingNetworker) AllowIncoming(address UniqueAddress, lanAllowed bool) error {
 	n.allowedIncoming = append(n.allowedIncoming, allowedIncoming{
 		address:    address,
@@ -108,6 +113,10 @@ func (n *workingNetworker) BlockIncoming(address UniqueAddress) error {
 
 func (n *workingNetworker) BlockFileshare(address UniqueAddress) error {
 	n.blockedFileshare = append(n.blockedFileshare, address)
+	return nil
+}
+
+func (n *workingNetworker) ForbidFileshare() error {
 	return nil
 }
 

--- a/networker/networker_test.go
+++ b/networker/networker_test.go
@@ -1872,7 +1872,19 @@ func TestCombined_Refresh(t *testing.T) {
 	for _, rule := range fw.rules {
 		ruleNames = append(ruleNames, rule.Name)
 	}
-	assert.Equal(t, 6, len(fw.rules), "%d firewall rules were configured, expected 5, rules content: \n%s",
+
+	// fileshare is forbidden here, so no new fileshare rules were added
+	assert.Equal(t, 5, len(fw.rules), "%d firewall rules were configured, expected 5, rules content: \n%s",
+		len(fw.rules),
+		strings.Join(ruleNames, "\n"))
+
+	// permit fileshare
+	netw.isFilesharePermitted = true
+
+	netw.Refresh(machineMap)
+
+	// now after refresh, fileshare rules are also added
+	assert.Equal(t, 6, len(fw.rules), "%d firewall rules were configured, expected 6, rules content: \n%s",
 		len(fw.rules),
 		strings.Join(ruleNames, "\n"))
 

--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -375,16 +375,18 @@ class FileSystemEntity(Enum):
 
 
 def bind_port() -> socket.socket | None:
-    try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
-        sock.bind(('0.0.0.0', 49111))
-        sock.listen(1)
-        print("Successfully bound to fileshare port")
-        return sock
-    except OSError as e:
-        print(f"Failed to bind to fileshare port: {e}")
-        return None
+    for _ in range(3):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+            sock.bind(('0.0.0.0', 49111))
+            sock.listen(1)
+            logging.log("successfully bound to fileshare port")
+            return sock
+        except OSError as e:
+            logging.log(f"failed to bind to fileshare port: {e}")
+        time.sleep(1)
+    return None
 
 
 def port_is_allowed() -> bool:

--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -380,9 +380,9 @@ def bind_port():
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
         sock.bind(('0.0.0.0', 49111))
         sock.listen(1)
-        print(f"Successfully bound to fileshare port")
+        print("Successfully bound to fileshare port")
         return sock
-    except socket.error as e:
+    except OSError as e:
         print(f"Failed to bind to fileshare port: {e}")
         return None
 

--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -8,6 +8,8 @@ from threading import Thread
 
 import pytest
 import sh
+import socket
+import os
 
 from . import FILE_HASH_UTILITY, logging, ssh
 
@@ -370,3 +372,21 @@ class FileSystemEntity(Enum):
 
     def __str__(self):
         return self.value
+
+
+def bind_port():
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+        sock.bind(('0.0.0.0', 49111))
+        sock.listen(1)
+        print(f"Successfully bound to fileshare port")
+        return sock
+    except socket.error as e:
+        print(f"Failed to bind to fileshare port: {e}")
+        return None
+
+
+def port_is_allowed() -> bool:
+    rules = os.popen("sudo iptables -S").read()
+    return "49111 -m comment --comment nordvpn-meshnet -j ACCEPT" in rules

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1353,9 +1353,9 @@ def test_fileshare_process_monitoring():
     assert "49111 -m comment --comment nordvpn-meshnet -j ACCEPT" in rules
 
     sh.pkill("-SIGKILL", "nordfileshare")
-    # at the time of writing, the monitoring job is executed periodically every 5 seconds,
-    # wait for 10 to be sure the job executed
-    time.sleep(10)
+    # at the time of writing, the monitoring job is executed periodically every 500 milliseconds,
+    # wait for 1 second to be sure the job executed
+    time.sleep(1)
 
     # port is not allowed when fileshare is down
     rules = os.popen("sudo iptables -S").read()

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1369,6 +1369,7 @@ def test_fileshare_process_monitoring_manages_fileshare_rules_on_process_state_c
         fileshare.ensure_mesh_is_on()
 
 
+@pytest.mark.skip(reason="LVPN-6691")
 def test_fileshare_process_monitoring_cuts_the_port_access_even_when_it_was_taken_before():
     try:
         # stop meshnet to bind to 49111 first

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1347,26 +1347,51 @@ def test_clear():
     assert len(lines_outgoing) == 3, str(lines_outgoing)
 
 
-def test_fileshare_process_monitoring():
+def test_fileshare_process_monitoring_manages_fileshare_rules_on_process_state_changes():
     # port is open when fileshare is running
-    rules = os.popen("sudo iptables -S").read()
-    assert "49111 -m comment --comment nordvpn-meshnet -j ACCEPT" in rules
+    assert fileshare.port_is_allowed()
 
     sh.pkill("-SIGKILL", "nordfileshare")
-    # at the time of writing, the monitoring job is executed periodically every 500 milliseconds,
-    # wait for 1 second to be sure the job executed
-    time.sleep(1)
+    # at the time of writing, the monitoring job is executed periodically every second,
+    # wait for 2 seconds to be sure the job executed
+    time.sleep(2)
 
     # port is not allowed when fileshare is down
-    rules = os.popen("sudo iptables -S").read()
-    assert "49111 -m comment --comment nordvpn-meshnet -j ACCEPT" not in rules
+    assert not fileshare.port_is_allowed()
 
     os.popen("/usr/lib/nordvpn/nordfileshare &")
-    time.sleep(10)
+    time.sleep(2)
+    # port is allowed again when fileshare process is up
+    assert fileshare.port_is_allowed()
+
+
+def test_fileshare_process_monitoring_cuts_the_port_access_even_when_it_was_taken_before():
+    # stop meshnet to bind to 49111 first
+    sh.nordvpn.set.meshnet.off()
+
+    # no meshnet - no port
+    assert not fileshare.port_is_allowed()
+
+    # bind to port before fileshare process starts
+    sock = fileshare.bind_port()
+    assert sock is not None
+
+    # start meshnet
+    sh.nordvpn.set.meshnet.on() # now fileshare tries to start but fails because the port is taken
+    time.sleep(2)
+
+    # port should not be allowed (fileshare is down)
+    assert not fileshare.port_is_allowed()
+
+    # free the port
+    sock.close()
+
+    # now fileshare can start properly
+    os.popen("/usr/lib/nordvpn/nordfileshare &")
+    time.sleep(2)
 
     # port is allowed again when fileshare process is up
-    rules = os.popen("sudo iptables -S").read()
-    assert "49111 -m comment --comment nordvpn-meshnet -j ACCEPT" in rules
+    assert fileshare.port_is_allowed()
 
 
 @pytest.mark.parametrize("background_accept", [True, False], ids=["accept_bg", "accept_int"])

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1373,6 +1373,7 @@ def test_fileshare_process_monitoring_cuts_the_port_access_even_when_it_was_take
     try:
         # stop meshnet to bind to 49111 first
         sh.nordvpn.set.meshnet.off()
+        time.sleep(2)
         assert fileshare.port_is_blocked()
 
         # bind to port before fileshare process starts


### PR DESCRIPTION
Changes:
- no API call for meshnet peers - it uses `MachineMap` now to get peers
- job reacts all the time (not only when it detects process state change) - this prevents the corner case of binding to port early and then enabling meshnet to open the port on firewall
- networker blocks fileshare for all attempts to add the rules (see `netw.isFilesharePermitted`) as long as the process is down
- job runs every second instead of 5s