### PR TITLE
LVPN-8355: Remove nordwhisper_enabled.proto from generate_protobuf.sh

### DIFF
--- a/ci/generate_protobuf.sh
+++ b/ci/generate_protobuf.sh
@@ -31,7 +31,6 @@ protoc --go_opt=module=github.com/NordSecurity/nordvpn-linux --go_out=. protobuf
 protoc --go_opt=module=github.com/NordSecurity/nordvpn-linux --go_out=. protobuf/fileshare/fileshare.proto -I protobuf/fileshare
 protoc --go_opt=module=github.com/NordSecurity/nordvpn-linux --go_out=. protobuf/snapconf/snapconf.proto -I protobuf/snapconf
 protoc --go_opt=module=github.com/NordSecurity/nordvpn-linux --go_out=. protobuf/norduser/norduser.proto -I protobuf/norduser
-protoc --go_opt=module=github.com/NordSecurity/nordvpn-linux --go_out=. protobuf/daemon/nordwhisper_enabled.proto -I protobuf/daemon
 protoc --go_opt=module=github.com/NordSecurity/nordvpn-linux --go_out=. protobuf/daemon/defaults.proto -I protobuf/daemon
 
 protoc --go_grpc_opt=module=github.com/NordSecurity/nordvpn-linux --go_grpc_out=. protobuf/daemon/service.proto -I protobuf/daemon


### PR DESCRIPTION
Changes:
- remove reference to `nordwhisper_enabled.proto` from `generate_protobuf.sh`, it was removed here https://github.com/NordSecurity/nordvpn-linux/pull/854/files#diff-46d3ad234b6d500f6a8d472e7541d1f8e7af758457dee279e7a618c9cd9ed1b3