### PR TITLE
Provide refreshed transfer rates only when status is connected

### DIFF
--- a/daemon/state/connection_info.go
+++ b/daemon/state/connection_info.go
@@ -55,11 +55,9 @@ func (cs *ConnectionInfo) Status() types.ConnectionStatus {
 	// thus it is OK to not synchronize them each time
 	cs.mu.RLock()
 	status := cs.status
-	tunnelName := cs.status.TunnelName
-	connectionState := cs.status.State
 	cs.mu.RUnlock()
-	if connectionState == pb.ConnectionState_CONNECTED {
-		status.Tx, status.Rx = cs.getTransferRatesForTunnel(tunnelName)
+	if status.State == pb.ConnectionState_CONNECTED {
+		status.Tx, status.Rx = cs.getTransferRatesForTunnel(status.TunnelName)
 	}
 	return status
 }

--- a/daemon/state/connection_info_test.go
+++ b/daemon/state/connection_info_test.go
@@ -224,6 +224,8 @@ func TestConnectionInfo_TransferRatesShallBeProvidedOnlyForConnectedState(t *tes
 		assert.Zero(t, status.Tx)
 		assert.Zero(t, status.Rx)
 
+		// connecting with valid TunnelName
+		// transfer rates should be zero
 		event := events.DataConnect{
 			EventStatus: events.StatusAttempt,
 			TunnelName:  loopBackInterface,
@@ -235,6 +237,8 @@ func TestConnectionInfo_TransferRatesShallBeProvidedOnlyForConnectedState(t *tes
 		assert.Zero(t, status.Tx)
 		assert.Zero(t, status.Rx)
 
+		// connected with valid TunnelName
+		// transfer rates should be non zero
 		event = events.DataConnect{
 			EventStatus: events.StatusSuccess,
 			TunnelName:  loopBackInterface,
@@ -247,6 +251,8 @@ func TestConnectionInfo_TransferRatesShallBeProvidedOnlyForConnectedState(t *tes
 		assert.NotZero(t, status.Tx)
 		assert.NotZero(t, status.Rx)
 
+		// connection failed with valid TunnelName
+		// transfer rates should be zero
 		event = events.DataConnect{
 			EventStatus: events.StatusFailure,
 			TunnelName:  loopBackInterface,
@@ -259,8 +265,22 @@ func TestConnectionInfo_TransferRatesShallBeProvidedOnlyForConnectedState(t *tes
 		assert.Zero(t, status.Tx)
 		assert.Zero(t, status.Rx)
 
+		// disconnected
+		// transfer rates should be zero
 		tf.subscriber.ExpectEvents(1)
 		tf.internalEvents.Disconnected.Publish(events.DataDisconnect{})
+		tf.subscriber.wg.Wait()
+
+		status = tf.sut.Status()
+		assert.Zero(t, status.Tx)
+		assert.Zero(t, status.Rx)
+
+		// connected with empty TunnelName
+		// transfer rates should be zero
+		tf.subscriber.ExpectEvents(1)
+		tf.internalEvents.Connected.Publish(events.DataConnect{
+			EventStatus: events.StatusSuccess,
+		})
 		tf.subscriber.wg.Wait()
 
 		status = tf.sut.Status()
@@ -271,7 +291,4 @@ func TestConnectionInfo_TransferRatesShallBeProvidedOnlyForConnectedState(t *tes
 	}()
 
 	tf.waitForCompletion(t)
-
-	status := tf.sut.Status()
-	assert.Nil(t, status.StartTime)
 }

--- a/daemon/state/connection_info_test.go
+++ b/daemon/state/connection_info_test.go
@@ -214,7 +214,7 @@ func TestConnectionInfo_TracksStartTime(t *testing.T) {
 	assert.Nil(t, status.StartTime)
 }
 
-func TestConnectionInfo_TransferRatersShallBeProvidedOnlyForConnectedState(t *testing.T) {
+func TestConnectionInfo_TransferRatesShallBeProvidedOnlyForConnectedState(t *testing.T) {
 	category.Set(t, category.Unit)
 	tf := newTestFixture(t)
 	tf.subscriber.ExpectEvents(1)

--- a/daemon/vpn/events.go
+++ b/daemon/vpn/events.go
@@ -4,7 +4,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/events/subs"
-	"github.com/NordSecurity/nordvpn-linux/tunnel"
 )
 
 type InternalVPNPublisher interface {
@@ -33,7 +32,6 @@ func GetDataConnectEvent(technology config.Technology,
 	protocol config.Protocol,
 	connectType events.TypeEventStatus,
 	server ServerData,
-	tunnelStatistics tunnel.Statistics,
 	isMeshPeer bool) events.DataConnect {
 	return events.DataConnect{
 		EventStatus:             connectType,
@@ -47,8 +45,6 @@ func GetDataConnectEvent(technology config.Technology,
 		IsVirtualLocation:       server.VirtualLocation,
 		Technology:              technology,
 		Protocol:                protocol,
-		Upload:                  tunnelStatistics.Tx,
-		Download:                tunnelStatistics.Rx,
 		IsObfuscated:            server.Obfuscated,
 		IsPostQuantum:           server.PostQuantum,
 		IP:                      server.IP,

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -713,17 +713,10 @@ func publishConnectEvent(publisher *vpn.Events,
 	if !state.IsVPN {
 		server.Name = state.Nickname
 	}
-
-	transferStats, err := tunnel.GetTransferRates(nordlynx.InterfaceName)
-	if err != nil {
-		log.Println(internal.ErrorPrefix, "failed to get transfer rates for tunnel:", err)
-	}
-
 	event := vpn.GetDataConnectEvent(config.Technology_NORDLYNX,
 		config.Protocol_UDP,
 		connectType,
 		server,
-		transferStats,
 		!state.IsVPN)
 	event.TunnelName = tun.Interface().Name
 	publisher.Connected.Publish(event)

--- a/daemon/vpn/openvpn/openvpn.go
+++ b/daemon/vpn/openvpn/openvpn.go
@@ -349,16 +349,10 @@ func (ovpn *OpenVPN) getSubstate() vpn.Substate {
 }
 
 func (ovpn *OpenVPN) getConnectedConnectingEvent(state events.TypeEventStatus) events.DataConnect {
-	stats, err := tunnel.GetTransferRates(InterfaceName)
-	if err != nil {
-		log.Println(internal.ErrorPrefix, "failed to get transfer rates for the tunnel:", err)
-	}
-
 	event := vpn.GetDataConnectEvent(config.Technology_OPENVPN,
 		ovpn.serverData.Protocol,
 		state,
 		ovpn.serverData,
-		stats,
 		false)
 	if ovpn.tun != nil {
 		event.TunnelName = ovpn.tun.Interface().Name

--- a/daemon/vpn/quench/libquench.go
+++ b/daemon/vpn/quench/libquench.go
@@ -98,16 +98,10 @@ func (o *observer) notifyConnectionStateChange(state vpn.State) {
 }
 
 func (o *observer) getConnectEvent(status events.TypeEventStatus) events.DataConnect {
-	transferStats, err := tunnel.GetTransferRates(o.nicName)
-	if err != nil {
-		fmt.Println(internal.ErrorPrefix, "failed to get transfer rates for tunnel:", err)
-	}
-
 	event := vpn.GetDataConnectEvent(config.Technology_NORDWHISPER,
 		config.Protocol_Webtunnel,
 		status,
 		o.currentServer,
-		transferStats,
 		false)
 
 	event.TunnelName = o.nicName

--- a/events/events.go
+++ b/events/events.go
@@ -87,8 +87,6 @@ type DataConnect struct {
 	TargetServerName           string
 	Error                      error
 	IsVirtualLocation          bool
-	Upload                     uint64
-	Download                   uint64
 	IsObfuscated               bool
 	IsPostQuantum              bool
 	IP                         netip.Addr


### PR DESCRIPTION
Changes under this PR:
- Rx/Tx rates are now updated only when status is connected
- removed Rx/Tx rates from events.DataConnect in favour of updating those fields in connection_info, right when providing connection status updated to other clients
- unit test to cover changes