### PR TITLE
LVPN-8012: Handle meshnet key registration delay

### DIFF
--- a/meshnet/register.go
+++ b/meshnet/register.go
@@ -19,10 +19,6 @@ import (
 // DelayFunc blocks the app for a duration of time
 type DelayFunc func(duration time.Duration)
 
-func delayFunc(duration time.Duration) {
-	time.Sleep(duration)
-}
-
 // Checker provides information about meshnet.
 type Checker interface {
 	// IsRegistrationInfoCorrect returns true when device has been registered to meshnet.
@@ -46,7 +42,7 @@ func NewRegisteringChecker(
 	gen KeyGenerator,
 	reg cmesh.Registry,
 ) *RegisteringChecker {
-	return &RegisteringChecker{cm: cm, gen: gen, reg: reg, delayFunc: delayFunc}
+	return &RegisteringChecker{cm: cm, gen: gen, reg: reg, delayFunc: time.Sleep}
 }
 
 func isRegistrationInfoCorrect(cfg config.Config) bool {


### PR DESCRIPTION
There is a delay on the backed between registering a new meshnet/NordLynx key and the key being recognized by the server. It may lead to connection failures, for example when user enables meshnet(registering a new key) and then immediately tries to connect usint NordLynx(key is not recognized yet). A sleep was added to ensure a wait time after new key is registered.