### PR TITLE
Add dpkg-dev to tester

### DIFF
--- a/ci/docker/tester/Dockerfile
+++ b/ci/docker/tester/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update && \
         # install python for tests
         python3 python3-pip \
         # install tshark  \
-        tshark && \
+        tshark \
+        # changelog parsing
+        dpkg-dev && \
     # make sure, that Docker does not hang during installation, when we get TUI screen
     yes yes | DEBIAN_FRONTEND=teletype dpkg-reconfigure wireshark-common && \
     # cleanup

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -23,7 +23,7 @@ const (
 	imageSnapPackager      = registryPrefix + "snaper:0.0.4"
 	imageProtobufGenerator = registryPrefix + "generator:1.4.1"
 	imageScanner           = registryPrefix + "scanner:1.1.0"
-	imageTester            = registryPrefix + "tester:1.3.2"
+	imageTester            = registryPrefix + "tester:1.3.4"
 	imageQAPeer            = registryPrefix + "qa-peer:1.0.4"
 	imageRuster            = registryPrefix + "ruster:1.3.1"
 

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -334,6 +334,22 @@ def get_virtual_countries() -> list[str]:
 
     return countries
 
+class CommandExecutor:
+    def __init__(self, ssh_client = None):
+        self.ssh_client = ssh_client
+    def __call__(self, command: str):
+        """
+        Executes `command` locally, if `ssh_client` parameter was not provided to constructor.
+
+        Otherwise, `command` is executed on a remote SSH client.
+        """
+        if not isinstance(command, str):
+            msg = f"Expected a string, got {type(command).__name__}"
+            raise TypeError(msg)
+        if self.ssh_client is None:
+            return sh.Command(command.split()[0])(*command.split()[1:], tty_out=False)
+        return self.ssh_client.exec_command(command)
+
 def technology_to_upper_camel_case(tech: str) -> str:
     match tech.upper():
         case "NORDLYNX":


### PR DESCRIPTION
Needed for Python tests, as we want to use `dpkg-parsechangelog` tool.