### PR TITLE
LVPN-7402: Hide CLI icon from system apps

### DIFF
--- a/contrib/desktop/nordvpn.desktop
+++ b/contrib/desktop/nordvpn.desktop
@@ -7,3 +7,4 @@ Icon=nordvpn
 MimeType=x-scheme-handler/nordvpn
 Exec=nordvpn click %u
 Terminal=true
+NoDisplay=true


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

The CLI icon will not be displayed in the system when searching for NordVPN, but still register the mime type.