### PR TITLE
fix: for Incorrect conversion between integer types #2

### DIFF
--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -257,11 +257,12 @@ func startSnap() {
 		log.Println(internal.ErrorPrefix, "Failed to add autostart:", err)
 	}
 
-	uid, err := strconv.Atoi(usr.Uid)
+	uid64, err := strconv.ParseUint(usr.Uid, 10, 32)
 	if err != nil {
 		log.Printf("%s Invalid unix user id, failed to convert from string: %s", internal.ErrorPrefix, usr.Uid)
 		os.Exit(int(childprocess.CodeFailedToEnable))
 	}
+	uid := uint32(uid64)
 
 	logoutChan := make(chan interface{})
 	go func() {


### PR DESCRIPTION
## Ticket 🎟️ #785 

To fix the problem, we need to ensure that the integer value parsed from the string does not exceed the bounds of the `uint32` type. This can be achieved by using `strconv.ParseUint` with a specified bit size of 32, which directly parses the string into a `uint32` value. This approach avoids the need for additional bounds checking and ensures that the value is within the valid range for a `uint32`.


