### PR TITLE
Fix file sharing when daemon cannot access nordvpn socket on VM

### DIFF
--- a/contrib/systemd/user/nordfileshared.service
+++ b/contrib/systemd/user/nordfileshared.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=NordVPN Fileshare Daemon
 Requires=nordfileshared.socket
+# allow the daemon to run only if it can access nordvpn deamon socket
+ConditionPathExists=/run/nordvpn/nordvpnd.sock
+# on Vagrant VM without this the daemon is not able to access /run/nordvpn/nordvpnd.sock
+ConditionGroup=nordvpn
 
 [Service]
 ExecStart=/usr/bin/nordfileshared


### PR DESCRIPTION
Signed-off-by: Marius Sincovici <marius.sincovici@nordsec.com>

In some conditions file sharing daemon is not able to access the nordvpn's socket. Reproduced on Vagrant. Add conditions to service file:
* only start if the socket is accessible
* check if system manager is running in nordvpn group