### PR TITLE
LVPN-8206: fix route_traffic_to_peer_wrong_tech

### DIFF
--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -16,7 +16,7 @@ STANDARD_TECHNOLOGIES = [
     ("openvpn", "udp", "off"),
     ("openvpn", "tcp", "off"),
     ("nordlynx", "", ""),
-    ("nordwhisper", "", "")
+    ("nordwhisper", "", ""),
 ]
 
 # Used for test parametrization, when the tested functionality does not work with obfuscated and NordWhisper.
@@ -33,6 +33,15 @@ OBFUSCATED_TECHNOLOGIES = [
     ("openvpn", "udp", "on"),
     ("openvpn", "tcp", "on"),
 ]
+
+STANDARD_TECHNOLOGIES_NO_MESHNET = [
+    # technology, protocol, obfuscation,
+    ("openvpn", "udp", "off"),
+    ("openvpn", "tcp", "off"),
+    ("nordwhisper", "", ""),
+]
+
+TECHNOLOGIES_NO_MESHNET = OBFUSCATED_TECHNOLOGIES + STANDARD_TECHNOLOGIES_NO_MESHNET
 
 # Used for test parametrization, when the tested functionality does not work with obfuscated.
 OVPN_STANDARD_TECHNOLOGIES = [

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -202,7 +202,7 @@ def test_route_to_peer_that_is_disconnected():
     assert expected_message in str(ex)
 
 
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES[:-1])
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_NO_MESHNET)
 def test_route_traffic_to_peer_wrong_tech(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 


### PR DESCRIPTION
New technology was added to the technologies list used for test parametrization affected the tech ordering so that NordLynx was uset for testing when it shouldn't.