### PR TITLE
Add test for error payment status

### DIFF
--- a/events/moose/moose_test.go
+++ b/events/moose/moose_test.go
@@ -22,6 +22,7 @@ func TestIsPaymentValid(t *testing.T) {
 		{name: "empty payment", valid: false},
 		{name: "invalid status", valid: false, payment: core.Payment{Status: "invalid"}},
 		{name: "done status", valid: true, payment: core.Payment{Status: "done"}},
+		{name: "error status", valid: false, payment: core.Payment{Status: "error"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

If the payment status is "error" then consider it invalid.