### PR TITLE
LVPN-8358: Analytics not send in us market

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -465,6 +465,7 @@ func main() {
 		fsystem,
 		defaultAPI,
 		authChecker,
+		analytics,
 	)
 	consentChecker.PrepareDaemonIfConsentNotCompleted()
 

--- a/cmd/daemon/userconsent_moose.go
+++ b/cmd/daemon/userconsent_moose.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/core"
 	"github.com/NordSecurity/nordvpn-linux/daemon"
+	"github.com/NordSecurity/nordvpn-linux/events"
 )
 
 func newConsentChecker(
@@ -14,6 +15,7 @@ func newConsentChecker(
 	cm config.Manager,
 	insightsAPI core.InsightsAPI,
 	authChecker auth.Checker,
+	analytics events.Analytics,
 ) daemon.ConsentChecker {
-	return daemon.NewConsentChecker(isDevEnv, cm, insightsAPI, authChecker)
+	return daemon.NewConsentChecker(isDevEnv, cm, insightsAPI, authChecker, analytics)
 }

--- a/cmd/daemon/userconsent_no_moose.go
+++ b/cmd/daemon/userconsent_no_moose.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/core"
 	"github.com/NordSecurity/nordvpn-linux/daemon"
+	"github.com/NordSecurity/nordvpn-linux/events"
 )
 
 // AnalyticsConsentChecker here is a no-op stub struct used when there is no moose.
@@ -28,6 +29,7 @@ func newConsentChecker(
 	_ config.Manager,
 	_ core.InsightsAPI,
 	_ auth.Checker,
+	_ events.Analytics,
 ) daemon.ConsentChecker {
 	return &NoOpConsentChecker{}
 }

--- a/daemon/rpc_test.go
+++ b/daemon/rpc_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/sharedctx"
 	"github.com/NordSecurity/nordvpn-linux/test/mock"
 	testcore "github.com/NordSecurity/nordvpn-linux/test/mock/core"
+	testevents "github.com/NordSecurity/nordvpn-linux/test/mock/events"
 	testnetworker "github.com/NordSecurity/nordvpn-linux/test/mock/networker"
 	testnorduser "github.com/NordSecurity/nordvpn-linux/test/mock/norduser/service"
 
@@ -78,6 +79,7 @@ func testRPC() *RPC {
 	dm.SetServersData(time.Now(), serversList(), "")
 
 	cm := newMockConfigManager()
+	analytics := testevents.NewAnalytics(config.ConsentUndefined)
 
 	return NewRPC(
 		internal.Development,
@@ -106,7 +108,7 @@ func testRPC() *RPC {
 		sharedctx.New(),
 		mock.NewRemoteConfigMock(),
 		state.NewConnectionInfo(),
-		NewConsentChecker(false, cm, api, &workingLoginChecker{}),
+		NewConsentChecker(false, cm, api, &workingLoginChecker{}, &analytics),
 	)
 }
 


### PR DESCRIPTION
Changes:
- when we are in US market, the analytics consent was updated in configuration file, but analytics itself were not enabled
- now they are enabled