### PR TITLE
LVPN-5971: unify UA header value sent out for app and moose

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -206,8 +206,10 @@ func main() {
 			log.Fatalln("Error on creating validator:", err)
 		}
 	}
-
-	userAgent := fmt.Sprintf("NordApp Linux %s %s", Version, distro.KernelName())
+	userAgent, err := request.GetUserAgentValue(Version, distro.NewDistro())
+	if err != nil {
+		log.Fatalln("Error on getting user agent value:", err)
+	}
 
 	httpGlobalCtx, httpCancel := context.WithCancel(context.Background())
 

--- a/distro/distro.go
+++ b/distro/distro.go
@@ -23,7 +23,56 @@ type osRelease struct {
 	PrettyName string
 }
 
-func (o *osRelease) UnmarshalText(text []byte) error {
+type Distro interface {
+	// ReleaseName returns the name of the currently running distribution.
+	ReleaseName() (string, error)
+	// ReleasePrettyName returns the pretty name of the currently running distribution.
+	ReleasePrettyName() (string, error)
+	// KernelName returns just the name of the currently running kernel.
+	KernelName() string
+	// KernelFull returns full set of information about the currently running kernel.
+	KernelFull() string
+}
+
+type DistroImpl struct{}
+
+func NewDistro() Distro {
+	return &DistroImpl{}
+}
+
+func (DistroImpl) ReleaseName() (string, error) {
+	data, err := os.ReadFile(osReleaseFile)
+	if err != nil {
+		return "", err
+	}
+
+	var release osRelease
+	if err := (&release).unmarshalText(data); err != nil {
+		return "", err
+	}
+
+	return release.Name, nil
+}
+
+func (DistroImpl) ReleasePrettyName() (string, error) {
+	data, err := os.ReadFile(osReleaseFile)
+	if err != nil {
+		return "", err
+	}
+
+	var release osRelease
+	if err := (&release).unmarshalText(data); err != nil {
+		return "", err
+	}
+
+	return release.PrettyName, nil
+}
+
+func (DistroImpl) KernelName() string { return uname("-sr") }
+
+func (DistroImpl) KernelFull() string { return uname("-a") }
+
+func (o *osRelease) unmarshalText(text []byte) error {
 	for _, line := range bytes.Split(bytes.TrimSpace(text), []byte("\n")) {
 		key, value, ok := bytes.Cut(line, []byte("="))
 		if !ok {
@@ -42,42 +91,6 @@ func (o *osRelease) UnmarshalText(text []byte) error {
 	}
 	return nil
 }
-
-// ReleaseName of the currently running distribution.
-func ReleaseName() (string, error) {
-	data, err := os.ReadFile(osReleaseFile)
-	if err != nil {
-		return "", err
-	}
-
-	var release osRelease
-	if err := (&release).UnmarshalText(data); err != nil {
-		return "", err
-	}
-
-	return release.Name, nil
-}
-
-// ReleasePrettyName of the currently running distribution.
-func ReleasePrettyName() (string, error) {
-	data, err := os.ReadFile(osReleaseFile)
-	if err != nil {
-		return "", err
-	}
-
-	var release osRelease
-	if err := (&release).UnmarshalText(data); err != nil {
-		return "", err
-	}
-
-	return release.PrettyName, nil
-}
-
-// KernelName of the currently running kernel.
-func KernelName() string { return uname("-sr") }
-
-// KernelFull name of the currently running kernel.
-func KernelFull() string { return uname("-a") }
 
 // uname returns operating system information from uname executable
 func uname(flags string) string {

--- a/distro/distro.go
+++ b/distro/distro.go
@@ -47,10 +47,7 @@ func (DistroImpl) ReleaseName() (string, error) {
 	}
 
 	var release osRelease
-	if err := (&release).unmarshalText(data); err != nil {
-		return "", err
-	}
-
+	release.unmarshalText(data)
 	return release.Name, nil
 }
 
@@ -61,10 +58,7 @@ func (DistroImpl) ReleasePrettyName() (string, error) {
 	}
 
 	var release osRelease
-	if err := (&release).unmarshalText(data); err != nil {
-		return "", err
-	}
-
+	release.unmarshalText(data)
 	return release.PrettyName, nil
 }
 
@@ -72,7 +66,7 @@ func (DistroImpl) KernelName() string { return uname("-sr") }
 
 func (DistroImpl) KernelFull() string { return uname("-a") }
 
-func (o *osRelease) unmarshalText(text []byte) error {
+func (o *osRelease) unmarshalText(text []byte) {
 	for _, line := range bytes.Split(bytes.TrimSpace(text), []byte("\n")) {
 		key, value, ok := bytes.Cut(line, []byte("="))
 		if !ok {
@@ -89,7 +83,6 @@ func (o *osRelease) unmarshalText(text []byte) error {
 			// ignore undefined fields
 		}
 	}
-	return nil
 }
 
 // uname returns operating system information from uname executable

--- a/distro/distro_test.go
+++ b/distro/distro_test.go
@@ -11,13 +11,13 @@ import (
 func TestKernelName(t *testing.T) {
 	category.Set(t, category.Integration)
 
-	assert.Equal(t, uname("-sr"), KernelName())
+	assert.Equal(t, uname("-sr"), NewDistro().KernelName())
 }
 
 func TestKernelFull(t *testing.T) {
 	category.Set(t, category.Integration)
 
-	assert.Equal(t, uname("-a"), KernelFull())
+	assert.Equal(t, uname("-a"), NewDistro().KernelFull())
 }
 
 func TestOsRelease_UnmarshalText(t *testing.T) {

--- a/distro/distro_test.go
+++ b/distro/distro_test.go
@@ -63,8 +63,7 @@ func TestOsRelease_UnmarshalText(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var release osRelease
-			err := (&release).UnmarshalText([]byte(test.input))
-			assert.Equal(t, test.err, err)
+			release.unmarshalText([]byte(test.input))
 			assert.EqualValues(t, test.output, release)
 		})
 	}

--- a/events/moose/moose.go
+++ b/events/moose/moose.go
@@ -200,7 +200,7 @@ func (s *Subscriber) Init(httpClient http.Client) error {
 		return fmt.Errorf("setting moose time zone: %w", err)
 	}
 
-	distroVersion, err := distro.ReleasePrettyName()
+	distroVersion, err := distro.NewDistro().ReleasePrettyName()
 	if err != nil {
 		return fmt.Errorf("determining device os: %w", err)
 	}

--- a/meshnet/register.go
+++ b/meshnet/register.go
@@ -116,7 +116,7 @@ func (r *RegisteringChecker) register(cfg *config.Config) error {
 		privateKey = r.gen.Private()
 	}
 	token := cfg.TokensData[cfg.AutoConnectData.ID].Token
-	distroName, err := distro.ReleaseName()
+	distroName, err := distro.NewDistro().ReleaseName()
 	if err != nil {
 		return err
 	}

--- a/request/user_agent.go
+++ b/request/user_agent.go
@@ -1,0 +1,28 @@
+package request
+
+import (
+	"fmt"
+
+	"github.com/NordSecurity/nordvpn-linux/distro"
+)
+
+const appName = "NordApp Linux"
+
+// GetUserAgentValue generates a User-Agent header value compliant with RFC 9110 section 10.1.5.
+// It formats the user agent as "<application-name>/<version> (<platform-details>)" where:
+// - application-name is application identifier
+// - version is the application version
+// - platform-details contains the distro name of the currently running kernel
+//
+// Returns:
+//   - string: The formatted User-Agent string
+//   - error: An error if distribution information cannot be retrieved
+//
+// See: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5
+func GetUserAgentValue(version string, d distro.Distro) (string, error) {
+	distro_name, err := d.ReleasePrettyName()
+	if err != nil {
+		return "", fmt.Errorf("determining device os: %w", err)
+	}
+	return fmt.Sprintf("%s/%s (%s)", appName, version, distro_name), nil
+}

--- a/request/user_agent_test.go
+++ b/request/user_agent_test.go
@@ -1,0 +1,67 @@
+package request
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDistro struct {
+	prettyName string
+	err        error
+}
+
+func (m mockDistro) ReleasePrettyName() (string, error) { return m.prettyName, m.err }
+func (m mockDistro) ReleaseName() (string, error)       { return "", nil }
+func (m mockDistro) KernelName() string                 { return "" }
+func (m mockDistro) KernelFull() string                 { return "" }
+
+func TestGetUserAgentValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		distro  mockDistro
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "successful user agent generation",
+			version: "1.3.37",
+			distro:  mockDistro{prettyName: "Ubuntu 22.04", err: nil},
+			want:    "NordApp Linux/1.3.37 (Ubuntu 22.04)",
+		},
+		{
+			name:    "empty version",
+			version: "",
+			distro:  mockDistro{prettyName: "Ubuntu 22.04", err: nil},
+			want:    "NordApp Linux/ (Ubuntu 22.04)",
+		},
+		{
+			name:    "distro error",
+			version: "1.3.37",
+			distro:  mockDistro{prettyName: "", err: errors.New("os error")},
+			wantErr: "determining device os: os error",
+		},
+		{
+			name:    "with special characters in distro name",
+			version: "1.3.37",
+			distro:  mockDistro{prettyName: "Debian GNU/Linux 11 (bullseye)", err: nil},
+			want:    "NordApp Linux/1.3.37 (Debian GNU/Linux 11 (bullseye))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetUserAgentValue(tt.version, tt.distro)
+
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				assert.Empty(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Changes under this PR:
- unify data being used for the UA (currently it's based on distro name in both cases)
- make the UA RFC9110 complianat
- small changes required to make user_agent testable