### PR TITLE
LVPN-7941: Fix autoconnect for obfuscated servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The application manages:
 The project follows https://semver.org/. Version tags and release branches must be named accordingly.
 
 # Contributing
-We are happy to accept contibutions for the project. Please check out [Contribute.md](./CONTRIBUTE.md) file for more details on how to do so.
+We are happy to accept contributions for the project. Please check out [Contribute.md](./CONTRIBUTE.md) file for more details on how to do so.
 
 # Building
 You can find everything related to building, testing and environment setup in [BUILD.md](BUILD.md).

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,8 @@ type Config struct {
 }
 
 type AutoConnectData struct {
-	ID        int64  `json:"id,omitempty"`
+	ID int64 `json:"id,omitempty"`
+	// TODO: remove this in v4 and only use the country, city and group fields
 	ServerTag string `json:"server_tag,omitempty"`
 	Country   string
 	City      string

--- a/config/server_groups.go
+++ b/config/server_groups.go
@@ -13,3 +13,14 @@ var GroupMap = map[string]ServerGroup{
 	"africa_the_middle_east_and_india": ServerGroup_AFRICA_THE_MIDDLE_EAST_AND_INDIA,
 	"obfuscated_servers":               ServerGroup_OBFUSCATED,
 }
+
+// GroupTitleForId converts group ID to group lowercase title
+func GroupTitleForId(group ServerGroup) string {
+	for k, v := range GroupMap {
+		if v == group {
+			return k
+		}
+	}
+
+	return ""
+}

--- a/daemon/rpc_set_autoconnect.go
+++ b/daemon/rpc_set_autoconnect.go
@@ -74,7 +74,7 @@ func (r *RPC) SetAutoConnect(ctx context.Context, in *pb.SetAutoconnectRequest) 
 			c.AutoConnectData = config.AutoConnectData{
 				ID:                   cfg.AutoConnectData.ID,
 				ServerTag:            serverTag,
-				Country:              parameters.Country,
+				Country:              parameters.CountryCode,
 				City:                 parameters.City,
 				Group:                parameters.Group,
 				Protocol:             cfg.AutoConnectData.Protocol,

--- a/daemon/rpc_settings.go
+++ b/daemon/rpc_settings.go
@@ -40,9 +40,11 @@ func (r *RPC) Settings(ctx context.Context, in *pb.Empty) (*pb.SettingsResponse,
 		cfg.AutoConnectData.Group == config.ServerGroup_UNDEFINED
 	if cfg.AutoConnect && cfg.AutoConnectData.ServerTag != "" && autoconnectParamsNotSet {
 		// use group tag as a second parameter once it is implemented
-		parameters := GetServerParameters(cfg.AutoConnectData.ServerTag,
+		parameters := GetServerParameters(
 			cfg.AutoConnectData.ServerTag,
-			r.dm.GetCountryData().Countries)
+			cfg.AutoConnectData.ServerTag,
+			r.dm.GetCountryData().Countries,
+		)
 		cfg.AutoConnectData.Country = parameters.Country
 		cfg.AutoConnectData.City = parameters.City
 		cfg.AutoConnectData.Group = parameters.Group

--- a/daemon/servers_test.go
+++ b/daemon/servers_test.go
@@ -732,3 +732,88 @@ func TestPickServer(t *testing.T) {
 		})
 	}
 }
+
+func TestGetServerParameters(t *testing.T) {
+	category.Set(t, category.Unit)
+	tests := []struct {
+		name     string
+		tag      string
+		group    string
+		expected ServerParameters
+	}{
+		{
+			name:     "group found for group name",
+			group:    "p2p",
+			tag:      "",
+			expected: ServerParameters{Group: config.ServerGroup_P2P},
+		},
+		{
+			name:     "group name is in tag field",
+			group:    "",
+			tag:      "p2p",
+			expected: ServerParameters{Group: config.ServerGroup_P2P},
+		},
+		{
+			name:     "country name",
+			group:    "",
+			tag:      "germany",
+			expected: ServerParameters{Group: config.ServerGroup_UNDEFINED, Country: "Germany", CountryCode: "DE"},
+		},
+		{
+			name:     "country code",
+			group:    "",
+			tag:      "De",
+			expected: ServerParameters{Group: config.ServerGroup_UNDEFINED, Country: "Germany", CountryCode: "DE"},
+		},
+		{
+			name:     "country code + group",
+			group:    "p2p",
+			tag:      "De",
+			expected: ServerParameters{Group: config.ServerGroup_P2P, Country: "Germany", CountryCode: "DE"},
+		},
+		{
+			name:     "city name",
+			group:    "",
+			tag:      "berlin",
+			expected: ServerParameters{Group: config.ServerGroup_UNDEFINED, Country: "Germany", CountryCode: "DE", City: "Berlin"},
+		},
+		{
+			name:     "country name + city",
+			group:    "",
+			tag:      "germany berlin",
+			expected: ServerParameters{Group: config.ServerGroup_UNDEFINED, Country: "Germany", CountryCode: "DE", City: "Berlin"},
+		},
+		{
+			name:     "country code + city",
+			group:    "",
+			tag:      "de berlin",
+			expected: ServerParameters{Group: config.ServerGroup_UNDEFINED, Country: "Germany", CountryCode: "DE", City: "Berlin"},
+		},
+		{
+			name:     "country code + city + group",
+			group:    "p2p",
+			tag:      "de berlin",
+			expected: ServerParameters{Group: config.ServerGroup_P2P, Country: "Germany", CountryCode: "DE", City: "Berlin"},
+		},
+		{
+			name:     "server name",
+			group:    "",
+			tag:      "de123",
+			expected: ServerParameters{Group: config.ServerGroup_UNDEFINED, ServerName: "de123"},
+		},
+		{
+			name:     "server name + group",
+			group:    "p2p",
+			tag:      "de123",
+			expected: ServerParameters{Group: config.ServerGroup_P2P, ServerName: "de123"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			params := GetServerParameters(test.tag, test.group, countriesList())
+
+			assert.Equal(t, test.expected, params)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* When group name is not after --group argument, then the group enum value is stored into the autoconnect tag. For obfuscated server the enum name is different than the API group name.
* Store into the autoconnect the country code and not country name
* Add tests for autoconnect