### PR TITLE
Increase usage of newMockedServer in meshnet tests

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -473,7 +473,6 @@ func main() {
 		notificationClient,
 		analytics,
 		norduserService,
-		meshAPIex,
 		statePublisher,
 		sharedContext,
 		rcConfig,

--- a/core/mesh.go
+++ b/core/mesh.go
@@ -262,42 +262,6 @@ func peersResponseToLocalPeers(rawPeers []mesh.MachinePeerResponse) []mesh.Machi
 	return peers
 }
 
-// Local peer list.
-func (api *DefaultAPI) Local(token string) (mesh.Machines, error) {
-	api.mu.Lock()
-	defer api.mu.Unlock()
-
-	resp, err := api.request(
-		urlMeshMachines,
-		http.MethodGet,
-		nil,
-		token,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := ExtractError(resp); err != nil {
-		return nil, err
-	}
-
-	body, err := MaxBytesReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var rawPeers []mesh.MachinePeerResponse
-	err = json.Unmarshal(body, &rawPeers)
-	if err != nil {
-		return nil, err
-	}
-
-	peers := peersResponseToLocalPeers(rawPeers)
-
-	return peers, nil
-}
-
 func (api *DefaultAPI) Map(token string, self uuid.UUID) (*mesh.MachineMap, error) {
 	api.mu.Lock()
 	defer api.mu.Unlock()

--- a/core/mesh/mesh.go
+++ b/core/mesh/mesh.go
@@ -20,8 +20,6 @@ type Registry interface {
 	) error
 	// Unregister Peer from the mesh network.
 	Unregister(token string, self uuid.UUID) error
-	// Local peers owned the same user.
-	Local(token string) (Machines, error)
 	// List given peer's neighbours in the mesh network.
 	List(token string, self uuid.UUID) (MachinePeers, error)
 	Map(token string, self uuid.UUID) (*MachineMap, error)

--- a/daemon/mocks_test.go
+++ b/daemon/mocks_test.go
@@ -53,7 +53,6 @@ type RegistryMock struct {
 	listErr      error
 	peers        mesh.MachinePeers
 	configureErr error
-	localPeers   mesh.Machines
 }
 
 func (*RegistryMock) Register(token string, self mesh.Machine) (*mesh.Machine, error) {
@@ -68,9 +67,6 @@ func (r *RegistryMock) Configure(string, uuid.UUID, uuid.UUID, mesh.PeerUpdateRe
 }
 
 func (*RegistryMock) Unregister(token string, self uuid.UUID) error { return nil }
-func (r *RegistryMock) Local(token string) (mesh.Machines, error) {
-	return r.localPeers, nil
-}
 
 func (r *RegistryMock) List(token string, self uuid.UUID) (mesh.MachinePeers, error) {
 	if r.listErr != nil {

--- a/daemon/rpc.go
+++ b/daemon/rpc.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/config/remote"
 	"github.com/NordSecurity/nordvpn-linux/core"
-	"github.com/NordSecurity/nordvpn-linux/core/mesh"
 	"github.com/NordSecurity/nordvpn-linux/daemon/dns"
 	daemonevents "github.com/NordSecurity/nordvpn-linux/daemon/events"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
@@ -52,7 +51,6 @@ type RPC struct {
 	ncClient             nc.NotificationClient
 	analytics            events.Analytics
 	norduser             service.Service
-	meshRegistry         mesh.Registry
 	systemShutdown       atomic.Bool
 	statePublisher       *state.StatePublisher
 	ConnectionParameters ParametersStorage
@@ -82,7 +80,6 @@ func NewRPC(
 	ncClient nc.NotificationClient,
 	analytics events.Analytics,
 	norduser service.Service,
-	meshRegistry mesh.Registry,
 	statePublisher *state.StatePublisher,
 	connectContext *sharedctx.Context,
 	remoteConfigGetter remote.RemoteConfigGetter,
@@ -110,7 +107,6 @@ func NewRPC(
 		ncClient:           ncClient,
 		analytics:          analytics,
 		norduser:           norduser,
-		meshRegistry:       meshRegistry,
 		statePublisher:     statePublisher,
 		connectContext:     connectContext,
 		remoteConfigGetter: remoteConfigGetter,

--- a/daemon/rpc_set_lan_discovery_test.go
+++ b/daemon/rpc_set_lan_discovery_test.go
@@ -125,10 +125,9 @@ func TestSetLANDiscovery_Success(t *testing.T) {
 			}}
 
 			rpc := RPC{
-				cm:           configManager,
-				netw:         &networker,
-				events:       &mockEvents,
-				meshRegistry: &RegistryMock{},
+				cm:     configManager,
+				netw:   &networker,
+				events: &mockEvents,
 			}
 			resp, err := rpc.SetLANDiscovery(context.Background(), &pb.SetLANDiscoveryRequest{
 				Enabled: test.enabled,

--- a/daemon/rpc_test.go
+++ b/daemon/rpc_test.go
@@ -96,7 +96,6 @@ func testRPC() *RPC {
 		nil,
 		&mockAnalytics{},
 		&testnorduser.MockNorduserCombinedService{},
-		&RegistryMock{},
 		nil,
 		sharedctx.New(),
 		mock.NewRemoteConfigMock(),

--- a/meshnet/registry/registry.go
+++ b/meshnet/registry/registry.go
@@ -53,11 +53,6 @@ func (r *Registry) Unregister(token string, self uuid.UUID) error {
 	return r.inner.Unregister(token, self)
 }
 
-// Local peers owned the same user.
-func (r *Registry) Local(token string) (mesh.Machines, error) {
-	return r.inner.Local(token)
-}
-
 // List given peer's neighbours in the mesh network.
 func (r *Registry) List(token string, self uuid.UUID) (resp mesh.MachinePeers, err error) {
 	anotherMachine := self

--- a/test/mock/meshnet.go
+++ b/test/mock/meshnet.go
@@ -69,9 +69,6 @@ func (r *RegistryMock) GetPeerWithIdentifier(id string) *mesh.MachinePeer {
 }
 
 func (*RegistryMock) Unregister(token string, self uuid.UUID) error { return nil }
-func (r *RegistryMock) Local(token string) (mesh.Machines, error) {
-	return r.LocalPeers, nil
-}
 
 func (r *RegistryMock) List(token string, self uuid.UUID) (mesh.MachinePeers, error) {
 	if r.ListErr != nil {


### PR DESCRIPTION
Following changes were done:
* Instead of executing NewServer in meshnet tests when only some of server fields need to be changed, newMockedServer helper function is used instead to reduce code duplication;
* Some dead code removed.