### PR TITLE
Add git hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This hook enforces the commit message format:
+#   LVPN-<id>: <msg>
+# where <id> is one or more digits and <msg> can be any text.
+
+commit_msg_file="$1"
+commit_msg=$(head -n 1 "${commit_msg_file}")
+
+pattern="^LVPN-[0-9]+: .+"
+
+if ! echo "${commit_msg}" | grep -qE "${pattern}"; then
+  echo "ERROR: Commit message must be in the format 'LVPN-<id>: <msg>'"
+  echo "       where <id> is a number and <msg> is a non-empty message."
+  exit 1
+fi
+
+exit 0
+

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This hook extracts the 'lvpn-<id>' (case-insensitive) from the current branch name,
+# converts it to uppercase, and prepends it to the commit message in the format:
+# `LVPN-<id>: `
+
+commit_msg_file="$1"
+
+branch_name=$(git rev-parse --abbrev-ref HEAD)
+
+prefix=$(echo "${branch_name}" | sed -En 's/^(lvpn-[0-9]+).*$/\1/ip')
+
+if [ -n "${prefix}" ]; then
+  # prepare commit messae prefix
+  prefix_upper=$(echo "${prefix}" | tr '[:lower:]' '[:upper:]')
+  prefix_formatted="${prefix_upper}: "
+
+  # prepend to commit message
+  existing_msg=$(cat "${commit_msg_file}")
+  if ! echo "${existing_msg}" | grep -q "^${prefix_upper}:"; then
+    {
+      echo "${prefix_formatted}"
+      # add blank line if there is already content in the commit message.
+      [ -n "${existing_msg}" ] && echo "" && echo "${existing_msg}"
+    } >"${commit_msg_file}.tmp" && mv "${commit_msg_file}.tmp" "${commit_msg_file}"
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
Changes:
- `commit-msg` hook which verifies that your commit msg has proper format
- `prepare-commit-msg` hook which uses branch name to get the commit prefix and adds this prefix to your commit message

Enable with `git config core.hooksPath .githooks`