### PR TITLE
LVPN-8118: Replace setup/teardown functions with pytest fixtures

### DIFF
--- a/test/qa/test_allowlist_port.py
+++ b/test/qa/test_allowlist_port.py
@@ -4,28 +4,11 @@ import pytest
 import sh
 
 import lib
-from lib import allowlist, daemon, firewall, info, logging, login
+from lib import allowlist, firewall
 from lib.dynamic_parametrize import dynamic_parametrize
 
 
-def setup_module(module):  # noqa: ARG001
-    firewall.add_and_delete_random_route()
-
-
-def setup_function(function):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
-
-    sh.nordvpn.logout("--persist-token")
-    sh.nordvpn.set.defaults("--logout")
-    daemon.stop()
+pytestmark = pytest.mark.usefixtures("add_and_delete_random_route", "nordvpnd_scope_function")
 
 
 @dynamic_parametrize(["tech", "proto", "obfuscated", "port"], randomized_source=lib.TECHNOLOGIES, ordered_source=lib.PORTS + lib.PORTS_RANGE,

--- a/test/qa/test_allowlist_subnet.py
+++ b/test/qa/test_allowlist_subnet.py
@@ -7,35 +7,13 @@ import sh
 import lib
 from lib import (
     allowlist,
-    daemon,
     firewall,
-    info,
-    logging,
-    login,
     network,
 )
 
+pytestmark = pytest.mark.usefixtures("add_and_delete_random_route", "nordvpnd_scope_function")
+
 CIDR_32 = "/32"
-
-
-def setup_module(module):  # noqa: ARG001
-    firewall.add_and_delete_random_route()
-
-
-def setup_function(function):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
-
-    sh.nordvpn.logout("--persist-token")
-    sh.nordvpn.set.defaults("--logout")
-    daemon.stop()
 
 
 @pytest.mark.parametrize("subnet", lib.SUBNETS)

--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -4,23 +4,11 @@ import pytest
 import sh
 
 import lib
-from lib import daemon, info, logging, login, network, server, settings
+from lib import daemon, network, server, settings
 from lib.shell import sh_no_tty
 
 
-def setup_function(function):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
-
-    sh.nordvpn.logout("--persist-token")
-    sh.nordvpn.set.defaults("--logout")
-    daemon.stop()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_function")
 
 
 def autoconnect_base_test(group):

--- a/test/qa/test_combinations.py
+++ b/test/qa/test_combinations.py
@@ -4,9 +4,6 @@ import sh
 import lib
 from lib import (
     daemon,
-    info,
-    logging,
-    login,
     network
 )
 from test_connect import disconnect_base_test, get_alias
@@ -32,19 +29,7 @@ def connect_base_test(group: str = (), name: str = "", hostname: str = "", ipv6 
     if ipv6:
         assert network.is_ipv6_connected()
 
-def setup_function(function):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
-
-    sh.nordvpn.logout("--persist-token")
-    sh.nordvpn.set.defaults("--logout")
-    daemon.stop()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_function")
 
 
 @pytest.mark.parametrize(("target_tech", "target_proto", "target_obfuscated"), lib.TECHNOLOGIES)

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -6,26 +6,15 @@ import pytest
 import sh
 
 import lib
-from lib import daemon, info, logging, login, network, server
+from lib import daemon, info, logging, network, server
+
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_function")
+
 
 CONNECT_ALIAS = [
     "connect",
     "c"
 ]
-
-def setup_function(function):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
-
-    sh.nordvpn.logout("--persist-token")
-    sh.nordvpn.set.defaults("--logout")
-    daemon.stop()
 
 
 def get_alias() -> str:

--- a/test/qa/test_dns.py
+++ b/test/qa/test_dns.py
@@ -3,30 +3,10 @@ import sh
 import dns.resolver as dnspy
 
 import lib
-from lib import daemon, dns, info, logging, login, settings
+from lib import dns, settings
 
 
-def setup_module(module):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-
-def teardown_module(module):  # noqa: ARG001
-    sh.nordvpn.logout("--persist-token")
-    daemon.stop()
-
-
-def setup_function(function):  # noqa: ARG001
-    logging.log()
-
-    # Make sure that Custom DNS and Threat Protection Lite are disabled before we execute each test
-    lib.set_dns("off")
-    lib.set_threat_protection_lite("off")
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_module", "collect_logs", "disable_dns_and_threat_protection")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)

--- a/test/qa/test_firewall.py
+++ b/test/qa/test_firewall.py
@@ -6,32 +6,12 @@ import sh
 import lib
 from lib import (
     allowlist,
-    daemon,
     firewall,
-    info,
-    logging,
-    login,
     network,
 )
 
 
-def setup_module(module):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-
-def teardown_module(module):  # noqa: ARG001
-    sh.nordvpn.logout("--persist-token")
-    daemon.stop()
-
-
-def setup_function(function):  # noqa: ARG001
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_module", "collect_logs")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)

--- a/test/qa/test_gateway.py
+++ b/test/qa/test_gateway.py
@@ -1,32 +1,15 @@
 import sh
 
+import pytest
 import lib
 from lib import (
     daemon,
-    info,
     logging,
-    login,
     network,
 )
 
 
-def setup_module(module):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-
-def teardown_module(module):  # noqa: ARG001
-    sh.nordvpn.logout("--persist-token")
-    daemon.stop()
-
-
-def setup_function(function):  # noqa: ARG001
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_module", "collect_logs")
 
 
 # Test for 3.8.10 hotfix. Default gateway is not detected when there is not a physical interface

--- a/test/qa/test_grpc.py
+++ b/test/qa/test_grpc.py
@@ -1,26 +1,15 @@
+import pytest
 import threading
 import sh
 import grpc
 from collections.abc import Sequence
-from lib import daemon, info, logging, login
 from lib.protobuf.daemon import (common_pb2, service_pb2_grpc, state_pb2, status_pb2)
 
+
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_function")
+
+
 NORDVPND_SOCKET = 'unix:///run/nordvpn/nordvpnd.sock'
-
-
-def setup_function():  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-    logging.log()
-
-
-def teardown_function():  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
-
-    sh.nordvpn.logout("--persist-token")
-    sh.nordvpn.set.defaults("--logout")
-    daemon.stop()
 
 
 def test_multiple_state_subscribers():

--- a/test/qa/test_killswitch.py
+++ b/test/qa/test_killswitch.py
@@ -4,30 +4,12 @@ import sh
 import lib
 from lib import (
     daemon,
-    info,
-    logging,
     login,
     network,
 )
 
 
-def setup_module(module):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-
-def teardown_module(module):  # noqa: ARG001
-    sh.nordvpn.logout("--persist-token")
-    daemon.stop()
-
-
-def setup_function(function):  # noqa: ARG001
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_module", "collect_logs")
 
 
 MSG_KILLSWITCH_ON = "Kill Switch is set to 'enabled' successfully."

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -5,12 +5,13 @@ import sh
 import lib
 from lib import (
     daemon,
-    info,
-    logging,
     login,
     network,
     settings,
 )
+
+
+pytestmark = pytest.mark.usefixtures("collect_logs")
 
 
 def setup_module(module):  # noqa: ARG001
@@ -19,15 +20,6 @@ def setup_module(module):  # noqa: ARG001
 
 def teardown_module(module):  # noqa: ARG001
     daemon.stop()
-
-
-def setup_function(function):  # noqa: ARG001
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
 
 
 def test_user_consent_is_displayed_on_login():

--- a/test/qa/test_misc.py
+++ b/test/qa/test_misc.py
@@ -6,29 +6,10 @@ import sh
 import lib
 from lib import (
     daemon,
-    logging,
-    login,
     network,
 )
 
-
-def setup_module(module):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-
-def teardown_module(module):  # noqa: ARG001
-    network.unblock()
-    sh.nordvpn.logout("--persist-token")
-    daemon.stop()
-
-
-def setup_function(function):  # noqa: ARG001
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_module", "unblock_network", "collect_logs")
 
 
 def test_api_call_after_vpn_connect():

--- a/test/qa/test_notify.py
+++ b/test/qa/test_notify.py
@@ -2,29 +2,10 @@ import pytest
 import sh
 
 import lib
-from lib import daemon, info, logging, login, notify, settings
+from lib import notify, settings
 
 
-def setup_module(module):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-
-def teardown_module(module):  # noqa: ARG001
-    sh.nordvpn.logout("--persist-token")
-    daemon.stop()
-
-
-def setup_function(function):  # noqa: ARG001
-    logging.log()
-
-    # Make sure that Notifications are disabled before we execute each test
-    lib.set_notify("off")
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
+pytestmark = pytest.mark.usefixtures("nordvpnd_scope_module", "collect_logs", "disable_notifications")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)

--- a/test/qa/test_routing.py
+++ b/test/qa/test_routing.py
@@ -4,27 +4,10 @@ import pytest
 import sh
 
 import lib
-from lib import allowlist, daemon, firewall, info, logging, login, network, settings
+from lib import allowlist, daemon, firewall, network, settings
 
 
-def setup_module(module):  # noqa: ARG001
-    firewall.add_and_delete_random_route()
-
-
-def setup_function(function):  # noqa: ARG001
-    daemon.start()
-    login.login_as("default")
-
-    logging.log()
-
-
-def teardown_function(function):  # noqa: ARG001
-    logging.log(data=info.collect())
-    logging.log()
-
-    sh.nordvpn.logout("--persist-token")
-    sh.nordvpn.set.defaults("--logout")
-    daemon.stop()
+pytestmark = pytest.mark.usefixtures("add_and_delete_random_route", "nordvpnd_scope_function")
 
 
 def get_network_interface(tech):


### PR DESCRIPTION
There are duplicated setup/teardown functions for daemon start/login in test modules. To get rid of duplicated code, it was  decided to replace it with pytest fixtures.