### PR TITLE
Include specialty servers in servers list respose

### DIFF
--- a/daemon/data_manager.go
+++ b/daemon/data_manager.go
@@ -136,9 +136,14 @@ func (dm *DataManager) SetServersData(updatedAt time.Time, servers core.Servers,
 	}()
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
-	dm.serversData.UpdatedAt = updatedAt
-	dm.serversData.Servers = servers
-	dm.serversData.Hash = hash
+	// Replace entire object to prevent race, because only the ServerData object is protected by the lock
+	// Using members outside could case race conditions, if in the same time they are replaced
+	dm.serversData = ServersData{
+		UpdatedAt: updatedAt,
+		Servers:   servers,
+		Hash:      hash,
+		filePath:  dm.serversData.filePath,
+	}
 	return dm.serversData.save()
 }
 

--- a/daemon/rpc_servers.go
+++ b/daemon/rpc_servers.go
@@ -121,7 +121,7 @@ func (r *RPC) GetServers(ctx context.Context, in *pb.Empty) (*pb.ServersResponse
 			(core.IsObfuscated()(s) == cfg.AutoConnectData.Obfuscate)
 	})
 
-	if err != nil {
+	if len(servers) == 0 {
 		log.Println(internal.ErrorPrefix, "filtering servers", err)
 		return &pb.ServersResponse{Response: &pb.ServersResponse_Error{
 			Error: pb.ServersError_FILTER_SERVERS_ERROR,

--- a/daemon/rpc_servers_test.go
+++ b/daemon/rpc_servers_test.go
@@ -446,7 +446,7 @@ func TestServers(t *testing.T) {
 		},
 		{
 			name:        "failure because of filter error",
-			serversList: core.Servers{}, // servers will return an error because it will fails to find available servers
+			serversList: core.Servers{}, // servers will return an error because it fails to find available servers
 			expectedResponse: &pb.ServersResponse{
 				Response: &pb.ServersResponse_Error{
 					Error: pb.ServersError_FILTER_SERVERS_ERROR,

--- a/daemon/rpc_servers_test.go
+++ b/daemon/rpc_servers_test.go
@@ -446,7 +446,7 @@ func TestServers(t *testing.T) {
 		},
 		{
 			name:        "failure because of filter error",
-			serversList: core.Servers{}, // servers will retrun an error because it will fails to find available servers
+			serversList: core.Servers{}, // servers will return an error because it will fails to find available servers
 			expectedResponse: &pb.ServersResponse{
 				Response: &pb.ServersResponse_Error{
 					Error: pb.ServersError_FILTER_SERVERS_ERROR,
@@ -465,7 +465,7 @@ func TestServers(t *testing.T) {
 			cfgManager.Cfg.AutoConnectData.Protocol = test.protocol
 
 			dm := DataManager{}
-			dm.serversData.Servers = servers
+			dm.serversData.Servers = test.serversList
 			r := RPC{dm: &dm, cm: cfgManager}
 
 			resp, err := r.GetServers(context.Background(), &pb.Empty{})


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* Include Double VPN and Onion over VPN servers into the list.
* To prevent possible race condition on the members of ServersData, when data is changed from DataManager the entire object is replaced instead of only the members.