### PR TITLE
LVPN-8144: Remove NoDelay=True from socket config

### DIFF
--- a/contrib/systemd/system/nordvpnd.socket
+++ b/contrib/systemd/system/nordvpnd.socket
@@ -4,12 +4,10 @@ PartOf=nordvpnd.service
 
 [Socket]
 ListenStream=/run/nordvpn/nordvpnd.sock
-NoDelay=true
 # SocketUser=root
 SocketGroup=nordvpn
 SocketMode=0770
 DirectoryMode=0750
-NoDelay=true
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
This PR fixes https://github.com/NordSecurity/nordvpn-linux/issues/897