### PR TITLE
LVPN-6013: Integrate Architecture metrics

### DIFF
--- a/cmd/daemon/events_linux.go
+++ b/cmd/daemon/events_linux.go
@@ -52,6 +52,7 @@ func newAnalytics(
 	fs *config.FilesystemConfigManager,
 	subAPI core.SubscriptionAPI,
 	httpClient http.Client,
-	version, env, id string) *dummyAnalytics {
+	buildTarget config.BuildTarget,
+	id string) *dummyAnalytics {
 	return &dummyAnalytics{}
 }

--- a/cmd/daemon/events_moose.go
+++ b/cmd/daemon/events_moose.go
@@ -23,14 +23,14 @@ func newAnalytics(
 	fs *config.FilesystemConfigManager,
 	subAPI core.SubscriptionAPI,
 	httpClient http.Client,
-	ver, env, id string) *moose.Subscriber {
+	buildTarget config.BuildTarget,
+	id string) *moose.Subscriber {
 	_ = os.Setenv("MOOSE_LOG_FILE", "Stdout")
 
 	sub := &moose.Subscriber{
 		EventsDbPath:    eventsDbPath,
 		Config:          fs,
-		Version:         ver,
-		Environment:     env,
+		BuildTarget:     buildTarget,
 		Domain:          EventsDomain,
 		Subdomain:       EventsSubdomain,
 		DeviceID:        id,

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -296,7 +296,7 @@ func main() {
 		Version:      Version,
 		Environment:  Environment,
 		Architecture: Arch}
-	if archVariant, err := machineIdGenerator.GetArchitectureVariantName(Arch); err == nil {
+	if archVariant, err := machineIdGenerator.GetArchitectureVariantName(sysinfo.GetHostArchitecture()); err == nil {
 		buildTarget.Architecture = archVariant
 	}
 

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -115,7 +115,6 @@ const (
 )
 
 func main() {
-
 	// pprof
 	if internal.IsDevEnv(Environment) {
 		go func() {
@@ -292,15 +291,21 @@ func main() {
 	// obfuscated machineID and add the mask to identify how the ID was generated
 	deviceID := fmt.Sprintf("%x_%d", sha256.Sum256([]byte(machineID.String()+Salt)), machineIdGenerator.GetUsedInformationMask())
 
+	// populate build target configuration
+	buildTarget := config.BuildTarget{
+		Version:      Version,
+		Environment:  Environment,
+		Architecture: Arch}
+	if archVariant, err := machineIdGenerator.GetArchitectureVariantName(Arch); err == nil {
+		buildTarget.Architecture = archVariant
+	}
+
 	analytics := newAnalytics(
 		eventsDbPath,
 		fsystem,
 		defaultAPI,
 		*httpClientSimple,
-		config.BuildTarget{
-			Version:      Version,
-			Environment:  Environment,
-			Architecture: Arch},
+		buildTarget,
 		deviceID)
 
 	heartBeatSubject.Subscribe(analytics.NotifyHeartBeat)

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -115,6 +115,7 @@ const (
 )
 
 func main() {
+
 	// pprof
 	if internal.IsDevEnv(Environment) {
 		go func() {
@@ -291,7 +292,17 @@ func main() {
 	// obfuscated machineID and add the mask to identify how the ID was generated
 	deviceID := fmt.Sprintf("%x_%d", sha256.Sum256([]byte(machineID.String()+Salt)), machineIdGenerator.GetUsedInformationMask())
 
-	analytics := newAnalytics(eventsDbPath, fsystem, defaultAPI, *httpClientSimple, Version, Environment, deviceID)
+	analytics := newAnalytics(
+		eventsDbPath,
+		fsystem,
+		defaultAPI,
+		*httpClientSimple,
+		config.BuildTarget{
+			Version:      Version,
+			Environment:  Environment,
+			Architecture: Arch},
+		deviceID)
+
 	heartBeatSubject.Subscribe(analytics.NotifyHeartBeat)
 	httpCallsSubject.Subscribe(analytics.NotifyRequestAPI)
 	daemonEvents.Subscribe(analytics)

--- a/config/build_target.go
+++ b/config/build_target.go
@@ -1,0 +1,8 @@
+package config
+
+// BuildTarget mirrors values passed to a compiler when building
+type BuildTarget struct {
+	Version      string
+	Environment  string
+	Architecture string
+}

--- a/config/machine_id_test.go
+++ b/config/machine_id_test.go
@@ -180,3 +180,416 @@ func TestFallbackGenerateUUID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEqual(t, id, uuid.UUID{})
 }
+
+func TestMachineID_GetArchitectureVariantName(t *testing.T) {
+	tests := []struct {
+		name       string
+		archFamily string
+		content    string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "Detects valid ARMv7",
+			archFamily: "armhf",
+			content: `Linux Everest 3.2.40 #7321 SMP Wed Mar 23 11:47:17 CST 2016 armv7l GNU/Linux synology_armada375_ds115
+Processor : ARMv7 Processor rev 1 (v7l)
+processor : 0
+BogoMIPS : 1594.16
+
+processor : 1
+BogoMIPS : 1594.16
+
+Features : swp half thumb fastmult vfp edsp neon vfpv3 tls
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant : 0x4
+CPU part : 0xc09
+CPU revision : 1
+
+Hardware : Marvell Armada-375 Board
+Revision : 0000
+Serial : 0000000000000000`,
+			want:    "armhfv7",
+			wantErr: false,
+		},
+		{
+			name:       "Detects valid ARMv5TE",
+			archFamily: "armel",
+			content: `Processor name : Feroceon 88F6281 rev 1 (v5l) @ 1.2 GHz
+BogoMIPS : 1196.85
+Features : swp half thumb fastmult edsp
+CPU implementer : 0x56
+CPU architecture: 5TE
+CPU variant : 0x2
+CPU part : 0x131
+CPU revision : 1
+
+Hardware : Feroceon-KW ARM
+Revision : 0000
+Serial : 0000000000000000`,
+			want:    "armelv5te",
+			wantErr: false,
+		},
+		{
+			name:       "Detects valid ARMv7 (2)",
+			archFamily: "armhf",
+			content: `Processor : Marvell PJ4Bv7 Processor rev 2 (v7l)
+processor : 0
+BogoMIPS : 1196.85
+
+processor : 1
+BogoMIPS : 1196.85
+
+processor : 2
+BogoMIPS : 1196.85
+
+Features : swp half thumb fastmult vfp edsp vfpv3 tls
+CPU implementer : 0x56
+CPU architecture: 7
+CPU variant : 0x2
+CPU part : 0x584
+CPU revision : 2
+
+Hardware : Marvell Armada XP Development Board
+Revision : 0000
+Serial : 0000000000000000`,
+			want:    "armhfv7",
+			wantErr: false,
+		},
+		{
+			name:       "Detects valid ARMv8",
+			archFamily: "aarch64",
+			content: `Processor       : AArch64 Processor rev 4 (aarch64)
+processor       : 0
+processor       : 1
+processor       : 2
+processor       : 3
+Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 wp half thumb fastmult vfp edsp neon vfpv3 tlsi vfpv4 idiva idivt
+CPU implementer : 0x41
+CPU architecture: 8
+CPU variant     : 0x0
+CPU part        : 0xd03
+CPU revision    : 4
+
+Hardware        : Amlogic
+Serial          : beca79021141185f
+AmLogic Serial  : 210d740041443cd1828b454f6133c990`,
+			want:    "aarch64v8",
+			wantErr: false,
+		},
+		{
+			name:       "Detects valid ARMv7 (3) Multi processors",
+			archFamily: "armhf",
+			content: `processor : 0
+model name : ARMv7 Processor rev 4 (v7l)
+BogoMIPS : 38.40
+Features : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant : 0x0
+CPU part : 0xd03
+CPU revision : 4
+
+processor : 1
+model name : ARMv7 Processor rev 4 (v7l)
+BogoMIPS : 38.40
+Features : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant : 0x0
+CPU part : 0xd03
+CPU revision : 4
+
+processor : 2
+model name : ARMv7 Processor rev 4 (v7l)
+BogoMIPS : 38.40
+Features : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant : 0x0
+CPU part : 0xd03
+CPU revision : 4
+
+processor : 3
+model name : ARMv7 Processor rev 4 (v7l)
+BogoMIPS : 38.40
+Features : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant : 0x0
+CPU part : 0xd03
+CPU revision : 4
+
+Hardware : BCM2709
+Revision : a22082
+Serial : 000000000db98e4e`,
+			want:    "armhfv7",
+			wantErr: false,
+		},
+		{
+			name:       "Detects valid ARMv6",
+			archFamily: "armel",
+			content: `Processor       : ARMv6-compatible processor rev 7 (v6l)
+BogoMIPS        : 697.95
+Features        : half thumb fastmult vfp edsp java tls
+CPU implementer : 0x41
+CPU architecture: 6
+CPU variant     : 0x0
+CPU part        : 0xb76
+CPU revision    : 7
+Hardware        : BCM2708
+Revision        : 0002
+Serial          : 00000000abcdef01`,
+			want:    "armelv6",
+			wantErr: false,
+		},
+		{
+			name:       "Detects valid ARMv5",
+			archFamily: "armel",
+			content: `Processor       : ARM926EJ-S rev 5 (v5l)
+BogoMIPS        : 226.06
+Features        : swp half thumb fastmult edsp java
+CPU implementer : 0x41
+CPU architecture: 5
+CPU variant     : 0x0
+CPU part        : 0x926
+CPU revision    : 5
+Hardware        : ARM-Board
+Revision        : 0000
+Serial          : 00000000deadbeef`,
+			want:    "armelv5",
+			wantErr: false,
+		},
+		{
+			name:       "Unsupported arch - amd64 architecture",
+			archFamily: "amd64",
+			content: `		processor	: 0
+vendor_id	: AuthenticAMD
+cpu family	: 25
+model		: 116
+model name	: AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics
+stepping	: 1
+microcode	: 0xa704107
+cpu MHz		: 2162.084
+cache size	: 1024 KB
+physical id	: 0
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 16
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good amd_lbr_v2 nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba perfmon_v2 ibrs ibpb stibp ibrs_enhanced vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold vgif x2avic v_spec_ctrl vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid overflow_recov succor smca fsrm flush_l1d amd_lbr_pmc_freeze
+bugs		: sysret_ss_attrs spectre_v1 spectre_v2 spec_store_bypass srso
+bogomips	: 6587.11
+TLB size	: 3584 4K pages
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 48 bits physical, 48 bits virtual
+power management: ts ttp tm hwpstate cpb eff_freq_ro [13] [14] [15]`,
+			want:    "amd64",
+			wantErr: false,
+		},
+		{
+			name:       "Unsupported arch - x86 architecture",
+			archFamily: "i386",
+			content: `processor   : 0
+vendor_id   : GenuineIntel
+cpu family  : 6
+model       : 37
+model name  : Intel(R) Core(TM) i3 CPU       M 330  @ 2.13GHz
+stepping    : 2
+cpu MHz     : 933.000
+cache size  : 3072 KB
+physical id : 0
+siblings    : 4
+core id     : 0
+cpu cores   : 2
+apicid      : 0
+initial apicid  : 0
+fdiv_bug    : no
+hlt_bug     : no
+f00f_bug    : no
+coma_bug    : no
+fpu     : yes
+fpu_exception   : yes
+cpuid level : 11
+wp      : yes
+flags       : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe nx rdtscp lm constant_tsc arch_perfmon pebs bts xtopology nonstop_tsc aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 popcnt lahf_lm arat dts tpr_shadow vnmi flexpriority ept vpid
+bogomips    : 4256.49
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 36 bits physical, 48 bits virtual
+power management:`,
+			want:    "i386",
+			wantErr: false,
+		},
+		{
+			name:       "Empty content",
+			archFamily: "armhf",
+			content:    "",
+			want:       "",
+			wantErr:    true,
+		},
+		{
+			name:       "Malformed content with no architecture line",
+			archFamily: "armhf",
+			content: `Processor: Unknown CPU
+Features: none
+Something Else: else else else`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:       "ARMv7 architecture without keyword 'CPU architecture'",
+			archFamily: "armhf",
+			content: `Processor : ARMv7 Processor rev 1 (v7l)
+processor : 0
+BogoMIPS : 1594.16
+
+Hardware : Marvell Armada-375 Board
+Revision : 0000
+Serial : 0000000000000000`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:       "ARMv5 with lowercase CPU architecture line",
+			archFamily: "armel",
+			content: `processor : 0
+cpu implementer : 0x41
+cpu architecture: 5
+cpu variant : 0x0
+cpu part : 0x926
+cpu revision : 1
+Hardware : ARM-Board`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:       "ARMv8 AArch64 missing architecture line",
+			archFamily: "aarch64",
+			content: `Processor       : AArch64 Processor rev 4 (aarch64)
+Features        : fp asimd evtstrm aes sha1 sha2 crc32`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:       "Completely unsupported input format",
+			archFamily: "armhf",
+			content:    "<<<binary data>>> \x00\x01\x02\x03",
+			want:       "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getter := NewMachineID(
+				func(fileName string) ([]byte, error) {
+					if fileName != "/proc/cpuinfo" {
+						return nil, fmt.Errorf("incorrect file used")
+					}
+					return []byte(tt.content), nil
+				},
+				func() (name string, err error) { return "", nil },
+			)
+
+			got, err := getter.GetArchitectureVariantName(tt.archFamily)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MachineID.GetArchitectureVariantName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("MachineID.GetArchitectureVariantName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	getter := NewMachineID(
+		func(fileName string) ([]byte, error) {
+			if fileName != "/proc/something-other" {
+				return nil, fmt.Errorf("incorrect file used")
+			}
+			return []byte(""), nil
+		},
+		func() (name string, err error) { return "", nil },
+	)
+
+	got, err := getter.GetArchitectureVariantName("aarch64")
+	if err == nil {
+		t.Errorf("MachineID.GetArchitectureVariantName() error = %v, wantErr %v", err, true)
+		return
+	}
+	if got != "" {
+		t.Errorf("MachineID.GetArchitectureVariantName() = %v, want %v", got, "")
+	}
+}
+
+func Test_normalizeArchFamily(t *testing.T) {
+	type args struct {
+		family string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Exact arm string",
+			args: args{family: "arm"},
+			want: "arm",
+		},
+		{
+			name: "ARM uppercase",
+			args: args{family: "ARM"},
+			want: "arm",
+		},
+		{
+			name: "armv7 variant",
+			args: args{family: "armv7l"},
+			want: "arm",
+		},
+		{
+			name: "aarch64 lowercase",
+			args: args{family: "aarch64"},
+			want: "arm",
+		},
+		{
+			name: "AARCH64 uppercase",
+			args: args{family: "AARCH64"},
+			want: "arm",
+		},
+		{
+			name: "Unrelated x86_64",
+			args: args{family: "x86_64"},
+			want: "x86_64",
+		},
+		{
+			name: "Mixed-case AMD64",
+			args: args{family: "AmD64"},
+			want: "amd64",
+		},
+		{
+			name: "RISC-V architecture",
+			args: args{family: "riscv64"},
+			want: "riscv64",
+		},
+		{
+			name: "MIPS architecture",
+			args: args{family: "mips"},
+			want: "mips",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeArchFamily(tt.args.family); got != tt.want {
+				t.Errorf("normalizeArchFamily() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/machine_id_test.go
+++ b/config/machine_id_test.go
@@ -500,13 +500,10 @@ Features        : fp asimd evtstrm aes sha1 sha2 crc32`,
 			)
 
 			got, err := getter.GetArchitectureVariantName(tt.archFamily)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MachineID.GetArchitectureVariantName() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("MachineID.GetArchitectureVariantName() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, err != nil, tt.wantErr,
+				"MachineID.GetArchitectureVariantName() error = %v, wantErr %v", err, tt.wantErr)
+			assert.Equal(t, got, tt.want,
+				"MachineID.GetArchitectureVariantName() = %v, want %v", got, tt.want)
 		})
 	}
 
@@ -521,13 +518,10 @@ Features        : fp asimd evtstrm aes sha1 sha2 crc32`,
 	)
 
 	got, err := getter.GetArchitectureVariantName("aarch64")
-	if err == nil {
-		t.Errorf("MachineID.GetArchitectureVariantName() error = %v, wantErr %v", err, true)
-		return
-	}
-	if got != "" {
-		t.Errorf("MachineID.GetArchitectureVariantName() = %v, want %v", got, "")
-	}
+	assert.NotEqual(t, err, nil,
+		"MachineID.GetArchitectureVariantName() error = %v, wantErr %v", err, true)
+	assert.Equal(t, got, "",
+		"MachineID.GetArchitectureVariantName() = %v, want %v", got, "")
 }
 
 func Test_normalizeArchFamily(t *testing.T) {
@@ -587,9 +581,8 @@ func Test_normalizeArchFamily(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeArchFamily(tt.args.family); got != tt.want {
-				t.Errorf("normalizeArchFamily() = %v, want %v", got, tt.want)
-			}
+			got := normalizeArchFamily(tt.args.family)
+			assert.Equal(t, got, tt.want, "normalizeArchFamily() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/events/moose/errors.go
+++ b/events/moose/errors.go
@@ -30,7 +30,7 @@ func (s *Subscriber) PostInit(initResult moose.InitResult, errCode int32, errMsg
 }
 
 func (s *Subscriber) OnError(err moose.TrackerError, level uint32, code int32, msg string) *moose.ListenerError {
-	if internal.IsProdEnv(s.Environment) && level < 2 {
+	if internal.IsProdEnv(s.BuildTarget.Environment) && level < 2 {
 		return nil
 	}
 	log.Printf("%s MOOSE: %d: %d: %s", internal.ErrorPrefix, err, code, msg)

--- a/events/moose/moose.go
+++ b/events/moose/moose.go
@@ -49,8 +49,7 @@ type mooseConsentFunc func(bool) uint32
 type Subscriber struct {
 	EventsDbPath            string
 	Config                  config.Manager
-	Version                 string
-	Environment             string
+	BuildTarget             config.BuildTarget
 	Domain                  string
 	Subdomain               string
 	DeviceID                string
@@ -160,7 +159,7 @@ func (s *Subscriber) Init(httpClient http.Client) error {
 
 	if err := s.response(moose.MooseNordvpnappInit(
 		s.EventsDbPath,
-		internal.IsProdEnv(s.Environment),
+		internal.IsProdEnv(s.BuildTarget.Environment),
 		s,
 		s,
 		sendAllEvents,
@@ -190,7 +189,7 @@ func (s *Subscriber) Init(httpClient http.Client) error {
 		return fmt.Errorf("setting application name: %w", err)
 	}
 
-	if err := s.response(moose.NordvpnappSetContextApplicationNordvpnappVersion(s.Version)); err != nil {
+	if err := s.response(moose.NordvpnappSetContextApplicationNordvpnappVersion(s.BuildTarget.Version)); err != nil {
 		return fmt.Errorf("setting application version: %w", err)
 	}
 
@@ -230,6 +229,11 @@ func (s *Subscriber) Init(httpClient http.Client) error {
 	if err := sub.NotifyTechnology(cfg.Technology); err != nil {
 		return fmt.Errorf("setting moose technology: %w", err)
 	}
+
+	if err := s.response(moose.NordvpnappSetContextDeviceCpuArchitecture(s.BuildTarget.Architecture)); err != nil {
+		return fmt.Errorf("setting device architecture: %w", err)
+	}
+
 	return nil
 }
 

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -737,7 +737,7 @@ func qaSnap(_ context.Context, testGroup, testPattern string) error {
 
 // Performs linter check against Go codebase
 func (Test) Lint() error {
-	return sh.Run("golangci-lint", "run", "-v", "--config=.golangci-lint.yml")
+	return sh.RunV("golangci-lint", "run", "-v", "--config=.golangci-lint.yml")
 }
 
 // Binaries to their respective locations and restart

--- a/sysinfo/host_architecture.go
+++ b/sysinfo/host_architecture.go
@@ -1,0 +1,7 @@
+package sysinfo
+
+// GetHostArchitecture returns the processor architecture of the host system such as "amd64",
+// "arm64", etc.
+func GetHostArchitecture() string {
+	return uname(defaultCmdRunner, "-m")
+}

--- a/sysinfo/host_architecture_test.go
+++ b/sysinfo/host_architecture_test.go
@@ -1,0 +1,18 @@
+package sysinfo
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_TestGetHostArchitecture(t *testing.T) {
+	category.Set(t, category.Integration)
+
+	out, _ := exec.Command("uname", "-m").Output()
+	result := strings.TrimSpace(string(out))
+	assert.Equal(t, result, GetHostArchitecture())
+}


### PR DESCRIPTION
Changes:
- Depending on the architecture family, additional information will be provided. For example, ARM CPUs will have additional information on their architecture version (v5, v7, etc.)
- Fixed mage `test:lint` job not printing errors to os.stdout