### PR TITLE
LVPN-8137: Execute consent flow in tray

### DIFF
--- a/cli/cli_click.go
+++ b/cli/cli_click.go
@@ -85,13 +85,8 @@ func (c *cmd) Click(ctx *cli.Context) (err error) {
 				return nil
 
 			case "consent":
-				if err := c.setAnalyticsFlow(); err != nil {
-					return formatError(err)
-				}
-				// consent is triggered here only during login,
-				// so after consent flow is finished, continue with login
-				c.Login(ctx)
-				return nil
+				// login takes care of the analytics consent flow and continues with login
+				return c.Login(ctx)
 			}
 		}
 	}

--- a/cli/cli_click.go
+++ b/cli/cli_click.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 )
@@ -55,9 +56,9 @@ func (c *cmd) Click(ctx *cli.Context) (err error) {
 			return formatError(err)
 		}
 
-		if strings.ToLower(url.Scheme) == "nordvpn" {
+		if strings.ToLower(url.Scheme) == internal.NordVPNScheme {
 			switch strings.ToLower(url.Host) {
-			case "claim-online-purchase":
+			case internal.ClaimOnlinePurchaseSubcommand:
 				resp, err := c.client.ClaimOnlinePurchase(context.Background(), &pb.Empty{})
 				if err != nil {
 					return formatError(err)
@@ -70,7 +71,7 @@ func (c *cmd) Click(ctx *cli.Context) (err error) {
 				color.Green(ClaimOnlinePurchaseSuccess)
 				return nil
 
-			case "login":
+			case internal.LoginSubcommand:
 				// login can be regular, or after new account setup & vpn service purchase (signup)
 				regularLogin := true
 				if strings.ToLower(url.Query().Get("action")) == "signup" {
@@ -84,7 +85,7 @@ func (c *cmd) Click(ctx *cli.Context) (err error) {
 				}
 				return nil
 
-			case "consent":
+			case internal.ConsentSubcommand:
 				// login takes care of the analytics consent flow and continues with login
 				return c.Login(ctx)
 			}

--- a/cli/cli_click.go
+++ b/cli/cli_click.go
@@ -83,6 +83,15 @@ func (c *cmd) Click(ctx *cli.Context) (err error) {
 					return formatError(err)
 				}
 				return nil
+
+			case "consent":
+				if err := c.setAnalyticsFlow(); err != nil {
+					return formatError(err)
+				}
+				// consent is triggered here only during login,
+				// so after consent flow is finished, continue with login
+				c.Login(ctx)
+				return nil
 			}
 		}
 	}

--- a/cli/cli_login.go
+++ b/cli/cli_login.go
@@ -24,16 +24,32 @@ const (
 
 func (c *cmd) Login(ctx *cli.Context) error {
 	resp, err := c.client.IsLoggedIn(context.Background(), &pb.Empty{})
-	if err != nil || resp.GetIsLoggedIn() {
+	if err != nil {
+		return formatError(err)
+	}
+
+	if resp.GetIsLoggedIn() {
 		return formatError(internal.ErrAlreadyLoggedIn)
 	}
 
+	if resp.Status == pb.LoginStatus_CONSENT_MISSING {
+		// ask user for consent
+		if err := c.setAnalyticsFlow(); err != nil {
+			return formatError(err)
+		}
+	}
+
+	// continue with login
+	return c.loginCmd(ctx)
+}
+
+func (c *cmd) loginCmd(ctx *cli.Context) error {
 	if ctx.IsSet(flagLoginCallback) {
 		return c.oauth2(ctx, true)
 	}
 
 	if ctx.IsSet(flagToken) {
-		err = c.loginWithToken(ctx)
+		err := c.loginWithToken(ctx)
 		if err != nil {
 			return formatError(err)
 		}
@@ -55,8 +71,6 @@ func (c *cmd) login(requestType pb.LoginType) error {
 		return formatError(err)
 	}
 
-	// will be addressed in LVPN-8136
-	//exhaustive:ignore
 	switch resp.Status {
 	case pb.LoginStatus_UNKNOWN_OAUTH2_ERROR:
 		return formatError(internal.ErrUnhandled)
@@ -64,6 +78,12 @@ func (c *cmd) login(requestType pb.LoginType) error {
 		return formatError(internal.ErrNoNetWhenLoggingIn)
 	case pb.LoginStatus_ALREADY_LOGGED_IN:
 		return formatError(internal.ErrAlreadyLoggedIn)
+	case pb.LoginStatus_CONSENT_MISSING:
+		if err := c.setAnalyticsFlow(); err != nil {
+			return formatError(err)
+		}
+		// restart login flow after consent was completed
+		return c.login(requestType)
 	case pb.LoginStatus_SUCCESS:
 		if url := resp.Url; url != "" {
 			color.Green("Continue in the browser: %s", url)

--- a/config/config.go
+++ b/config/config.go
@@ -19,12 +19,10 @@ func newConfig(machineIDGetter MachineIDGetter) *Config {
 		AutoConnectData: AutoConnectData{
 			Protocol: Protocol_UDP,
 		},
-		MachineID:  machineIDGetter.GetMachineID(),
-		UsersData:  &UsersData{NotifyOff: UidBoolMap{}, TrayOff: UidBoolMap{}},
-		TokensData: map[int64]TokenData{},
-		// FIXME: This is set to some value now to not break the app as the full consent flow
-		// is not yet implemented. This will be addressed in LVPN-8137
-		AnalyticsConsent: ConsentDenied,
+		MachineID:        machineIDGetter.GetMachineID(),
+		UsersData:        &UsersData{NotifyOff: UidBoolMap{}, TrayOff: UidBoolMap{}},
+		TokensData:       map[int64]TokenData{},
+		AnalyticsConsent: ConsentUndefined,
 	}
 }
 

--- a/internal/click_subcommands.go
+++ b/internal/click_subcommands.go
@@ -1,0 +1,14 @@
+package internal
+
+import "fmt"
+
+const (
+	NordVPNScheme                 = "nordvpn"
+	ClaimOnlinePurchaseSubcommand = "claim-online-purchase"
+	LoginSubcommand               = "login"
+	ConsentSubcommand             = "consent"
+)
+
+func SubcommandURI(subcommand string) string {
+	return fmt.Sprintf("%s://%s", NordVPNScheme, subcommand)
+}

--- a/internal/click_subcommands_test.go
+++ b/internal/click_subcommands_test.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"gotest.tools/v3/assert"
+)
+
+func TestSubcommandURI_ProducesCorrectURI(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct{ subcommand, expected string }{
+		{ClaimOnlinePurchaseSubcommand, "nordvpn://claim-online-purchase"},
+		{LoginSubcommand, "nordvpn://login"},
+		{ConsentSubcommand, "nordvpn://consent"},
+		{"something-else", "nordvpn://something-else"},
+	}
+
+	for _, item := range tests {
+		got := SubcommandURI(item.subcommand)
+		assert.Equal(t, item.expected, got)
+	}
+}

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -19,7 +19,10 @@ var (
 	ErrAlreadyLoggedIn = errors.New("you are already logged in")
 	// ErrNotLoggedIn is returned when the caller is expected to be logged in
 	// but is not
-	ErrNotLoggedIn           = errors.New("you are not logged in")
-	ErrVirtualServerSelected = errors.New(SpecifiedServerIsVirtualLocation)
-	ErrNoNetWhenLoggingIn    = errors.New("You’re offline.\nWe can’t run this action without an internet connection. Please check it and try again.")
+	ErrNotLoggedIn = errors.New("you are not logged in")
+	// ErrAnalyticsConsentMissing is returned when user tries to login via tray
+	// but settings analytics consent failed for some reason. This should not happen.
+	ErrAnalyticsConsentMissing = errors.New("analytics consent is required before continuing")
+	ErrVirtualServerSelected   = errors.New(SpecifiedServerIsVirtualLocation)
+	ErrNoNetWhenLoggingIn      = errors.New("You’re offline.\nWe can’t run this action without an internet connection. Please check it and try again.")
 )

--- a/tray/actions.go
+++ b/tray/actions.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/cli"
 	"github.com/NordSecurity/nordvpn-linux/client"
@@ -15,13 +16,25 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	filesharepb "github.com/NordSecurity/nordvpn-linux/fileshare/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/godbus/dbus/v5"
 )
 
 // The pattern for actions is to return 'true' on success and 'false' (along with emitting a notification) on failure
 
 func (ti *Instance) login() {
 	resp, err := ti.client.IsLoggedIn(context.Background(), &pb.Empty{})
-	if err != nil || resp.GetIsLoggedIn() {
+	if err != nil {
+		ti.notify("Login failed")
+		log.Println(internal.ErrorPrefix, "Failed to login:", err)
+		return
+	}
+	if resp.Status == pb.LoginStatus_CONSENT_MISSING {
+		// ask user for consent by opening terminal with consent flow,
+		openURI("nordvpn://consent")
+		return
+	}
+
+	if resp.GetIsLoggedIn() {
 		ti.notify("You are already logged in")
 		return
 	}
@@ -45,8 +58,10 @@ func (ti *Instance) login() {
 	case pb.LoginStatus_ALREADY_LOGGED_IN:
 		ti.notify(internal.ErrAlreadyLoggedIn.Error())
 	case pb.LoginStatus_CONSENT_MISSING:
-		// will be addressed in LVPN-8137
-		ti.notify("Not implemented yet")
+		// NOTE: This should never happen, because analytics consent is
+		// triggered above, so at this point it should already be completed.
+		ti.notify(internal.ErrAnalyticsConsentMissing.Error())
+		log.Println(internal.ErrorPrefix, "analytics consent should be already completed at this point")
 	case pb.LoginStatus_SUCCESS:
 		if url := loginResp.Url; url != "" {
 			// #nosec G204 -- user input is not passed in
@@ -59,6 +74,34 @@ func (ti *Instance) login() {
 			}
 		}
 	}
+}
+
+func openURI(uri string) {
+	if err := tryDbus(uri); err != nil {
+		log.Printf(internal.ErrorPrefix+" failed to open URI '%s' using D-Bus: %v\n", uri, err)
+	}
+}
+
+func tryDbus(uri string) error {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return fmt.Errorf("failed to connect to session bus: %w", err)
+	}
+
+	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	call := obj.CallWithContext(ctx,
+		"org.freedesktop.portal.OpenURI.OpenURI", 0,
+		"", uri, map[string]dbus.Variant{},
+	)
+	if call.Err != nil {
+		return fmt.Errorf("DBus OpenURI failed: %w", call.Err)
+	}
+
+	return nil
 }
 
 func (ti *Instance) logout(persistToken bool) bool {

--- a/tray/actions.go
+++ b/tray/actions.go
@@ -30,7 +30,7 @@ func (ti *Instance) login() {
 	}
 	if resp.Status == pb.LoginStatus_CONSENT_MISSING {
 		// ask user for consent by opening terminal with consent flow,
-		openURI("nordvpn://consent")
+		openURI(internal.SubcommandURI(internal.ConsentSubcommand))
 		return
 	}
 

--- a/tray/notifications.go
+++ b/tray/notifications.go
@@ -84,7 +84,6 @@ func (n *dbusNotifier) sendNotification(summary string, body string) error {
 
 func newNotifier() (notify.Notifier, error) {
 	dbusConn, err := dbus.SessionBusPrivate()
-
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +105,6 @@ func newNotifier() (notify.Notifier, error) {
 	}
 
 	ntf, err := notify.New(dbusConn)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Changes:
- `cli_click.go` has new action "consent", this way tray triggers consent flow on login
- this PR enables analytics consent feature by setting `AnalyticsConsent` field to `ConsentUndefined`
- login command in tray triggers the consent by opening `nordvpn://consent` with D-Bus