### PR TITLE
LVPN-5030: Add snap info into app version output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -111,7 +111,7 @@ func NewApp(version, environment, hash, salt string,
 	}
 
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Printf("NordVPN Version %s\n", c.App.Version)
+		cmd.Version(c)
 	}
 	cli.BashCompletionFlag = &cli.BoolFlag{
 		Name:   "complete",
@@ -350,10 +350,8 @@ func NewApp(version, environment, hash, salt string,
 		return nil
 	}
 
-	app.Version = version
-	if internal.IsDevEnv(environment) {
-		app.Version = fmt.Sprintf("%s - %s (%s)", version, internal.Environment(environment), hash)
-	}
+	app.Version = composeAppVersion(version, environment, snapconf.IsUnderSnap())
+
 	app.Commands = []*cli.Command{
 		{
 			Name:               "account",
@@ -1397,4 +1395,21 @@ func readForConfirmationBlockUntilValid(r io.Reader, prompt string) bool {
 		}
 		fmt.Println(InputParsingError)
 	}
+}
+
+// composeAppVersion concatenates the provided information to produce a string
+// representing the application version in the format: 1.2.3 [snap] - dev
+// Later it is used by the version command to display to the user
+func composeAppVersion(buildVersion string, environment string, isSnap bool) string {
+	env := ""
+	if internal.IsDevEnv(environment) {
+		env = fmt.Sprintf(" - %s", environment)
+	}
+
+	snap := ""
+	if isSnap {
+		snap = " [snap]"
+	}
+
+	return fmt.Sprintf("%s%s%s", buildVersion, snap, env)
 }

--- a/cli/cli_cities_test.go
+++ b/cli/cli_cities_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/helpers"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
 
 func TestCitiesList(t *testing.T) {
 	category.Set(t, category.Unit)
-	mockClient := mockDaemonClient{}
+	mockClient := mock.MockDaemonClient{}
 	c := cmd{&mockClient, nil, nil, "", nil}
 
 	tests := []struct {
@@ -54,10 +56,10 @@ func TestCitiesList(t *testing.T) {
 			if test.country != "" {
 				set.Parse([]string{test.country})
 			}
-			mockClient.cities = test.cities
+			mockClient.CitiesResponse = test.cities
 			ctx := cli.NewContext(app, set, &cli.Context{Context: context.Background()})
 
-			result, err := captureOutput(func() {
+			result, err := helpers.CaptureOutput(func() {
 				err := c.Cities(ctx)
 				assert.Equal(t, test.expectedError, err)
 			})

--- a/cli/cli_connect_test.go
+++ b/cli/cli_connect_test.go
@@ -1,97 +1,22 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"flag"
-	"io"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
-	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/helpers"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
-	"google.golang.org/grpc"
 )
-
-func captureOutput(f func()) (string, error) {
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		return "", err
-	}
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-	}()
-
-	os.Stdout = writer
-	os.Stderr = writer
-
-	f()
-
-	writer.Close() // close to unblock io.Copy(&buf, reader)
-	var buf bytes.Buffer
-	io.Copy(&buf, reader)
-	return strings.TrimSuffix(buf.String(), "\n"), nil
-}
-
-type mockDaemonClient struct {
-	pb.DaemonClient
-	cities    []*pb.ServerGroup
-	groups    []*pb.ServerGroup
-	countries []*pb.ServerGroup
-}
-
-func (c mockDaemonClient) Cities(ctx context.Context, in *pb.CitiesRequest, opts ...grpc.CallOption) (*pb.ServerGroupsList, error) {
-	if c.cities != nil {
-		return &pb.ServerGroupsList{
-			Type:    internal.CodeSuccess,
-			Servers: c.cities,
-		}, nil
-	} else {
-		return &pb.ServerGroupsList{
-			Type:    internal.CodeEmptyPayloadError,
-			Servers: nil,
-		}, nil
-	}
-}
-
-func (c mockDaemonClient) Countries(ctx context.Context, in *pb.Empty, opts ...grpc.CallOption) (*pb.ServerGroupsList, error) {
-	if c.countries != nil {
-		return &pb.ServerGroupsList{
-			Type:    internal.CodeSuccess,
-			Servers: c.countries,
-		}, nil
-	} else {
-		return &pb.ServerGroupsList{
-			Type:    internal.CodeEmptyPayloadError,
-			Servers: nil,
-		}, nil
-	}
-}
-func (c mockDaemonClient) Groups(ctx context.Context, in *pb.Empty, opts ...grpc.CallOption) (*pb.ServerGroupsList, error) {
-	if c.groups != nil {
-		return &pb.ServerGroupsList{
-			Type:    internal.CodeSuccess,
-			Servers: c.groups,
-		}, nil
-	} else {
-		return &pb.ServerGroupsList{
-			Type:    internal.CodeEmptyPayloadError,
-			Servers: nil,
-		}, nil
-	}
-}
 
 func TestConnectAutoComplete(t *testing.T) {
 	category.Set(t, category.Unit)
-	mockClient := mockDaemonClient{}
+	mockClient := mock.MockDaemonClient{}
 	c := cmd{&mockClient, nil, nil, "", nil}
 	tests := []struct {
 		name      string
@@ -130,13 +55,13 @@ func TestConnectAutoComplete(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			app := cli.NewApp()
 			set := flag.NewFlagSet("test", 0)
-			mockClient.cities = test.cities
-			mockClient.countries = test.countries
-			mockClient.groups = test.groups
+			mockClient.CitiesResponse = test.cities
+			mockClient.CountriesResponse = test.countries
+			mockClient.GroupsResponse = test.groups
 			set.Parse([]string{test.input})
 			ctx := cli.NewContext(app, set, &cli.Context{Context: context.Background()})
 
-			result, err := captureOutput(func() {
+			result, err := helpers.CaptureOutput(func() {
 				c.ConnectAutoComplete(ctx)
 			})
 

--- a/cli/cli_countries_test.go
+++ b/cli/cli_countries_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/helpers"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
 
 func TestCountriesList(t *testing.T) {
 	category.Set(t, category.Unit)
-	mockClient := mockDaemonClient{}
+	mockClient := mock.MockDaemonClient{}
 	c := cmd{&mockClient, nil, nil, "", nil}
 
 	tests := []struct {
@@ -49,10 +51,10 @@ func TestCountriesList(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			app := cli.NewApp()
 			set := flag.NewFlagSet("test", 0)
-			mockClient.countries = test.countries
+			mockClient.CountriesResponse = test.countries
 			ctx := cli.NewContext(app, set, &cli.Context{Context: context.Background()})
 
-			result, err := captureOutput(func() {
+			result, err := helpers.CaptureOutput(func() {
 				err := c.Countries(ctx)
 				assert.Equal(t, test.expectedError, err)
 			})

--- a/cli/cli_groups_test.go
+++ b/cli/cli_groups_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/helpers"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
 
 func TestGroupsList(t *testing.T) {
 	category.Set(t, category.Unit)
-	mockClient := mockDaemonClient{}
+	mockClient := mock.MockDaemonClient{}
 	c := cmd{&mockClient, nil, nil, "", nil}
 
 	tests := []struct {
@@ -39,10 +41,10 @@ func TestGroupsList(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			app := cli.NewApp()
 			set := flag.NewFlagSet("test", 0)
-			mockClient.groups = test.groups
+			mockClient.GroupsResponse = test.groups
 			ctx := cli.NewContext(app, set, &cli.Context{Context: context.Background()})
 
-			result, err := captureOutput(func() {
+			result, err := helpers.CaptureOutput(func() {
 				err := c.Groups(ctx)
 				assert.Equal(t, test.expectedError, err)
 			})

--- a/cli/cli_set_autoconnect_test.go
+++ b/cli/cli_set_autoconnect_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/helpers"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
@@ -14,7 +16,7 @@ import (
 
 func TestAutoConnectAutoComplete(t *testing.T) {
 	category.Set(t, category.Unit)
-	mockClient := mockDaemonClient{}
+	mockClient := mock.MockDaemonClient{}
 	c := cmd{&mockClient, nil, nil, "", nil}
 	tests := []struct {
 		name      string
@@ -78,13 +80,13 @@ func TestAutoConnectAutoComplete(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			app := cli.NewApp()
 			set := flag.NewFlagSet("test", 0)
-			mockClient.cities = test.cities
-			mockClient.countries = test.countries
-			mockClient.groups = test.groups
+			mockClient.CitiesResponse = test.cities
+			mockClient.CountriesResponse = test.countries
+			mockClient.GroupsResponse = test.groups
 			set.Parse(test.input)
 			ctx := cli.NewContext(app, set, &cli.Context{Context: context.Background()})
 
-			result, err := captureOutput(func() {
+			result, err := helpers.CaptureOutput(func() {
 				c.SetAutoConnectAutoComplete(ctx)
 			})
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
@@ -311,6 +312,55 @@ func TestReadForConfirmationDefaultValue(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			answer := readForConfirmationDefaultValue(test.input, test.name, test.defaultValue)
 			assert.Equal(t, test.defaultValue, answer)
+		})
+	}
+}
+
+// TestVersion checks how the version member for App.Version is constructed
+func TestComposeAppVersion(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name         string
+		buildVersion string
+		env          string
+		isUnderSnap  bool
+		expected     string
+	}{
+		{
+			name:         "version for deb/rpm production build",
+			buildVersion: "1.2.3",
+			env:          string(internal.Production),
+			isUnderSnap:  false,
+			expected:     "1.2.3",
+		},
+		{
+			name:         "version for deb/rpm development build",
+			buildVersion: "1.2.3",
+			env:          string(internal.Development),
+			isUnderSnap:  false,
+			expected:     "1.2.3 - dev",
+		},
+		{
+			name:         "version for snap production build",
+			buildVersion: "1.2.3",
+			env:          string(internal.Production),
+			isUnderSnap:  true,
+			expected:     "1.2.3 [snap]",
+		},
+		{
+			name:         "version for snap development build",
+			buildVersion: "1.2.3",
+			env:          string(internal.Development),
+			isUnderSnap:  true,
+			expected:     "1.2.3 [snap] - dev",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			version := composeAppVersion(test.buildVersion, test.env, test.isUnderSnap)
+			assert.Equal(t, test.expected, version)
 		})
 	}
 }

--- a/cli/cli_version.go
+++ b/cli/cli_version.go
@@ -3,46 +3,20 @@ package cli
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"github.com/urfave/cli/v2"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/urfave/cli/v2"
 )
 
 func (c *cmd) Version(ctx *cli.Context) error {
+	outdated := ""
 	resp, err := c.client.Ping(context.Background(), &pb.Empty{})
-	if err != nil {
-		if strings.Contains(err.Error(), "no such file or directory") {
-			return internal.ErrSocketNotFound
-		}
-		if strings.Contains(err.Error(), "permission denied") || strings.Contains(err.Error(), "connection reset by peer") {
-			return internal.ErrSocketAccessDenied
-		}
-		if snapErr := RetrieveSnapConnsError(err); snapErr != nil {
-			return err
-		}
-		return internal.ErrDaemonConnectionRefused
+	if err == nil && resp.Type == internal.CodeOutdated {
+		outdated = " (outdated)"
 	}
 
-	switch resp.Type {
-	case internal.CodeOffline:
-		return ErrInternetConnection
-	case internal.CodeDaemonOffline:
-		return internal.ErrDaemonConnectionRefused
-	case internal.CodeOutdated:
-	case internal.CodeSuccess:
-	}
-
-	fmt.Printf("Daemon: NordVPN Version %d.%d.%d", resp.Major, resp.Minor, resp.Patch)
-	if resp.Metadata != "" {
-		fmt.Printf("+%s", resp.Metadata)
-	}
-	if resp.Type == internal.CodeOutdated {
-		fmt.Print(" (outdated)")
-	}
-	fmt.Print("\n")
+	fmt.Printf("NordVPN Version %s%s\n", ctx.App.Version, outdated)
 
 	return nil
 }

--- a/cli/cli_version_test.go
+++ b/cli/cli_version_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/helpers"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+// TestVersion checks that the cli.Version command adds when needed the outdated information to the version
+func TestVersion(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	mockClient := mock.MockDaemonClient{}
+	c := cmd{&mockClient, nil, nil, "", nil}
+	// this is constructed using composeAppVersion,
+	// covered in other tests and is expected to be set in app.Version field
+	const appVersion = "1.2.3"
+
+	tests := []struct {
+		name      string
+		outdated  bool
+		pingError error
+		expected  string
+	}{
+		{
+			name:     "App version",
+			outdated: false,
+		},
+		{
+			name:     "Application is outdated",
+			outdated: true,
+		},
+		{
+			name:      "Ping returns error",
+			outdated:  true,
+			pingError: fmt.Errorf("some error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := cli.NewApp()
+			app.Version = appVersion
+			set := flag.NewFlagSet("test", 0)
+			ctx := cli.NewContext(app, set, &cli.Context{Context: context.Background()})
+			mockClient.PingFn = func() (*pb.PingResponse, error) {
+				typeResponse := internal.CodeSuccess
+				if test.outdated {
+					typeResponse = internal.CodeOutdated
+				}
+				// only the Type member is used from the response,
+				// because of this set the version to something different than the appVersion
+				// string to be sure is not used in the output
+				return &pb.PingResponse{
+					Major:    5,
+					Minor:    6,
+					Patch:    7,
+					Metadata: "456",
+					Type:     typeResponse,
+				}, test.pingError
+			}
+
+			result, err := helpers.CaptureOutput(func() {
+				assert.Nil(t, c.Version(ctx))
+			})
+			assert.Nil(t, err)
+
+			// compose the app version message taking outdated value into account
+			expectedVersion := "NordVPN Version " + appVersion
+			if test.outdated && test.pingError == nil {
+				expectedVersion = expectedVersion + " (outdated)"
+			}
+			assert.Equal(t, expectedVersion, result)
+		})
+	}
+}

--- a/internal/environment.go
+++ b/internal/environment.go
@@ -6,11 +6,11 @@ const (
 	// Development defines development environment
 	Development Environment = "dev"
 	// QA defines qa environment
-	QA = "qa"
+	QA Environment = "qa"
 	// Production defines production environment
-	Production = "prod"
+	Production Environment = "prod"
 	// Downloader modifies configs and servers jobs
-	Downloader = "downloader"
+	Downloader Environment = "downloader"
 )
 
 // IsProdEnv short hand of condition check, for clear reading

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -305,16 +305,9 @@ func buildPackageDocker(ctx context.Context, packageType string, buildFlags stri
 		mg.Deps(Build.OpenvpnDocker)
 	}
 
-	git, err := getGitInfo()
-	if err != nil {
-		return err
-	}
-
 	env["WORKDIR"] = dockerWorkDir
 	env["ENVIRONMENT"] = string(internal.Development)
-	env["HASH"] = git.commitHash
 	env["PACKAGE"] = devPackageType
-	env["VERSION"] = git.versionTag
 	if packageType == "snap" {
 		return RunDockerWithSettings(
 			ctx,
@@ -370,14 +363,8 @@ func buildBinaries(buildFlags string) error {
 		mg.Deps(Build.Rust)
 	}
 
-	git, err := getGitInfo()
-	if err != nil {
-		return err
-	}
 	env["WORKDIR"] = cwd
-	env["HASH"] = git.commitHash
 	env["PACKAGE"] = devPackageType
-	env["VERSION"] = git.versionTag
 	env["ENVIRONMENT"] = string(internal.Development)
 	env["BUILD_FLAGS"] = buildFlags
 
@@ -405,15 +392,9 @@ func buildBinariesDocker(ctx context.Context, buildFlags string) error {
 		mg.Deps(Build.RustDocker)
 	}
 
-	git, err := getGitInfo()
-	if err != nil {
-		return err
-	}
 	env["WORKDIR"] = dockerWorkDir
 	env["ENVIRONMENT"] = string(internal.Development)
-	env["HASH"] = git.commitHash
 	env["PACKAGE"] = devPackageType
-	env["VERSION"] = git.versionTag
 	env["BUILD_FLAGS"] = buildFlags
 
 	return RunDocker(

--- a/magefiles/scripts.go
+++ b/magefiles/scripts.go
@@ -4,22 +4,11 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"go/build"
-	"io/fs"
 	"log"
 	"os"
-	"slices"
 	"strings"
-
-	"github.com/coreos/go-semver/semver"
-	"github.com/magefile/mage/sh"
 )
-
-type gitInfo struct {
-	commitHash string
-	versionTag string
-}
 
 func getEnv() (map[string]string, error) {
 	env, err := readVarsFromFile(".env")
@@ -57,82 +46,6 @@ func getVersions() (map[string]string, error) {
 		return nil, err
 	}
 	return versions, nil
-}
-
-// TODO: replace with information coming from the Go toolchain
-func getGitInfo() (*gitInfo, error) {
-	hash, err := sh.Output("git", "rev-parse", "--short", "HEAD")
-	if err != nil {
-		return nil, err
-	}
-
-	version, err := getLatestVersion()
-	if err != nil {
-		return nil, err
-	}
-
-	return &gitInfo{
-		commitHash: hash,
-		versionTag: version,
-	}, nil
-}
-
-func getLatestVersion() (string, error) {
-	version, err := getLatestVersionGit()
-	if err != nil {
-		return "", err
-	}
-	if version != "" {
-		return version, nil
-	}
-	fmt.Println("Unable to determine version from git tags. Using changelog.")
-
-	version, err = getLatestVersionChangelog()
-	if err != nil {
-		return "", err
-	}
-	if version != "" {
-		return version, nil
-	}
-	fmt.Println("Unable to determine version the changelog. Using 0.0.0")
-
-	return "0.0.0", nil
-}
-
-func getLatestVersionGit() (string, error) {
-	version, err := sh.Output("git", "describe", "--tags", "--abbrev=0")
-	if err != nil && !strings.Contains(err.Error(), "exit code 128") {
-		return "", err
-	}
-	return version, nil
-}
-
-func getLatestVersionChangelog() (string, error) {
-	changelogs, err := os.ReadDir("contrib/changelog/prod")
-	if err != nil {
-		return "", err
-	}
-	if len(changelogs) == 0 {
-		return "", nil
-	}
-	changelog := slices.MaxFunc(changelogs, func(a fs.DirEntry, b fs.DirEntry) int {
-		return changelogMdToSemver(a.Name()).Compare(changelogMdToSemver(b.Name()))
-	})
-	if changelog == nil {
-		return "", nil
-	}
-	return changelogMdToSemver(changelog.Name()).String(), nil
-}
-
-func changelogMdToSemver(filename string) semver.Version {
-	if !strings.HasSuffix(filename, ".md") {
-		return semver.Version{}
-	}
-	ver, err := semver.NewVersion(strings.Split(strings.TrimSuffix(filename, ".md"), "_")[0])
-	if err != nil && ver == nil {
-		return semver.Version{}
-	}
-	return *ver
 }
 
 func mergeMaps(m1, m2 map[string]string) map[string]string {

--- a/test/helpers/capture_output.go
+++ b/test/helpers/capture_output.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+)
+
+// CaptureOutput will capture the stdout + stderr of a function execution and return it as a string
+func CaptureOutput(f func()) (string, error) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+
+	os.Stdout = writer
+	os.Stderr = writer
+
+	f()
+
+	writer.Close() // close to unblock io.Copy(&buf, reader)
+	var buf bytes.Buffer
+	io.Copy(&buf, reader)
+	return strings.TrimSuffix(buf.String(), "\n"), nil
+}

--- a/test/mock/daemon_client.go
+++ b/test/mock/daemon_client.go
@@ -1,0 +1,62 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"google.golang.org/grpc"
+)
+
+type MockDaemonClient struct {
+	pb.DaemonClient
+	CitiesResponse    []*pb.ServerGroup
+	GroupsResponse    []*pb.ServerGroup
+	CountriesResponse []*pb.ServerGroup
+	PingFn            func() (*pb.PingResponse, error)
+}
+
+func (c MockDaemonClient) Cities(ctx context.Context, in *pb.CitiesRequest, opts ...grpc.CallOption) (*pb.ServerGroupsList, error) {
+	if c.CitiesResponse != nil {
+		return &pb.ServerGroupsList{
+			Type:    internal.CodeSuccess,
+			Servers: c.CitiesResponse,
+		}, nil
+	} else {
+		return &pb.ServerGroupsList{
+			Type:    internal.CodeEmptyPayloadError,
+			Servers: nil,
+		}, nil
+	}
+}
+
+func (c MockDaemonClient) Countries(ctx context.Context, in *pb.Empty, opts ...grpc.CallOption) (*pb.ServerGroupsList, error) {
+	if c.CountriesResponse != nil {
+		return &pb.ServerGroupsList{
+			Type:    internal.CodeSuccess,
+			Servers: c.CountriesResponse,
+		}, nil
+	} else {
+		return &pb.ServerGroupsList{
+			Type:    internal.CodeEmptyPayloadError,
+			Servers: nil,
+		}, nil
+	}
+}
+func (c MockDaemonClient) Groups(ctx context.Context, in *pb.Empty, opts ...grpc.CallOption) (*pb.ServerGroupsList, error) {
+	if c.GroupsResponse != nil {
+		return &pb.ServerGroupsList{
+			Type:    internal.CodeSuccess,
+			Servers: c.GroupsResponse,
+		}, nil
+	} else {
+		return &pb.ServerGroupsList{
+			Type:    internal.CodeEmptyPayloadError,
+			Servers: nil,
+		}, nil
+	}
+}
+
+func (c MockDaemonClient) Ping(ctx context.Context, in *pb.Empty, opts ...grpc.CallOption) (*pb.PingResponse, error) {
+	return c.PingFn()
+}


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

Change the version output to add [snap] at the end of the version when the application is running in snap.