### PR TITLE
LVPN-7966: Cancellable HTTP context for moose-worker

### DIFF
--- a/request/cancellable.go
+++ b/request/cancellable.go
@@ -5,19 +5,22 @@ import (
 	"net/http"
 )
 
-type CancellableRoundTripper struct {
+// ContextRoundTripper adds a common context to requests that pass through it.
+type ContextRoundTripper struct {
 	inner http.RoundTripper
 	ctx   context.Context
 }
 
-func NewCancellableRoundTripper(ctx context.Context) *CancellableRoundTripper {
-	return &CancellableRoundTripper{
+// NewCancellableRoundTripper creates a new ContextRoundTripper.
+// ctx is added to request passing through the RoundTripper.
+func NewCancellableRoundTripper(ctx context.Context) *ContextRoundTripper {
+	return &ContextRoundTripper{
 		inner: http.DefaultTransport,
 		ctx:   ctx,
 	}
 }
 
-func (ct *CancellableRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (ct *ContextRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	reqWithCtx := req.WithContext(ct.ctx)
 	return ct.inner.RoundTrip(reqWithCtx)
 }

--- a/request/cancellable.go
+++ b/request/cancellable.go
@@ -1,0 +1,23 @@
+package request
+
+import (
+	"context"
+	"net/http"
+)
+
+type CancellableRoundTripper struct {
+	inner http.RoundTripper
+	ctx   context.Context
+}
+
+func NewCancellableRoundTripper(ctx context.Context) *CancellableRoundTripper {
+	return &CancellableRoundTripper{
+		inner: http.DefaultTransport,
+		ctx:   ctx,
+	}
+}
+
+func (ct *CancellableRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqWithCtx := req.WithContext(ct.ctx)
+	return ct.inner.RoundTrip(reqWithCtx)
+}


### PR DESCRIPTION
moose-worker needs to send out all outstanding events before it is stopped. Sometimes this may block the daemon shutdown for longer than necessary. A custom HTTP RoundTripper was added, which allows our moose wrapper to cancel all ongoing HTTP requests on shutdown. This fix was needed primarily for qa tests, as they disconnect/reconnect often, causing issues for the ongoing connections.