### PR TITLE
fix Lack of Obfuscation in HTTP Request Logging Leading to Sensitive Data Exposure

### DIFF
--- a/events/logger/logger.go
+++ b/events/logger/logger.go
@@ -111,8 +111,8 @@ func dataRequestAPIToString(
 			data.Request.Proto,
 			data.Request.Method,
 			data.Request.URL,
-			headers,
-			string(reqBody),
+			headers, // Ensure headers are properly obfuscated
+			"(request body hidden)", // Do not log request body
 		))
 	}
 	if data.Error != nil {
@@ -142,6 +142,11 @@ func processHeaders(hide bool, headers http.Header) http.Header {
 	headers = headers.Clone()
 	sensitiveHeaders := []string{
 		"Authorization",
+		"Cookie",
+		"Set-Cookie",
+		"Proxy-Authorization",
+		"WWW-Authenticate",
+		"Proxy-Authenticate",
 	}
 	for _, header := range sensitiveHeaders {
 		if headers.Get(header) != "" {


### PR DESCRIPTION
https://github.com/NordSecurity/nordvpn-linux/blob/52c6b3707f0723dcf403cecf7305fcf9ed0f8521/events/logger/logger.go#L48-L48

fix to ensure that all sensitive headers are properly obfuscated or removed before logging. We can enhance the `processHeaders` function to include a more comprehensive list of sensitive headers and ensure they are hidden. Additionally, we should review the `dataRequestAPIToString` function to ensure no other sensitive information is logged.

1. Update the `processHeaders` function to include a more comprehensive list of sensitive headers.
2. Ensure that the `dataRequestAPIToString` function does not log any sensitive information in clear text.

##POC
Sensitive information that is logged unencrypted is accessible to an attacker who gains access to the logs. The following code logs user credentials (in this case, their password) in plain text:

```go
package main

import (
	"log"
	"net/http"
)

func serve() {
	http.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
		r.ParseForm()
		user := r.Form.Get("user")
		pw := r.Form.Get("password")

		log.Printf("Registering new user %s with password %s.\n", user, pw)
	})
	http.ListenAndServe(":80", nil)
}
```
Instead, the credentials should be encrypted, obfuscated, or omitted entirely:
```go
package main

import (
	"log"
	"net/http"
)

func serve1() {
	http.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
		r.ParseForm()
		user := r.Form.Get("user")
		pw := r.Form.Get("password")

		log.Printf("Registering new user %s.\n", user)

		// ...
		use(pw)
	})
	http.ListenAndServe(":80", nil)
}
```
## References
[CWE-359](https://cwe.mitre.org/data/definitions/359.html)
[CWE-315](https://cwe.mitre.org/data/definitions/315.html)
[CWE-312](https://cwe.mitre.org/data/definitions/312.html)
[Password Plaintext Storage](https://www.owasp.org/index.php/Password_Plaintext_Storage)