### PR TITLE
LVPN-7958: Avoid data race in monitorFileshareProcessJob

### DIFF
--- a/meshnet/jobs.go
+++ b/meshnet/jobs.go
@@ -2,7 +2,6 @@ package meshnet
 
 import (
 	"log"
-	"sync"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -62,9 +61,6 @@ func JobMonitorFileshareProcess(s *Server) func() error {
 }
 
 func (j *monitorFileshareProcessJob) run() error {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-
 	if !j.meshChecker.isMeshOn() {
 		if j.isFileshareAllowed {
 			if err := j.rulesController.ForbidFileshare(); err == nil {
@@ -96,7 +92,6 @@ type monitorFileshareProcessJob struct {
 	meshChecker        meshChecker
 	rulesController    rulesController
 	processChecker     processChecker
-	mu                 sync.Mutex
 }
 
 type meshChecker interface {

--- a/meshnet/jobs.go
+++ b/meshnet/jobs.go
@@ -2,6 +2,7 @@ package meshnet
 
 import (
 	"log"
+	"sync"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -61,6 +62,9 @@ func JobMonitorFileshareProcess(s *Server) func() error {
 }
 
 func (j *monitorFileshareProcessJob) run() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
 	if !j.meshChecker.isMeshOn() {
 		if j.isFileshareAllowed {
 			if err := j.rulesController.ForbidFileshare(); err == nil {
@@ -92,6 +96,7 @@ type monitorFileshareProcessJob struct {
 	meshChecker        meshChecker
 	rulesController    rulesController
 	processChecker     processChecker
+	mu                 sync.Mutex
 }
 
 type meshChecker interface {

--- a/meshnet/server.go
+++ b/meshnet/server.go
@@ -71,7 +71,7 @@ func NewServer(
 	norduser service.NorduserFileshareClient,
 	connectContext *sharedctx.Context,
 ) *Server {
-	scheduler, _ := gocron.NewScheduler(gocron.WithLocation(time.UTC))
+	scheduler, _ := gocron.NewScheduler(gocron.WithLocation(time.UTC), gocron.WithLimitConcurrentJobs(1, gocron.LimitModeReschedule))
 	return &Server{
 		ac:             ac,
 		cm:             cm,


### PR DESCRIPTION
Job is executed every 1sec, job itself is quick ~1..10ms, but at the `set mesh on` time (or right after it) it's taking longer than 1sec and overlapping with next job run - and gocron scheduler was not configured properly. 