### PR TITLE
LVPN-7510: log caller name for config update

### DIFF
--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -250,13 +250,12 @@ func (l *LoginEvents) Subscribe(to LoginPublisher) {
 }
 
 // Config changes
-
 type ConfigPublisher interface {
-	NotifyConfigChanged(cfg *config.Config) error
+	NotifyConfigChanged(cfg config.DataConfigChange) error
 }
 
 type ConfigEvents struct {
-	Config events.PublishSubcriber[*config.Config]
+	Config events.PublishSubcriber[config.DataConfigChange]
 }
 
 func (c *ConfigEvents) Subscribe(to ConfigPublisher) {
@@ -265,7 +264,7 @@ func (c *ConfigEvents) Subscribe(to ConfigPublisher) {
 
 func NewConfigEvents() *ConfigEvents {
 	return &ConfigEvents{
-		Config: &subs.Subject[*config.Config]{},
+		Config: &subs.Subject[config.DataConfigChange]{},
 	}
 }
 

--- a/daemon/state/state.go
+++ b/daemon/state/state.go
@@ -111,7 +111,7 @@ func (s *StatePublisher) NotifyConfigChanged(e config.DataConfigChange) error {
 
 	log.Println(internal.DebugPrefix, "notifying about config change:", e.Caller)
 
-	s.notify(e)
+	s.notify(e.Config)
 
 	return nil
 }

--- a/daemon/state/state.go
+++ b/daemon/state/state.go
@@ -105,11 +105,12 @@ func (s *StatePublisher) NotifyMFA(bool) error {
 	return nil
 }
 
-func (s *StatePublisher) NotifyConfigChanged(e *config.Config) error {
+func (s *StatePublisher) NotifyConfigChanged(e config.DataConfigChange) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Println(internal.DebugPrefix, "notifying about config change")
+	log.Println(internal.DebugPrefix, "notifying about config change:", e.Caller)
+
 	s.notify(e)
 
 	return nil


### PR DESCRIPTION
Filename and line number of the call to SaveFile will be appended to config update debug log, to make tracing easier in case of log spam.