### PR TITLE
Set version for tunnelblick patches to version v6.0beta09

### DIFF
--- a/ci/openvpn/check_dependencies.sh
+++ b/ci/openvpn/check_dependencies.sh
@@ -5,8 +5,7 @@ source "${WORKDIR}/ci/openvpn/env.sh"
 
 openvpn_tarbal_dir="${WORKDIR}/build/openvpn/tarballs"
 
-tunnelblick_sha256sum="ea4e810e15c963a53fe3625cf37e078ed118b9a6879d92ce9a01c3395c9aad42"
-tunnelblick_url="https://github.com/Tunnelblick/Tunnelblick/raw/master/third_party/sources"
+tunnelblick_url="https://github.com/Tunnelblick/Tunnelblick/raw/refs/tags/${TUNNELBLICK_TAG}/third_party/sources"
 
 mkdir -p "${openvpn_tarbal_dir}"
 pushd "${openvpn_tarbal_dir}"
@@ -31,5 +30,5 @@ pushd "${openvpn_patches_dir}"
 	wget -nv -nc "${tunnelblick_url}/openvpn/openvpn-${OPENVPN_VERSION}/patches/04-tunnelblick-openvpn_xorpatch-c.diff"
 	wget -nv -nc "${tunnelblick_url}/openvpn/openvpn-${OPENVPN_VERSION}/patches/05-tunnelblick-openvpn_xorpatch-d.diff"
 	wget -nv -nc "${tunnelblick_url}/openvpn/openvpn-${OPENVPN_VERSION}/patches/06-tunnelblick-openvpn_xorpatch-e.diff"
-	[[ "$(sha256sum <<< "$(cat ./*diff)" | awk $'{print $1}')" == "${tunnelblick_sha256sum}" ]] || exit 1
+	[[ "$(sha256sum <<< "$(cat ./*diff)" | awk $'{print $1}')" == "${TUNNELBLICK_SHA256SUM}" ]] || exit 1
 popd

--- a/ci/openvpn/env.sh
+++ b/ci/openvpn/env.sh
@@ -2,10 +2,17 @@
 
 set -euxo pipefail
 
+# This needs to be in sync with TUNNELBLICK_TAG
 OPENVPN_VERSION="2.6.12"
 export OPENVPN_VERSION
 OPENVPN_SHA256SUM="1c610fddeb686e34f1367c347e027e418e07523a10f4d8ce4a2c2af2f61a1929"
 export OPENVPN_SHA256SUM
+
+# Used to download the patches for OpenVPN obfuscation. This needs to be in sync with OPENVPN_VERSION.
+TUNNELBLICK_TAG="v6.0beta09" # it is a beta tag, because no other non-beta still has version 2.6.12
+export TUNNELBLICK_TAG
+TUNNELBLICK_SHA256SUM="ea4e810e15c963a53fe3625cf37e078ed118b9a6879d92ce9a01c3395c9aad42"
+export TUNNELBLICK_SHA256SUM
 
 OPENSSL_VERSION="3.0.14"
 export OPENSSL_VERSION


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

The patches for OpenVPN 2.6.12 were removed from master and other tags. The last tag containing the patches is v6.0beta09.