### PR TITLE
LVPN-8079: Block telio events when event is being handled

### DIFF
--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -125,6 +125,8 @@ func (t *telioCallbackHandler) handleEvent(e teliogo.Event) *teliogo.TelioError 
 				log.Println(internal.ErrorPrefix, "canceling event monitoring:", t.monitoringContext.Err())
 			}
 			t.monitoringContext = nil
+		case <-time.After(1 * time.Second):
+			log.Println(internal.ErrorPrefix, "telio event was dropped because of timeout:", st)
 		}
 	}
 

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -117,7 +117,6 @@ func (t *telioCallbackHandler) handleEvent(e teliogo.Event) *teliogo.TelioError 
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.monitoringContext != nil {
-
 		select {
 		case t.statesChan <- st:
 		case <-t.monitoringContext.Done(): // drop if nobody is listening

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -849,8 +849,6 @@ func monitorConnection(
 	for {
 		select {
 		case state := <-states:
-			time.Sleep(1 * time.Second)
-
 			if !state.IsExit {
 				break
 			}


### PR DESCRIPTION
Change the telio event handling function so that it will block when sending the event downstream when connection is active. Previously, the function would default to dropping the event immediately if receiver was not listening, which would cause some events to be ignored.