### PR TITLE
LVPN-7413: Change moose DB permissions

### DIFF
--- a/ci/docker/builder/Dockerfile
+++ b/ci/docker/builder/Dockerfile
@@ -47,7 +47,6 @@ RUN dpkg --add-architecture i386 && \
 # dependency for `libxml2`, a proper library is loaded
 RUN ln -s /usr/lib/arm-linux-gnueabihf/libxml2.so /usr/lib/arm-linux-gnueabi/libxml2.so && \
     # Download and install musl to PATH (/usr/bin)
-    # Because i386 app compiled with Zig segfaults when linked against glibc during go runtime setup
     wget --progress=dot:giga "https://musl.cc/i686-linux-musl-cross.tgz" -O /tmp/musl.tar.gz && \
     echo "5047afc68170a2910895db2dfa448227e71a984bfa2130a1bc946fd1015d722b80b15e4abf90c64300815aa84fe781cc8b8a72f10174f9dce96169e035911880 /tmp/musl.tar.gz" | sha512sum -c - && \
     tar -xzf /tmp/musl.tar.gz -C /usr/lib && rm /tmp/musl.tar.gz && \

--- a/cmd/daemon/moose_db_creation_test.go
+++ b/cmd/daemon/moose_db_creation_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/stretchr/testify/assert"
+)
+
+const TestDataPath = "testdata/"
+
+func TestCreateMooseDB(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	path := TestDataPath + "test_moose_db.db"
+	const perm os.FileMode = internal.PermUserRWGroupRW
+	defer os.Remove(path)
+
+	checkPermissionsFn := func() {
+		info, err := os.Stat(path)
+		assert.NoError(t, err)
+		assert.Equal(t, perm, info.Mode().Perm())
+	}
+
+	// create DB
+	assignMooseDBPermissions(path)
+
+	assert.FileExists(t, path)
+	checkPermissionsFn()
+
+	// file exists, check that the permissions are updated
+	os.Chmod(path, internal.PermUserRW)
+	assignMooseDBPermissions(path)
+
+	checkPermissionsFn()
+}

--- a/daemon/data_models.go
+++ b/daemon/data_models.go
@@ -151,7 +151,7 @@ func (data *VersionData) save() error {
 		return err
 	}
 
-	err = internal.FileWrite(data.filePath, buffer.Bytes(), internal.PermUserRWGroupROthersR)
+	err = internal.FileWrite(data.filePath, buffer.Bytes(), internal.PermUserRW)
 	if err != nil {
 		return err
 	}

--- a/daemon/job_appversion.go
+++ b/daemon/job_appversion.go
@@ -13,7 +13,9 @@ func JobVersionCheck(dm *DataManager, api *RepoAPI) func() {
 		if currentVersion.LessThan(vdata.version) {
 			dm.SetVersionData(vdata.version, true)
 		}
-		if vdata.newerVersionAvailable {
+
+		// if vdata.version.Major == 0 that means the data is incorrect, possibly the file is missing
+		if vdata.newerVersionAvailable && vdata.version.Major != 0 {
 			return
 		}
 
@@ -39,8 +41,9 @@ func JobVersionCheck(dm *DataManager, api *RepoAPI) func() {
 		versions := StringsToVersions(versionStrings)
 		latestVersion := GetLatestVersion(versions)
 
-		if currentVersion.LessThan(latestVersion) {
-			dm.SetVersionData(latestVersion, true)
+		newerVersionAvailable := currentVersion.LessThan(latestVersion)
+		if newerVersionAvailable || vdata.version.Major == 0 {
+			dm.SetVersionData(latestVersion, newerVersionAvailable)
 		}
 	}
 }

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -40,10 +40,10 @@ const (
 	// PermUserRWGroupROthersR user permission type for user to read and write to it, everyone else can only read it.
 	PermUserRWGroupROthersR = 0644
 
-	// PermUserRWGroupROthersR allows user and group to read and write, other only read
+	// PermUserRWGroupRWOthersR allows user and group to read and write, other only read
 	PermUserRWGroupRWOthersR = 0664
 
-	// PermUserRWGroupROthersR user permission type for everyone to read and write to it.
+	// PermUserRWGroupRWOthersRW user permission type for everyone to read and write to it.
 	PermUserRWGroupRWOthersRW = 0666
 
 	// PermUserRWXGroupRXOthersRX forbidding group and others to write to it

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -236,17 +236,19 @@ func EnsureDirFull(path string) error {
 
 // FileWrite writes the given string array to file, previously flushing it clean
 func FileWrite(path string, contents []byte, permissions os.FileMode) error {
-	err := EnsureDir(path)
-	if err != nil {
-		return err
+	if err := EnsureDir(path); err != nil {
+		return fmt.Errorf("failed to create parent folders: %w", err)
 	}
-	err = os.WriteFile(path, contents, permissions)
-	if err != nil {
-		return err
+
+	if err := os.WriteFile(path, contents, permissions); err != nil {
+		return fmt.Errorf("writing file: %w", err)
 	}
 	// if file exists os.WriteFile is not changing the permissions,
 	// ensure file has expected permissions
-	return os.Chmod(path, permissions)
+	if err := os.Chmod(path, permissions); err != nil {
+		return fmt.Errorf("change permissions failed: %w", err)
+	}
+	return nil
 }
 
 // FileCreate with the given permissions, but leave the closing to the caller.

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -240,7 +240,13 @@ func FileWrite(path string, contents []byte, permissions os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, contents, permissions)
+	err = os.WriteFile(path, contents, permissions)
+	if err != nil {
+		return err
+	}
+	// if file exists os.WriteFile is not changing the permissions,
+	// ensure file has expected permissions
+	return os.Chmod(path, permissions)
 }
 
 // FileCreate with the given permissions, but leave the closing to the caller.


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

* Allow access to the moose DB only for root and users part of nordvpn group.
* Update FileWrite to always set file permissions, because os.WriteFile is not updating the permissions if the file already exists.