### PR TITLE
LVPN-8094: Change tunnel netmask for NordLynx

### DIFF
--- a/daemon/vpn/nordlynx/nordlynx.go
+++ b/daemon/vpn/nordlynx/nordlynx.go
@@ -30,7 +30,7 @@ var (
 	errUnrecognizedIpRouteOutput = errors.New("unrecognized output of 'ip route show default'")
 )
 
-var DefaultPrefix = netip.MustParsePrefix("10.5.0.2/32")
+var DefaultPrefix = netip.MustParsePrefix("10.5.0.2/16")
 
 // getDefaultIpRouteInterface takes output of the `ip route show default` command and returns the
 // interface/device name. If there are multiple default routes in the output, first one will be returned

--- a/daemon/vpn/nordlynx/nordlynx_test.go
+++ b/daemon/vpn/nordlynx/nordlynx_test.go
@@ -2,6 +2,7 @@ package nordlynx
 
 import (
 	"net"
+	"net/netip"
 	"os/exec"
 	"strings"
 	"testing"
@@ -55,6 +56,11 @@ func TestGetDefaultIpRouteInterface(t *testing.T) {
 			assert.Equal(t, err, test.expectedError)
 		})
 	}
+}
+
+func TestNordLynxDefaultIp(t *testing.T) {
+	category.Set(t, category.Unit)
+	assert.Equal(t, DefaultPrefix, netip.MustParsePrefix("10.5.0.2/16"))
 }
 
 func TestGetDefaultIpRouteInterfaceFromCommandOutput(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* Change netmask for NordLynx to /16 to be able to communicate with the VPN server thru the tunnel.
* Add tests to check that LAN routing works correctly with and without LAN discovery enabled