### PR TITLE
LVPN-7579: Fix possible data race in NotificationManager

### DIFF
--- a/fileshare/notification_manager.go
+++ b/fileshare/notification_manager.go
@@ -223,6 +223,8 @@ type NotificationManager struct {
 	fileshare          Fileshare
 	openFileFunc       func(string)
 	defaultDownloadDir string
+	// fileLock guards OpenFile and NotifyFile operations, as they cannot be performed at the same time
+	fileLock sync.Mutex
 }
 
 // NewNotificationManager creates a new notification
@@ -258,6 +260,9 @@ func (nm *NotificationManager) Disable() {
 
 // OpenFile associated with notificationID
 func (nm *NotificationManager) OpenFile(notificationID uint32) {
+	nm.fileLock.Lock()
+	defer nm.fileLock.Unlock()
+
 	if filename, ok := nm.notifications.GetAndDeleteFileNotification(notificationID); ok {
 		nm.openFileFunc(filename)
 	}
@@ -313,6 +318,14 @@ func (nm *NotificationManager) NotifyFile(filename string, direction pb.Directio
 	summary := fileStatusToNotificationSummary(direction, status)
 
 	if direction == pb.Direction_INCOMING && status == pb.Status_SUCCESS {
+		// lock fileLock, because in case of incoming files both SendNotification and AddFileNotification need to finish
+		// before OpenFile can proceed. Otherwise it would be possible for the following race to occur:
+		// 1. SendNotification finishes, notification is displayerd for the user.
+		// 2. User clicks Open File, OpenFile is called.
+		// 3. Because AddFileNotification was not called at this point, the requested file notification is not found and
+		// the operation fails.
+		nm.fileLock.Lock()
+		defer nm.fileLock.Unlock()
 		if notificationID, err := nm.notifier.SendNotification(summary, filename, []Action{{actionKeyOpenFile, "Open"}}); err == nil {
 			nm.notifications.AddFileNotification(notificationID, filename)
 		} else {


### PR DESCRIPTION
The race occurs because creating a notification for the user and storing this notification ID so that it can be handled later is not handled atomically.