### PR TITLE
Fix service restart after adding plug

### DIFF
--- a/snap/hooks/connect-plug-firewall-control
+++ b/snap/hooks/connect-plug-firewall-control
@@ -1,4 +1,10 @@
 #!/bin/sh
-if [ "$(cat ${SNAP_COMMON}/connections/firewall-control 2> /dev/null)" -ne "1" ]; then
-	snapctl restart nordvpn.nordvpnd
+
+INTERFACE_NAME="firewall-control"
+
+if snapctl is-connected ${INTERFACE_NAME}; then
+  echo "The ${INTERFACE_NAME} interface is connected. Restarting the Snap container..."
+  snapctl restart nordvpn.nordvpnd
+else
+  echo "The ${INTERFACE_NAME} interface is not connected."
 fi

--- a/snap/hooks/connect-plug-hardware-observe
+++ b/snap/hooks/connect-plug-hardware-observe
@@ -1,6 +1,10 @@
 #!/bin/sh
-echo "==============================                       calling the hook"
-echo "==============================                       calling the hook" >/tmp/calllog
-if [ "$(cat ${SNAP_COMMON}/connections/hardware-observe 2>/dev/null)" -ne "1" ]; then
+
+INTERFACE_NAME="hardware-observe"
+
+if snapctl is-connected ${INTERFACE_NAME}; then
+  echo "The ${INTERFACE_NAME} interface is connected. Restarting the Snap container..."
   snapctl restart nordvpn.nordvpnd
+else
+  echo "The ${INTERFACE_NAME} interface is not connected."
 fi

--- a/snap/hooks/connect-plug-hardware-observe
+++ b/snap/hooks/connect-plug-hardware-observe
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo "==============================                       calling the hook"
+echo "==============================                       calling the hook" >/tmp/calllog
+if [ "$(cat ${SNAP_COMMON}/connections/hardware-observe 2>/dev/null)" -ne "1" ]; then
+  snapctl restart nordvpn.nordvpnd
+fi

--- a/snap/hooks/connect-plug-network-control
+++ b/snap/hooks/connect-plug-network-control
@@ -1,4 +1,10 @@
 #!/bin/sh
-if [ "$(cat ${SNAP_COMMON}/connections/network-control 2> /dev/null)" -ne "1" ]; then
-	snapctl restart nordvpn.nordvpnd
+
+INTERFACE_NAME="network-control"
+
+if snapctl is-connected ${INTERFACE_NAME}; then
+  echo "The ${INTERFACE_NAME} interface is connected. Restarting the Snap container..."
+  snapctl restart nordvpn.nordvpnd
+else
+  echo "The ${INTERFACE_NAME} interface is not connected."
 fi

--- a/snapconf/snapconf.go
+++ b/snapconf/snapconf.go
@@ -30,6 +30,9 @@ const (
 // https://snapcraft.io/docs/supported-interfaces
 type Interface string
 
+// NOTE: Some of the interfaces require restart of the service. This is achieved
+// by using snap hooks see snap/hooks directory.
+// For more information see the docs: https://snapcraft.io/docs/interface-hooks.
 const (
 	InterfaceNetwork             Interface = "network"
 	InterfaceNetworkBind         Interface = "network-bind"
@@ -60,8 +63,6 @@ type ConnChecker struct {
 
 // NewSnapChecker snap permission checker with specific setup
 func NewSnapChecker(publisherErr events.Publisher[error]) *ConnChecker {
-	// currently the order is important for machine ID generation:
-	// At the moment InterfaceHardwareObserve needs to be first because snap restarts the daemon only for some of the interfaces.
 	return NewConnChecker(
 		[]Interface{
 			InterfaceHardwareObserve,


### PR DESCRIPTION
Changes:
- new hook for hardware-observe interface to restart the service
- updated the old hooks - looks like ../connections/.. directory is not managed by snap, there are appropriate files in the directory for firewall-control and network-control, but it's not working for other hooks, so this PR changes the method of verifying if the interface is connected