### PR TITLE
LVPN-8165: Add proper automation test reports

### DIFF
--- a/ci/docker/tester/requirements.txt
+++ b/ci/docker/tester/requirements.txt
@@ -10,3 +10,7 @@ dnspython==2.6.1
 protobuf==5.28.3
 selenium==4.26.0
 grpcio==1.68.1
+MarkupSafe>=3.0.2
+jinja2>=3.1.6
+pytest-html==4.1.1
+pytest-metadata==3.1.1

--- a/ci/test_deb.sh
+++ b/ci/test_deb.sh
@@ -71,7 +71,7 @@ if [[ -n ${LATTE:-} ]]; then
     fi
 fi
 
-python3 -m pytest -v -x -rsx --setup-timeout 60 --execution-timeout 180 --teardown-timeout 25 -o log_cli=true --html=reports/report.html "${args[@]}"
+python3 -m pytest -v -x -rsx --setup-timeout 60 --execution-timeout 180 --teardown-timeout 25 -o log_cli=true --html=artifacts/report.html "${args[@]}"
 
 if ! sudo grep -q "export GOCOVERDIR=${WORKDIR}/${COVERDIR}" "/etc/init.d/nordvpn"; then
     sudo sed -i "2d" "/etc/init.d/nordvpn"

--- a/ci/test_deb.sh
+++ b/ci/test_deb.sh
@@ -71,7 +71,7 @@ if [[ -n ${LATTE:-} ]]; then
     fi
 fi
 
-python3 -m pytest -v -x -rsx --setup-timeout 60 --execution-timeout 180 --teardown-timeout 25 -o log_cli=true "${args[@]}"
+python3 -m pytest -v -x -rsx --setup-timeout 60 --execution-timeout 180 --teardown-timeout 25 -o log_cli=true --html=reports/report.html "${args[@]}"
 
 if ! sudo grep -q "export GOCOVERDIR=${WORKDIR}/${COVERDIR}" "/etc/init.d/nordvpn"; then
     sudo sed -i "2d" "/etc/init.d/nordvpn"

--- a/ci/test_snap.sh
+++ b/ci/test_snap.sh
@@ -50,7 +50,7 @@ esac
 #     fi
 # fi
 
-python3 -m pytest -v--disable-pytest-warnings --timeout 180 -x -rsx --timeout-method=signal -o log_cli=true --html=reports/report.html "${args[@]}"
+python3 -m pytest -v--disable-pytest-warnings --timeout 180 -x -rsx --timeout-method=signal -o log_cli=true --html=artifacts/report.html "${args[@]}"
 
 # if ! sudo grep -q "export GOCOVERDIR=${WORKDIR}/${COVERDIR}" "/etc/init.d/nordvpn"; then
 #     sudo sed -i "2d" "/etc/init.d/nordvpn"

--- a/ci/test_snap.sh
+++ b/ci/test_snap.sh
@@ -50,7 +50,7 @@ esac
 #     fi
 # fi
 
-python3 -m pytest -v --disable-pytest-warnings --timeout 180 -x -rsx --timeout-method=signal -o log_cli=true "${args[@]}"
+python3 -m pytest -v--disable-pytest-warnings --timeout 180 -x -rsx --timeout-method=signal -o log_cli=true --html=reports/report.html "${args[@]}"
 
 # if ! sudo grep -q "export GOCOVERDIR=${WORKDIR}/${COVERDIR}" "/etc/init.d/nordvpn"; then
 #     sudo sed -i "2d" "/etc/init.d/nordvpn"


### PR DESCRIPTION
Added new test report solution. Now reports will be stored in **nordvpn/test/qa/artifactory/report.html**. Example of a report:
![image](https://github.com/user-attachments/assets/7a59b713-75d0-40f4-ae15-cd103d5c29cd)
