### PR TITLE
LVPN-8136: Execute consent flow in cli on login and register

### DIFF
--- a/cli/cli_login.go
+++ b/cli/cli_login.go
@@ -27,6 +27,11 @@ func (c *cmd) Login(ctx *cli.Context) error {
 	if err != nil {
 		return formatError(err)
 	}
+
+	if resp.GetIsLoggedIn() {
+		return formatError(internal.ErrAlreadyLoggedIn)
+	}
+
 	if resp.Status == pb.LoginStatus_CONSENT_MISSING {
 		// ask user for consent
 		if err := c.setAnalyticsFlow(); err != nil {
@@ -39,17 +44,12 @@ func (c *cmd) Login(ctx *cli.Context) error {
 }
 
 func (c *cmd) loginCmd(ctx *cli.Context) error {
-	resp, err := c.client.IsLoggedIn(context.Background(), &pb.Empty{})
-	if err != nil || resp.GetIsLoggedIn() {
-		return formatError(internal.ErrAlreadyLoggedIn)
-	}
-
 	if ctx.IsSet(flagLoginCallback) {
 		return c.oauth2(ctx, true)
 	}
 
 	if ctx.IsSet(flagToken) {
-		err = c.loginWithToken(ctx)
+		err := c.loginWithToken(ctx)
 		if err != nil {
 			return formatError(err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -19,12 +19,10 @@ func newConfig(machineIDGetter MachineIDGetter) *Config {
 		AutoConnectData: AutoConnectData{
 			Protocol: Protocol_UDP,
 		},
-		MachineID:  machineIDGetter.GetMachineID(),
-		UsersData:  &UsersData{NotifyOff: UidBoolMap{}, TrayOff: UidBoolMap{}},
-		TokensData: map[int64]TokenData{},
-		// FIXME: This is set to some value now to not break the app as the full consent flow
-		// is not yet implemented. This will be addressed in LVPN-8137
-		AnalyticsConsent: ConsentDenied,
+		MachineID:        machineIDGetter.GetMachineID(),
+		UsersData:        &UsersData{NotifyOff: UidBoolMap{}, TrayOff: UidBoolMap{}},
+		TokensData:       map[int64]TokenData{},
+		AnalyticsConsent: ConsentUndefined,
 	}
 }
 


### PR DESCRIPTION
Changes:
- CLI reacts to `LoginStatus_CONSENT_MISSING` and triggers consent flow, then continues with login procedure