### PR TITLE
LVPN-8022: Fix snap build in docker

### DIFF
--- a/ci/docker/snaper/Dockerfile
+++ b/ci/docker/snaper/Dockerfile
@@ -1,64 +1,20 @@
-# build image: docker build --no-cache -f ci/docker/snaper/Dockerfile --tag ghcr.io/nordsecurity/nordvpn-linux/snaper:0.0.1 .
-# build snap: docker run -v "$PWD":/build -w /build ghcr.io/nordsecurity/nordvpn-linux/snaper:0.0.1 snapcraft --destructive-mode
-# cleanup: sudo rm -rf ./parts ./stage ./prime
+FROM ghcr.io/canonical/snapcraft:8_core22@sha256:d6d2d32a1f87da38756f96145fc05683e60e612e08cc264eeba4cb824dbd4631
 
-ARG RISK=stable
-# ubuntu 22.04
-ARG UBUNTU=jammy
+ARG DEBIAN_FRONTEND=noninteractive
 
-FROM ubuntu:$UBUNTU as builder
-ARG RISK
-ARG UBUNTU
-RUN echo "Building snapcraft:$RISK in ubuntu:$UBUNTU"
+# NOTE: Don't remove apt sources after installation here because snapcraft needs them.
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  elfutils=0.186-1ubuntu0.1 \
+  git=1:2.34.1-1ubuntu1.12
 
-# Grab dependencies
-RUN apt-get update \
-        && apt-get dist-upgrade --yes \
-        && apt-get install --yes curl jq squashfs-tools 
+# snapcraft is running in privileged user
+# mode which does not match git repo owner
+RUN git config --global --add safe.directory "/opt" && \
+  git config --global --add safe.directory "/opt/parts/nordvpn/build"
 
-# Grab the core22 snap (which snapcraft uses as a base) from the stable channel
-# and unpack it in the proper place.
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core22' | jq '.download_url' -r) --output core22.snap\
-        && mkdir -p /snap/core22 \
-        && unsquashfs -d /snap/core22/current core22.snap
+WORKDIR /opt
 
-# Grab the snapcraft snap from the $RISK channel and unpack it in the proper place.
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel='$RISK | jq '.download_url' -r) --output snapcraft.snap \
-        && mkdir -p /snap/snapcraft \
-        && unsquashfs -d /snap/snapcraft/current snapcraft.snap
-
-# Fix Python3 installation: Make sure we use the interpreter from the snapcraft snap:
-RUN unlink /snap/snapcraft/current/usr/bin/python3 \
-        && ln -s /snap/snapcraft/current/usr/bin/python3.* /snap/snapcraft/current/usr/bin/python3 \
-        && echo /snap/snapcraft/current/lib/python3.*/site-packages >> /snap/snapcraft/current/usr/lib/python3/dist-packages/site-packages.pth
-
-# Create a snapcraft runner (TODO: move version detection to the core of snapcraft).
-RUN mkdir -p /snap/bin \
-        && echo "#!/bin/sh" > /snap/bin/snapcraft \
-        && snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml | tr -d \')" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft \
-        && echo 'exec "$SNAP/usr/bin/python3" "$SNAP/bin/snapcraft" "$@"' >> /snap/bin/snapcraft \
-        && chmod +x /snap/bin/snapcraft
-
-# Multi-stage build, only need the snaps from the builder. Copy them one at a time so they can be cached.
-FROM ubuntu:$UBUNTU
-COPY --from=builder /snap/core22 /snap/core22
-COPY --from=builder /snap/snapcraft /snap/snapcraft
-COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
-
-RUN mkdir -p /.cache && chmod -R 777 /.cache
-RUN mkdir -p /.local/state && chmod -R 777 /.local/state
-
-# Generate locale and install dependencies.
-RUN apt-get update && apt-get dist-upgrade --yes \
-        && apt-get install --yes snapd locales \
-        && locale-gen en_US.UTF-8 \
-        && apt-get install --yes git elfutils
-
-# Set the proper environment.
-ENV LANG="en_US.UTF-8"
-ENV LANGUAGE="en_US:en"
-ENV LC_ALL="en_US.UTF-8"
-ENV PATH="/snap/bin:/snap/snapcraft/current/usr/bin:$PATH"
-ENV SNAP="/snap/snapcraft/current"
-ENV SNAP_NAME="snapcraft"
-ENV SNAP_ARCH="amd64"
+# override the entrypoint from base image, because
+# it runs long-running process which we don't need
+ENTRYPOINT []

--- a/magefiles/docker.go
+++ b/magefiles/docker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -18,12 +19,17 @@ import (
 
 type DockerSettings struct {
 	Privileged        bool
-	Daemonize         bool               // Container is run in background, output is not available then
-	DaemonizeStopChan chan<- interface{} // Value will be sent on this channel when daemonized docker container is stopped
+	Daemonize         bool       // Container is run in background, output is not available then
+	DaemonizeStopChan chan<- any // Value will be sent on this channel when daemonized docker container is stopped
 	Network           string
 }
 
-func RunDocker(ctx context.Context, env map[string]string, image string, cmd []string) error {
+func RunDocker(
+	ctx context.Context,
+	env map[string]string,
+	image string,
+	cmd []string,
+) error {
 	settings := DockerSettings{}
 	return runDocker(ctx, env, image, cmd, settings.Privileged, settings.Daemonize, nil, settings.Network)
 }
@@ -54,14 +60,23 @@ func BuildDocker(dockerfile, tag string) error {
 func runDocker(
 	ctx context.Context,
 	env map[string]string,
-	image string,
+	img string,
 	cmd []string,
 	isPrivileged bool,
 	daemonize bool,
-	containerStoppedChan chan<- interface{},
+	containerStoppedChan chan<- any,
 	network string,
 ) error {
 	fmt.Println("creating docker client")
+	defer func() {
+		if !isPrivileged {
+			return
+		}
+		fmt.Println("fixing permissions")
+		if err := fixPermissions(); err != nil {
+			fmt.Println("failed to fix permissions", err)
+		}
+	}()
 	docker, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return err
@@ -75,21 +90,21 @@ func runDocker(
 			return err
 		}
 
-		imageIndex := slices.IndexFunc(list, func(imageSummary types.ImageSummary) bool {
-			tagIndex := slices.Index(imageSummary.RepoTags, image)
+		imageIndex := slices.IndexFunc(list, func(imageSummary image.Summary) bool {
+			tagIndex := slices.Index(imageSummary.RepoTags, img)
 			return tagIndex != -1
 		})
 		pullImage = imageIndex == -1
 	}
 
 	if pullImage {
-		fmt.Printf("pulling docker image %s\n", image)
-		if err := pullDocker(ctx, docker, image); err != nil {
+		fmt.Printf("pulling docker image %s\n", img)
+		if err := pullDocker(ctx, docker, img); err != nil {
 			return err
 		}
 	}
 
-	name := getNameFromImage(image)
+	name := getNameFromImage(img)
 	fmt.Printf("creating %s docker container\n", name)
 
 	cwd, err := os.Getwd()
@@ -98,7 +113,7 @@ func runDocker(
 	}
 
 	containerConfig := container.Config{
-		Image:      image,
+		Image:      img,
 		Cmd:        cmd,
 		Env:        envMapToList(env),
 		WorkingDir: "/opt",
@@ -134,19 +149,21 @@ func runDocker(
 		}
 	}
 
-	resp, err := docker.ContainerCreate(ctx, &containerConfig, &container.HostConfig{
+	hostConfig := container.HostConfig{
 		AutoRemove:  true,
 		Mounts:      mounts,
 		Privileged:  isPrivileged,
 		Sysctls:     map[string]string{"net.ipv6.conf.all.disable_ipv6": "0"},
 		NetworkMode: container.NetworkMode(network),
-	}, nil, nil, name)
+	}
+
+	resp, err := docker.ContainerCreate(ctx, &containerConfig, &hostConfig, nil, nil, name)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("starting %s docker container\n", name)
-	if err := docker.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := docker.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
 		return err
 	}
 
@@ -167,7 +184,7 @@ func runDocker(
 
 	fmt.Printf("waiting for %s docker container to finish\n", name)
 	statusCh, errCh := docker.ContainerWait(ctx, resp.ID, container.WaitConditionRemoved)
-	attach, err := docker.ContainerAttach(ctx, resp.ID, types.ContainerAttachOptions{
+	attach, err := docker.ContainerAttach(ctx, resp.ID, container.AttachOptions{
 		Stream: true,
 		Stdin:  true,
 		Stdout: true,
@@ -195,6 +212,26 @@ func runDocker(
 			}
 		}
 	}
+}
+
+func fixPermissions() error {
+	user := os.Getenv("USER")
+	if user == "" {
+		return fmt.Errorf("USER environment variable not set")
+	}
+
+	ug := fmt.Sprintf("%s:%s", user, user)
+	cmd := exec.Command("sudo", "chown", "-R", ug, ".")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	fmt.Println("Permissions updated successfully.")
+	return nil
 }
 
 func pullDocker(

--- a/magefiles/docker.go
+++ b/magefiles/docker.go
@@ -72,7 +72,6 @@ func runDocker(
 		if !isPrivileged {
 			return
 		}
-		fmt.Println("fixing permissions")
 		if err := fixPermissions(); err != nil {
 			fmt.Println("failed to fix permissions", err)
 		}
@@ -215,6 +214,7 @@ func runDocker(
 }
 
 func fixPermissions() error {
+	fmt.Println("fixing permissions")
 	user := os.Getenv("USER")
 	if user == "" {
 		return fmt.Errorf("USER environment variable not set")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -219,7 +219,8 @@ parts:
     source-type: local
     source: dist
     organize:
-      THIRD-PARTY-NOTICES.md: usr/share/licenses/nordvpn/THIRD-PARTY-NOTICES.md
+      THIRD-PARTY-NOTICES.md:
+        usr/share/licenses/nordvpn/THIRD-PARTY-NOTICES.md
         # Snap does not support manpages. In order to enable them, after installing snap, execute:
         #
         # sudo ln -s /snap/nordvpn/current/usr/share/man/man1/nordvpn.1.gz /usr/share/man/man1/nordvpn.1.gz


### PR DESCRIPTION
Changes:
- snaper is now using official snapcraft image from Canonical
- snapcraft needs to run with elevated privileges so after it's done, mage fixes the permissions on the host
- the rest are cosmetic changes - deprecation fixes, formatting etc.