### PR TITLE
LVPN-8308: fully read SSH response before checking for exit status

### DIFF
--- a/test/qa/lib/ssh.py
+++ b/test/qa/lib/ssh.py
@@ -1,7 +1,6 @@
 import contextlib
 import json
 import time
-import socket
 from collections import namedtuple
 
 import paramiko

--- a/test/qa/lib/ssh.py
+++ b/test/qa/lib/ssh.py
@@ -28,14 +28,14 @@ class Ssh:
         self.client.connect(self.hostname, 22, username=self.username, password=self.password)
 
     def exec_command(self, command: str) -> str:
-        _, stdout, stderr = self.client.exec_command(command, timeout=30)
+        _, stdout, stderr = self.client.exec_command(command, timeout=10)
         try:
             output = stdout.read().decode()
             error = stderr.read().decode()
         except socket.TimeoutError as err:
             stdout.close()
             stderr.close()
-            raise RuntimeError("Socked timed out.") from err
+            raise RuntimeError("Socket timed out.") from err
 
         if stdout.channel.recv_exit_status() != 0:
             msg = f'{output} {error}'

--- a/test/qa/lib/ssh.py
+++ b/test/qa/lib/ssh.py
@@ -28,7 +28,7 @@ class Ssh:
         self.client.connect(self.hostname, 22, username=self.username, password=self.password)
 
     def exec_command(self, command: str) -> str:
-        _, stdout, stderr = self.client.exec_command(command, timeout=0.01)
+        _, stdout, stderr = self.client.exec_command(command, timeout=10)
         try:
             output = stdout.read().decode()
             error = stderr.read().decode()

--- a/test/qa/lib/ssh.py
+++ b/test/qa/lib/ssh.py
@@ -28,11 +28,11 @@ class Ssh:
         self.client.connect(self.hostname, 22, username=self.username, password=self.password)
 
     def exec_command(self, command: str) -> str:
-        _, stdout, stderr = self.client.exec_command(command, timeout=10)
+        _, stdout, stderr = self.client.exec_command(command, timeout=0.01)
         try:
             output = stdout.read().decode()
             error = stderr.read().decode()
-        except socket.TimeoutError as err:
+        except TimeoutError as err:
             stdout.close()
             stderr.close()
             raise RuntimeError("Socket timed out.") from err


### PR DESCRIPTION
In case when SSH response is bigger than SSH window_size, reading recv_exit_status before fully reading the response could lead to a deadlock. recv_exit_status would block because no exit status could be received untill full response from the server is read, but client would not accept any more data because the buffer is full. It is a good practice to first read the response, then check for exit status.