### PR TITLE
LVPN-8307: Update tests for consent

### DIFF
--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -18,4 +18,4 @@ jobs:
       project-id: ${{ secrets.PROJECT_ID }}
     with:
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v1.1.0
+      triggered-ref: v1.1.1

--- a/ci/docker/tester-selenium/requirements.txt
+++ b/ci/docker/tester-selenium/requirements.txt
@@ -1,2 +1,3 @@
 selenium==4.19.0
 pytest-html==4.1.1
+pexpect==4.8.0

--- a/ci/docker/tester/requirements.txt
+++ b/ci/docker/tester/requirements.txt
@@ -11,3 +11,4 @@ protobuf==5.28.3
 selenium==4.26.0
 grpcio==1.68.1
 pytest-html==4.1.1
+pexpect==4.8.0

--- a/daemon/userconsent.go
+++ b/daemon/userconsent.go
@@ -160,7 +160,7 @@ func (acc *AnalyticsConsentChecker) consentModeFromUserLocation() consentMode {
 	}
 
 	mode := modeForCountryCode(core.NewCountryCode(cc))
-	log.Printf(internal.DebugPrefix+" consent mode for country code '%s': %s", insights.CountryCode, mode)
+	log.Printf(internal.DebugPrefix+" consent mode for country code '%s': %s\n", cc, mode)
 	return mode
 }
 

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -23,7 +23,7 @@ const (
 	imageSnapPackager      = registryPrefix + "snaper:1.0.0"
 	imageProtobufGenerator = registryPrefix + "generator:1.4.1"
 	imageScanner           = registryPrefix + "scanner:1.1.0"
-	imageTester            = registryPrefix + "tester:1.4.0"
+	imageTester            = registryPrefix + "tester:1.5.0"
 	imageQAPeer            = registryPrefix + "qa-peer:1.0.4"
 	imageRuster            = registryPrefix + "ruster:1.3.1"
 

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -135,6 +135,18 @@ IPV6_SERVERS = [
 ]
 
 
+EXPECTED_CONSENT_MESSAGE = (
+    "We value your privacy.\n\n"
+    "That's why we want to be transparent about what data you agree to give us. "
+    "We only collect the bare minimum of information required to offer a smooth and stable VPN experience.\n\n"
+    'By pressing "y" (yes), you allow us to collect and use limited app performance data. '
+    "This helps us keep our features relevant to your needs and fix issues faster, as explained in our Privacy Policy. \n"
+    "https://my.nordaccount.com/legal/privacy-policy/?utm_medium=app&utm_source=nordvpn-linux-cli&utm_campaign=settings_account-privacy_policy&nm=app&ns=nordvpn-linux-cli&nc=settings-privacy_policy\n\n"
+    'Press "n" (no) to send only the essential data our app needs to work.\n\n'
+    "Your browsing activities remain private, regardless of your choice.\n\n"
+)
+
+
 class Protocol(Enum):
     UDP = "UDP"
     TCP = "TCP"
@@ -376,3 +388,8 @@ def technology_to_upper_camel_case(tech: str) -> str:
             return "OpenVPN"
         case "NORDWHISPER":
             return "NordWhisper"
+
+
+def squash_whitespace(text: str) -> str:
+    """Normalize whitespace by collapsing all sequences of whitespace into single spaces."""
+    return re.sub(r'\s+', ' ', text.strip())

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -148,7 +148,7 @@ Press "n" (no) to send only the essential data our app needs to work.
 Your browsing activities remain private, regardless of your choice.
 """
 WE_VALUE_YOUR_PRIVACY_MSG = "We value your privacy"
-USER_CONSENT_POMPT = "Do you allow us to collect and use limited app performance data\? \(y/n\)"
+USER_CONSENT_PROMPT = "Do you allow us to collect and use limited app performance data\? \(y/n\)"
 
 
 class UserConsentMode(str, Enum):

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -392,4 +392,4 @@ def technology_to_upper_camel_case(tech: str) -> str:
 
 def squash_whitespace(text: str) -> str:
     """Normalize whitespace by collapsing all sequences of whitespace into single spaces."""
-    return re.sub(r'\s+', ' ', text.strip())
+    return ' '.join(text.split())

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -135,18 +135,21 @@ IPV6_SERVERS = [
 ]
 
 
-EXPECTED_CONSENT_MESSAGE = (
-    "We value your privacy.\n\n"
-    "That's why we want to be transparent about what data you agree to give us. "
-    "We only collect the bare minimum of information required to offer a smooth and stable VPN experience.\n\n"
-    'By pressing "y" (yes), you allow us to collect and use limited app performance data. '
-    "This helps us keep our features relevant to your needs and fix issues faster, as explained in our Privacy Policy. \n"
-    "https://my.nordaccount.com/legal/privacy-policy/?utm_medium=app&utm_source=nordvpn-linux-cli&utm_campaign=settings_account-privacy_policy&nm=app&ns=nordvpn-linux-cli&nc=settings-privacy_policy\n\n"
-    'Press "n" (no) to send only the essential data our app needs to work.\n\n'
-    "Your browsing activities remain private, regardless of your choice.\n\n"
-)
+EXPECTED_CONSENT_MESSAGE = """
+We value your privacy.
+
+That's why we want to be transparent about what data you agree to give us. We only collect the bare minimum of information required to offer a smooth and stable VPN experience.
+
+By pressing "y" (yes), you allow us to collect and use limited app performance data. This helps us keep our features relevant to your needs and fix issues faster, as explained in our Privacy Policy.
+https://my.nordaccount.com/legal/privacy-policy/?utm_medium=app&utm_source=nordvpn-linux-cli&utm_campaign=settings_account-privacy_policy&nm=app&ns=nordvpn-linux-cli&nc=settings-privacy_policy
+
+Press "n" (no) to send only the essential data our app needs to work.
+
+Your browsing activities remain private, regardless of your choice.
+"""
 WE_VALUE_YOUR_PRIVACY_MSG = "We value your privacy"
 USER_CONSENT_POMPT = "Do you allow us to collect and use limited app performance data\? \(y/n\)"
+
 
 class UserConsentMode(str, Enum):
     ENABLED = "enabled"

--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -145,6 +145,13 @@ EXPECTED_CONSENT_MESSAGE = (
     'Press "n" (no) to send only the essential data our app needs to work.\n\n'
     "Your browsing activities remain private, regardless of your choice.\n\n"
 )
+WE_VALUE_YOUR_PRIVACY_MSG = "We value your privacy"
+USER_CONSENT_POMPT = "Do you allow us to collect and use limited app performance data\? \(y/n\)"
+
+class UserConsentMode(str, Enum):
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+    UNDEFINED = "undefined"
 
 
 class Protocol(Enum):

--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -1,9 +1,16 @@
 import json
 import os
+from enum import Enum
 
 import sh
 
 from . import logging, ssh
+
+
+class ConsentMode(Enum):
+    Undefined = 0
+    Granted = 1
+    Denied = 2
 
 
 class Credentials:
@@ -33,12 +40,28 @@ def get_credentials(key) -> Credentials:
             password=creds.get("password", None))
 
 
-def login_as(username, ssh_client: ssh.Ssh = None):
+def login_as(username, ssh_client: ssh.Ssh = None, with_analytics: ConsentMode = ConsentMode.Granted):
     """login_as specified user with optional delay before calling login."""
     token = get_credentials(username).token
 
     logging.log(f"logging in as {token}")
 
     if ssh_client is not None:
+        if with_analytics != ConsentMode.Undefined:
+            ssh_client.exec_command(f"nordvpn set analytics {analytics_value(with_analytics)}")
         return ssh_client.exec_command(f"nordvpn login --token {token}")
+
+    if with_analytics != ConsentMode.Undefined:
+        sh.nordvpn.set.analytics(analytics_value(with_analytics))
     return sh.nordvpn.login("--token", token)
+
+
+def analytics_value(mode: ConsentMode) -> str:
+    if mode == ConsentMode.Undefined:
+        raise "can't enable analytics with undefined consent"
+    elif mode == ConsentMode.Granted:
+        return "on"
+    elif mode == ConsentMode.Denied:
+        return "off"
+    raise f"not supported consent mode: {mode}"
+

--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -41,10 +41,7 @@ def get_credentials(key) -> Credentials:
 
 
 def login_as(username, ssh_client: ssh.Ssh = None, with_analytics: ConsentMode = ConsentMode.Granted):
-    """
-    login_as specified user, optional SSH connection and option for
-    setting analytics consent before calling login.
-    """
+    """login_as specified user, optional SSH connection and option for setting analytics consent before calling login."""
     token = get_credentials(username).token
 
     logging.log(f"logging in as {token}")
@@ -62,9 +59,13 @@ def login_as(username, ssh_client: ssh.Ssh = None, with_analytics: ConsentMode =
 def _analytics_value(mode: ConsentMode) -> str:
     if mode == ConsentMode.Undefined:
         raise Exception("can't set analytics with undefined consent")
-    elif mode == ConsentMode.Granted:
+
+    if mode == ConsentMode.Granted:
         return "on"
-    elif mode == ConsentMode.Denied:
+
+    if mode == ConsentMode.Denied:
         return "off"
-    raise Exception(f"not supported consent mode: {mode}")
+
+    msg = f"not supported consent mode: {mode}"
+    raise Exception(msg)
 

--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -41,27 +41,30 @@ def get_credentials(key) -> Credentials:
 
 
 def login_as(username, ssh_client: ssh.Ssh = None, with_analytics: ConsentMode = ConsentMode.Granted):
-    """login_as specified user with optional delay before calling login."""
+    """
+    login_as specified user, optional SSH connection and option for
+    setting analytics consent before calling login.
+    """
     token = get_credentials(username).token
 
     logging.log(f"logging in as {token}")
 
     if ssh_client is not None:
         if with_analytics != ConsentMode.Undefined:
-            ssh_client.exec_command(f"nordvpn set analytics {analytics_value(with_analytics)}")
+            ssh_client.exec_command(f"nordvpn set analytics {_analytics_value(with_analytics)}")
         return ssh_client.exec_command(f"nordvpn login --token {token}")
 
     if with_analytics != ConsentMode.Undefined:
-        sh.nordvpn.set.analytics(analytics_value(with_analytics))
+        sh.nordvpn.set.analytics(_analytics_value(with_analytics))
     return sh.nordvpn.login("--token", token)
 
 
-def analytics_value(mode: ConsentMode) -> str:
+def _analytics_value(mode: ConsentMode) -> str:
     if mode == ConsentMode.Undefined:
-        raise "can't enable analytics with undefined consent"
+        raise Exception("can't set analytics with undefined consent")
     elif mode == ConsentMode.Granted:
         return "on"
     elif mode == ConsentMode.Denied:
         return "off"
-    raise f"not supported consent mode: {mode}"
+    raise Exception(f"not supported consent mode: {mode}")
 

--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -5,7 +5,7 @@ import pexpect
 
 import sh
 
-from . import UserConsentMode, logging, ssh, squash_whitespace, WE_VALUE_YOUR_PRIVACY_MSG, USER_CONSENT_POMPT
+from . import UserConsentMode, logging, ssh, squash_whitespace, WE_VALUE_YOUR_PRIVACY_MSG, USER_CONSENT_PROMPT
 
 
 class Credentials:
@@ -75,7 +75,7 @@ def spawn_nordvpn_login():
 
 def wait_for_consent_prompt(cli):
     """Waits for the consent prompt to appear."""
-    cli.expect(USER_CONSENT_POMPT)
+    cli.expect(USER_CONSENT_PROMPT)
 
 
 def get_new_output(buffer, old_output=""):

--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -1,9 +1,11 @@
 import json
 import os
+import io
+import pexpect
 
 import sh
 
-from . import UserConsentMode, logging, ssh
+from . import UserConsentMode, logging, ssh, squash_whitespace, WE_VALUE_YOUR_PRIVACY_MSG, USER_CONSENT_POMPT
 
 
 class Credentials:
@@ -62,3 +64,30 @@ def _analytics_value(mode: UserConsentMode) -> str:
     msg = f"not supported consent mode: {mode}"
     raise Exception(msg)
 
+
+def spawn_nordvpn_login():
+    """Spawns the nordvpn login process and sets up an output buffer."""
+    buffer = io.StringIO()
+    cli = pexpect.spawn("nordvpn", args=["login"], encoding="utf-8", timeout=10)
+    cli.logfile_read = buffer
+    return cli, buffer
+
+
+def wait_for_consent_prompt(cli):
+    """Waits for the consent prompt to appear."""
+    cli.expect(USER_CONSENT_POMPT)
+
+
+def get_new_output(buffer, old_output=""):
+    """Returns only the newly added output since old_output."""
+    return buffer.getvalue()[len(old_output):]
+
+
+def assert_prompt_present(output, message=WE_VALUE_YOUR_PRIVACY_MSG):
+    """Asserts that the consent message is in the output."""
+    assert message in squash_whitespace(output)
+
+
+def assert_prompt_absent(output, message=WE_VALUE_YOUR_PRIVACY_MSG):
+    """Asserts that the consent message is not in the output."""
+    assert message not in squash_whitespace(output)

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -109,25 +109,25 @@ def is_dns_disabled():
     return Settings().get("DNS") == "disabled"
 
 
-def is_analytics_consent_granted():
+def is_user_consent_granted():
     """
-    Returns True, if Analytics Consent is granted, False if it's denied.
+    Returns True, if User Consent is enabled, False if it's disabled.
 
     If the consent was not declared. It raises an exception.
     """
-    analytics_consent = Settings().get("analytics consent")
-    if analytics_consent == "granted":
+    user_consent = Settings().get("user consent")
+    if user_consent == "enabled":
         return True
 
-    if analytics_consent == "denied":
+    if user_consent == "disabled":
         return False
 
-    raise Exception("analytics consent is undefined")
+    raise Exception("user consent is undefined")
 
 
-def is_analytics_consent_declared():
-    """Returns True, if Analytics Consent is denied or granted, False if it's undefined in application settings."""
-    return Settings().get("analytics consent") != "undefined"
+def is_user_consent_declared():
+    """Returns True, if User Consent is enabled or disabled, False if it's undefined in application settings."""
+    return Settings().get("user consent") != "undefined"
 
 
 def is_ipv6_enabled():

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -2,6 +2,8 @@ import random
 
 import sh
 
+from . import UserConsentMode
+
 
 MSG_AUTOCONNECT_ENABLE_SUCCESS = "Auto-connect is set to 'enabled' successfully."
 MSG_AUTOCONNECT_DISABLE_SUCCESS = "Auto-connect is set to 'disabled' successfully."
@@ -116,10 +118,10 @@ def is_user_consent_granted():
     If the consent was not declared. It raises an exception.
     """
     user_consent = Settings().get("user consent")
-    if user_consent == "enabled":
+    if user_consent == UserConsentMode.ENABLED:
         return True
 
-    if user_consent == "disabled":
+    if user_consent == UserConsentMode.DISABLED:
         return False
 
     raise Exception("user consent is undefined")
@@ -127,7 +129,7 @@ def is_user_consent_granted():
 
 def is_user_consent_declared():
     """Returns True, if User Consent is enabled or disabled, False if it's undefined in application settings."""
-    return Settings().get("user consent") != "undefined"
+    return Settings().get("user consent") != UserConsentMode.UNDEFINED
 
 
 def is_ipv6_enabled():

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -112,13 +112,16 @@ def is_dns_disabled():
 def is_analytics_consent_granted():
     """
     Returns True, if Analytics Consent is granted, False if it's denied.
+
     If the consent was not declared. It raises an exception.
     """
     analytics_consent = Settings().get("analytics consent")
     if analytics_consent == "granted":
         return True
-    elif analytics_consent == "denied":
+
+    if analytics_consent == "denied":
         return False
+
     raise Exception("analytics consent is undefined")
 
 

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -109,9 +109,22 @@ def is_dns_disabled():
     return Settings().get("DNS") == "disabled"
 
 
-def are_analytics_enabled():
-    """Returns True, if Analytics are enabled in application settings."""
-    return Settings().get("Analytics") == "enabled"
+def is_analytics_consent_granted():
+    """
+    Returns True, if Analytics Consent is granted, False if it's denied.
+    If the consent was not declared. It raises an exception.
+    """
+    analytics_consent = Settings().get("analytics consent")
+    if analytics_consent == "granted":
+        return True
+    elif analytics_consent == "denied":
+        return False
+    raise Exception("analytics consent is undefined")
+
+
+def is_analytics_consent_declared():
+    """Returns True, if Analytics Consent is denied or granted, False if it's undefined in application settings."""
+    return Settings().get("analytics consent") != "undefined"
 
 
 def is_ipv6_enabled():
@@ -137,7 +150,8 @@ def app_has_defaults_settings():
         "Firewall: enabled" in settings and
         "Firewall Mark: 0xe1f1" in settings and
         "Routing: enabled" in settings and
-        "Analytics: enabled" in settings and
+        # Analytics Consent is not restored to default on reset
+        ("Analytics Consent: granted" in settings or "Analytics Consent: denied" in settings) and
         "Kill Switch: disabled" in settings and
         "Threat Protection Lite: disabled" in settings and
         "Notify: enabled" in settings and

--- a/test/qa/lib/settings.py
+++ b/test/qa/lib/settings.py
@@ -128,7 +128,7 @@ def is_user_consent_granted():
 
 
 def is_user_consent_declared():
-    """Returns True, if User Consent is enabled or disabled, False if it's undefined in application settings."""
+    """Returns True, if User Consent is enabled or disabled, False if it is undefined in application settings."""
     return Settings().get("user consent") != UserConsentMode.UNDEFINED
 
 
@@ -155,8 +155,8 @@ def app_has_defaults_settings():
         "Firewall: enabled" in settings and
         "Firewall Mark: 0xe1f1" in settings and
         "Routing: enabled" in settings and
-        # Analytics Consent is not restored to default on reset
-        ("Analytics Consent: granted" in settings or "Analytics Consent: denied" in settings) and
+        # User Consent is not restored to default on reset
+        ("User Consent: enabled" in settings or "User Consent: disabled" in settings) and
         "Kill Switch: disabled" in settings and
         "Threat Protection Lite: disabled" in settings and
         "Notify: enabled" in settings and

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -112,7 +112,7 @@ def test_analytics_consent_granted_after_pressing_y_and_does_not_appear_again():
     try:
         # try to match the consent prompt
         cli2.expect(r"Do you allow us to collect and use limited app performance data\? \(y/n\)", timeout=3)
-        assert False, "Consent prompt appeared again after it was already granted"
+        raise AssertionError("Consent prompt appeared again after it was already granted")
     except pexpect.exceptions.TIMEOUT:
         # good - the prompt didn't appear
         pass

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -31,7 +31,7 @@ def teardown_function(function):  # noqa: ARG001
     logging.log()
 
 
-def test_analytics_consent_is_displayed_on_login():
+def test_user_consent_is_displayed_on_login():
     cli = pexpect.spawn("nordvpn", args=["login"], encoding='utf-8', timeout=10)
     # wait until the final prompt appears, then capture everything before it
     cli.expect(r"Do you allow us to collect and use limited app performance data\? \(y/n\)")
@@ -65,7 +65,7 @@ def test_invalid_input_repeats_consent_prompt_only():
     assert "(y/n)" in lib.squash_whitespace(second_output)
 
 
-def test_analytics_consent_prompt_reappears_after_ctrl_c_interrupt():
+def test_user_consent_prompt_reappears_after_ctrl_c_interrupt():
     # first run: user is interrupted with Ctrl+C at the prompt
     cli1 = pexpect.spawn("nordvpn", args=["login"], encoding="utf-8", timeout=10)
     buffer1 = io.StringIO()
@@ -94,17 +94,17 @@ def test_analytics_consent_prompt_reappears_after_ctrl_c_interrupt():
         "Consent prompt did not reappear on second login attempt"
 
 
-def test_analytics_consent_granted_after_pressing_y_and_does_not_appear_again():
+def test_user_consent_granted_after_pressing_y_and_does_not_appear_again():
     # first run: prompt appears, user consents
     cli = pexpect.spawn("nordvpn", args=["login"], encoding='utf-8', timeout=10)
     cli.expect(r"Do you allow us to collect and use limited app performance data\? \(y/n\)")
 
-    assert not settings.is_analytics_consent_declared(), "Consent should not be declared before interaction"
+    assert not settings.is_user_consent_declared(), "Consent should not be declared before interaction"
 
     cli.sendline("y")
     cli.expect(pexpect.EOF)
 
-    assert settings.is_analytics_consent_granted(), "Consent should be recorded after pressing 'y'"
+    assert settings.is_user_consent_granted(), "Consent should be recorded after pressing 'y'"
 
     # second run: ensure the consent prompt does NOT appear again
     cli2 = pexpect.spawn("nordvpn", args=["login"], encoding='utf-8', timeout=10)

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -82,7 +82,7 @@ def test_user_consent_granted_after_pressing_y_and_does_not_appear_again():
 
     cli2, _ = login.spawn_nordvpn_login()
     try:
-        cli2.expect(lib.USER_CONSENT_POMPT)
+        cli2.expect(lib.USER_CONSENT_PROMPT)
         raise AssertionError("Consent prompt appeared again after it was already granted")
     except (pexpect.exceptions.TIMEOUT, pexpect.exceptions.EOF):
         pass  # Good, prompt did not appear

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -1,6 +1,5 @@
 import pytest
 import pexpect
-import io
 import sh
 
 import lib

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -32,9 +32,9 @@ def teardown_function(function):  # noqa: ARG001
 
 
 def test_user_consent_is_displayed_on_login():
-    cli = pexpect.spawn("nordvpn", args=["login"], encoding='utf-8', timeout=10)
-    # wait until the final prompt appears, then capture everything before it
-    cli.expect(lib.USER_CONSENT_POMPT)
+    cli, _ = login.spawn_nordvpn_login()
+    login.wait_for_consent_prompt(cli)
+
     full_output = cli.before + cli.after  # everything printed so far, including the last line
 
     assert (
@@ -44,82 +44,49 @@ def test_user_consent_is_displayed_on_login():
 
 
 def test_invalid_input_repeats_consent_prompt_only():
-    output_buffer = io.StringIO()
-    cli = pexpect.spawn("nordvpn", args=["login"], encoding="utf-8", timeout=10)
-    cli.logfile_read = output_buffer
+    cli, buffer = login.spawn_nordvpn_login()
+    login.wait_for_consent_prompt(cli)
+    first_output = buffer.getvalue()
 
-    # wait for first full prompt
-    cli.expect(lib.USER_CONSENT_POMPT)
-    first_output = output_buffer.getvalue()
-
-    # send invalid input
     cli.sendline("blah")
+    login.wait_for_consent_prompt(cli)
+    second_output = login.get_new_output(buffer, first_output)
 
-    # wait for error + prompt again
-    cli.expect(lib.USER_CONSENT_POMPT)
-    second_output = output_buffer.getvalue()[len(first_output):]  # take just the new part
-
-    assert lib.WE_VALUE_YOUR_PRIVACY_MSG in lib.squash_whitespace(first_output)
-    assert lib.WE_VALUE_YOUR_PRIVACY_MSG not in lib.squash_whitespace(second_output)
+    login.assert_prompt_present(first_output)
+    login.assert_prompt_absent(second_output)
     assert "Invalid response" in lib.squash_whitespace(second_output)
     assert "(y/n)" in lib.squash_whitespace(second_output)
 
 
 def test_user_consent_prompt_reappears_after_ctrl_c_interrupt():
-    # first run: user is interrupted with Ctrl+C at the prompt
-    cli1 = pexpect.spawn("nordvpn", args=["login"], encoding="utf-8", timeout=10)
-    buffer1 = io.StringIO()
-    cli1.logfile_read = buffer1
-
-    # wait for the consent prompt
-    cli1.expect(lib.USER_CONSENT_POMPT)
-
-    # simulate user hitting Ctrl+C
-    cli1.sendintr()  # this sends SIGINT like Ctrl+C
+    cli1, buffer1 = login.spawn_nordvpn_login()
+    login.wait_for_consent_prompt(cli1)
+    cli1.sendintr()
     cli1.expect(pexpect.EOF)
-    first_output = buffer1.getvalue()
+    output1 = buffer1.getvalue()
+    login.assert_prompt_present(output1)
 
-    assert lib.WE_VALUE_YOUR_PRIVACY_MSG in lib.squash_whitespace(first_output), \
-        "Consent prompt not shown before Ctrl+C"
-
-    # second run: should still see the prompt
-    cli2 = pexpect.spawn("nordvpn", args=["login"], encoding="utf-8", timeout=10)
-    buffer2 = io.StringIO()
-    cli2.logfile_read = buffer2
-
-    cli2.expect(lib.USER_CONSENT_POMPT)
-    second_output = buffer2.getvalue()
-
-    assert lib.WE_VALUE_YOUR_PRIVACY_MSG in lib.squash_whitespace(second_output), \
-        "Consent prompt did not reappear on second login attempt"
+    cli2, buffer2 = login.spawn_nordvpn_login()
+    login.wait_for_consent_prompt(cli2)
+    output2 = buffer2.getvalue()
+    login.assert_prompt_present(output2)
 
 
 def test_user_consent_granted_after_pressing_y_and_does_not_appear_again():
-    # first run: prompt appears, user consents
-    cli = pexpect.spawn("nordvpn", args=["login"], encoding='utf-8', timeout=10)
-    cli.expect(lib.USER_CONSENT_POMPT)
+    cli, _ = login.spawn_nordvpn_login()
+    login.wait_for_consent_prompt(cli)
 
     assert not settings.is_user_consent_declared(), "Consent should not be declared before interaction"
-
     cli.sendline("y")
     cli.expect(pexpect.EOF)
-
     assert settings.is_user_consent_granted(), "Consent should be recorded after pressing 'y'"
 
-    # second run: ensure the consent prompt does NOT appear again
-    cli2 = pexpect.spawn("nordvpn", args=["login"], encoding='utf-8', timeout=10)
-
+    cli2, _ = login.spawn_nordvpn_login()
     try:
-        # try to match the consent prompt
         cli2.expect(lib.USER_CONSENT_POMPT)
         raise AssertionError("Consent prompt appeared again after it was already granted")
-    except pexpect.exceptions.TIMEOUT:
-        # good - the prompt didn't appear
-        pass
-    except pexpect.exceptions.EOF:
-        # also good — the process exited before showing the prompt
-        pass
-
+    except (pexpect.exceptions.TIMEOUT, pexpect.exceptions.EOF):
+        pass  # Good, prompt did not appear
     cli2.expect(pexpect.EOF)
 
 

--- a/test/qa/test_login_nordaccount.py
+++ b/test/qa/test_login_nordaccount.py
@@ -73,6 +73,7 @@ def test_selenium_login_callback(login_flag):
     browser = sel.browser_get()
 
     with lib.Defer(sel.browser_kill):
+        sh.nordvpn.set.analytics("on")
         # Get login link from NordVPN app, trim all spaces & chars after link itself
         login_link = sh.nordvpn.login(login_flag, _tty_out=False).strip().split(": ")[1]
         print(f"Login link: {login_link}\n")

--- a/test/qa/test_meshnet_other.py
+++ b/test/qa/test_meshnet_other.py
@@ -82,7 +82,7 @@ def test_set_defaults_when_logged_out_1st_set(tech, proto, obfuscated):
     assert "0xe1f1" not in  sh_no_tty.nordvpn.settings()
     assert daemon.is_killswitch_on()
     assert settings.is_lan_discovery_enabled()
-    assert settings.is_analytics_consent_declared()
+    assert settings.is_user_consent_declared()
     assert settings.is_tpl_enabled()
 
     if obfuscated == "on":

--- a/test/qa/test_meshnet_other.py
+++ b/test/qa/test_meshnet_other.py
@@ -82,7 +82,7 @@ def test_set_defaults_when_logged_out_1st_set(tech, proto, obfuscated):
     assert "0xe1f1" not in  sh_no_tty.nordvpn.settings()
     assert daemon.is_killswitch_on()
     assert settings.is_lan_discovery_enabled()
-    assert not settings.are_analytics_enabled()
+    assert settings.is_analytics_consent_declared()
     assert settings.is_tpl_enabled()
 
     if obfuscated == "on":

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -83,7 +83,7 @@ def test_set_defaults_when_logged_in_1st_set(tech, proto, obfuscated):
     assert not settings.is_firewall_enabled()
     assert not settings.is_routing_enabled()
     assert not settings.is_dns_disabled()
-    assert settings.is_analytics_consent_declared()
+    assert settings.is_user_consent_declared()
     assert settings.is_ipv6_enabled()
     assert settings.is_notify_enabled()
     assert not settings.is_virtual_location_enabled()
@@ -159,7 +159,7 @@ def test_set_defaults_when_connected_1st_set(tech, proto, obfuscated):
 
     assert not settings.is_routing_enabled()
     assert not settings.is_dns_disabled()
-    assert settings.is_analytics_consent_declared()
+    assert settings.is_user_consent_declared()
     assert settings.is_lan_discovery_enabled()
     assert not settings.is_virtual_location_enabled()
 
@@ -261,10 +261,10 @@ def test_set_analytics_starts_prompt_even_if_completed_before():
 def test_set_analytics_off_on():
 
     assert "Analytics is set to 'disabled' successfully." in sh.nordvpn.set.analytics("off")
-    assert not settings.is_analytics_consent_granted()
+    assert not settings.is_user_consent_granted()
 
     assert "Analytics is set to 'enabled' successfully." in sh.nordvpn.set.analytics("on")
-    assert settings.is_analytics_consent_granted()
+    assert settings.is_user_consent_granted()
 
 
 def test_set_analytics_on_off_repeated():

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -233,7 +233,7 @@ def test_is_custom_dns_removed_after_setting_defaults(tech, proto, obfuscated, n
 def test_set_analytics_starts_prompt_even_if_completed_before():
     # first run: see prompt and respond
     cli1 = pexpect.spawn("nordvpn", args=["set", "analytics"], encoding='utf-8', timeout=10)
-    cli1.expect(lib.USER_CONSENT_POMPT)
+    cli1.expect(lib.USER_CONSENT_PROMPT)
     output1 = cli1.before + cli1.after
 
     assert (
@@ -246,7 +246,7 @@ def test_set_analytics_starts_prompt_even_if_completed_before():
 
     # second run: should see the prompt again
     cli2 = pexpect.spawn("nordvpn", args=["set", "analytics"], encoding='utf-8', timeout=10)
-    cli2.expect(lib.USER_CONSENT_POMPT)
+    cli2.expect(lib.USER_CONSENT_PROMPT)
     output2 = cli2.before + cli2.after
 
     assert (

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -233,7 +233,7 @@ def test_is_custom_dns_removed_after_setting_defaults(tech, proto, obfuscated, n
 def test_set_analytics_starts_prompt_even_if_completed_before():
     # first run: see prompt and respond
     cli1 = pexpect.spawn("nordvpn", args=["set", "analytics"], encoding='utf-8', timeout=10)
-    cli1.expect(r"Do you allow us to collect and use limited app performance data\? \(y/n\)")
+    cli1.expect(lib.USER_CONSENT_POMPT)
     output1 = cli1.before + cli1.after
 
     assert (
@@ -246,7 +246,7 @@ def test_set_analytics_starts_prompt_even_if_completed_before():
 
     # second run: should see the prompt again
     cli2 = pexpect.spawn("nordvpn", args=["set", "analytics"], encoding='utf-8', timeout=10)
-    cli2.expect(r"Do you allow us to collect and use limited app performance data\? \(y/n\)")
+    cli2.expect(lib.USER_CONSENT_POMPT)
     output2 = cli2.before + cli2.after
 
     assert (

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -82,7 +82,7 @@ def test_set_defaults_when_logged_in_1st_set(tech, proto, obfuscated):
     assert not settings.is_firewall_enabled()
     assert not settings.is_routing_enabled()
     assert not settings.is_dns_disabled()
-    assert not settings.are_analytics_enabled()
+    assert settings.is_analytics_consent_declared()
     assert settings.is_ipv6_enabled()
     assert settings.is_notify_enabled()
     assert not settings.is_virtual_location_enabled()
@@ -158,7 +158,7 @@ def test_set_defaults_when_connected_1st_set(tech, proto, obfuscated):
 
     assert not settings.is_routing_enabled()
     assert not settings.is_dns_disabled()
-    assert not settings.are_analytics_enabled()
+    assert settings.is_analytics_consent_declared()
     assert settings.is_lan_discovery_enabled()
     assert not settings.is_virtual_location_enabled()
 
@@ -232,10 +232,10 @@ def test_is_custom_dns_removed_after_setting_defaults(tech, proto, obfuscated, n
 def test_set_analytics_off_on():
 
     assert "Analytics is set to 'disabled' successfully." in sh.nordvpn.set.analytics("off")
-    assert not settings.are_analytics_enabled()
+    assert not settings.is_analytics_consent_granted()
 
     assert "Analytics is set to 'enabled' successfully." in sh.nordvpn.set.analytics("on")
-    assert settings.are_analytics_enabled()
+    assert settings.is_analytics_consent_granted()
 
 
 def test_set_analytics_on_off_repeated():


### PR DESCRIPTION
Changes:
- adds `pexpect` as a dependency to tester and bumps tester image
- updates existing tests to take into account analytics consent
- adds new tests for analytics consent:
  - analytics consent displayed on login
  - invalid user input repeats the prompt
  - ctrl+c causes the prompt to appear again on next login
  - after confirming consent it does not appear again
  - `nordvpn set analytics` also triggers prompt
- helpers