### PR TITLE
LVPN 8346: Login after app update

### DIFF
--- a/test/qa/lib/login.py
+++ b/test/qa/lib/login.py
@@ -3,9 +3,7 @@ import os
 import io
 import pexpect
 
-import sh
-
-from . import UserConsentMode, logging, ssh, squash_whitespace, WE_VALUE_YOUR_PRIVACY_MSG, USER_CONSENT_PROMPT
+from . import UserConsentMode, logging, ssh, squash_whitespace, WE_VALUE_YOUR_PRIVACY_MSG, USER_CONSENT_PROMPT, CommandExecutor
 
 
 class Credentials:
@@ -41,14 +39,11 @@ def login_as(username, ssh_client: ssh.Ssh = None, with_user_consent: UserConsen
 
     logging.log(f"logging in as {token}")
 
-    if ssh_client is not None:
-        if with_user_consent != UserConsentMode.UNDEFINED:
-            ssh_client.exec_command(f"nordvpn set analytics {_analytics_value(with_user_consent)}")
-        return ssh_client.exec_command(f"nordvpn login --token {token}")
-
+    exec_command = CommandExecutor(ssh_client=ssh_client)
     if with_user_consent != UserConsentMode.UNDEFINED:
-        sh.nordvpn.set.analytics(_analytics_value(with_user_consent))
-    return sh.nordvpn.login("--token", token)
+        logging.log(f"set consent to {with_user_consent}")
+        exec_command(f"nordvpn set analytics {_analytics_value(with_user_consent)}")
+    return exec_command(f"nordvpn login --token {token}")
 
 
 def _analytics_value(mode: UserConsentMode) -> str:

--- a/test/qa/test_update.py
+++ b/test/qa/test_update.py
@@ -37,12 +37,13 @@ def setup_function(function):  # noqa: ARG001
 
     daemon.start()
 
-    login.login_as("default")
-
     daemon.stop() # TODO: LVPN-6403
     deb_path = glob.glob(f'{PROJECT_ROOT}/dist/app/deb/*amd64.deb')[0]
     sh.sudo.apt.install(deb_path, "-y")
     daemon.start() # TODO: LVPN-6403
+
+    # login into the app after update, because if user didn't agree with the consent it will be logged out at update
+    login.login_as("default")
 
     if TestData.INVOLVES_MESHNET:
         sh.nordvpn.set.notify.off()


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

Move the login after the application is updated because if the consent was not set then the user will be logged out after app update.