### PR TITLE
LVPN-8733: set MTU based on the route's MTU and header size for quench

### DIFF
--- a/daemon/vpn/mtu.go
+++ b/daemon/vpn/mtu.go
@@ -1,42 +1,17 @@
 package vpn
 
 import (
-	"errors"
+	"fmt"
 	"log"
 	"net"
-	"os/exec"
-	"strings"
 	"syscall"
 
 	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
-var (
-	errNoDefaultIpRoute          = errors.New("default gateway not found")
-	errUnrecognizedIpRouteOutput = errors.New("unrecognized output of 'ip route show default'")
-)
-
 const defaultMTU = 1500
-
-// getDefaultIpRouteInterface takes output of the `ip route show default` command and returns the
-// interface/device name. If there are multiple default routes in the output, first one will be returned
-func getDefaultIpRouteInterface(ipRouteOutput string) (string, error) {
-	outputRows := strings.Split(ipRouteOutput, "\n")
-
-	if len(outputRows) < 1 || outputRows[0] == "" {
-		return "", errNoDefaultIpRoute
-	}
-
-	outputColumns := strings.Split(strings.Trim(outputRows[0], "\n"), " ")
-
-	if len(outputColumns) < 5 {
-		log.Printf("unexpected output of 'ip route show default': %s, dev value not found", outputRows[0])
-		return "", errUnrecognizedIpRouteOutput
-	}
-
-	return outputColumns[4], nil
-}
 
 // SetMTU for an interface.
 func SetMTU(iface net.Interface, headerSize int) error {
@@ -57,44 +32,32 @@ func SetMTU(iface net.Interface, headerSize int) error {
 	return unix.IoctlIfreq(fd, unix.SIOCSIFMTU, req)
 }
 
-func retrieveAndCalculateMTU(headerSize int) int {
-	c1 := exec.Command("ip", "route", "show", "default")
-	out, err := c1.Output()
-
+func getDefaultGatewayMTU() (int, error) {
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
-		log.Println(internal.ErrorPrefix, "ip route show default failed: ", err)
-		out = nil
+		return 0, fmt.Errorf("listing routes: %w", err)
 	}
 
-	return calculateMTU(string(out), headerSize)
+	for _, route := range routes {
+		if route.Dst == nil {
+			link, err := netlink.LinkByIndex(route.LinkIndex)
+			if err != nil {
+				return 0, fmt.Errorf("getting link attributes: %w", err)
+			}
+			return link.Attrs().MTU, nil
+		}
+	}
+
+	return 0, fmt.Errorf("failed to find default route")
 }
 
-func calculateMTU(ipRouteOutput string, headerSize int) int {
-	defaultGatewayMTU := func() (int, error) {
-		defaultGatewayName, err := getDefaultIpRouteInterface(ipRouteOutput)
-
-		if err != nil {
-			return 0, err
-		}
-
-		defaultGateway, err := net.InterfaceByName(defaultGatewayName)
-		if err != nil {
-			return 0, err
-		}
-
-		// wireguard-quick does this
-		mtu := defaultGateway.MTU - headerSize
-		return mtu, nil
+func retrieveAndCalculateMTU(headerSize int) int {
+	defaultRouteMTU, err := getDefaultGatewayMTU()
+	if err != nil {
+		log.Println(internal.ErrorPrefix, "failed to retrieve default interface, will use default value of: %w",
+			defaultMTU, err)
+		return defaultMTU
 	}
 
-	if ipRouteOutput != "" {
-		mtu, err := defaultGatewayMTU()
-		if err == nil {
-			return mtu
-		}
-
-		log.Println(internal.WarningPrefix, "using default MTU, failed to get default gateway MTU:", err)
-	}
-
-	return defaultMTU - headerSize
+	return defaultRouteMTU - headerSize
 }

--- a/daemon/vpn/mtu.go
+++ b/daemon/vpn/mtu.go
@@ -1,0 +1,100 @@
+package vpn
+
+import (
+	"errors"
+	"log"
+	"net"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	errNoDefaultIpRoute          = errors.New("default gateway not found")
+	errUnrecognizedIpRouteOutput = errors.New("unrecognized output of 'ip route show default'")
+)
+
+const defaultMTU = 1500
+
+// getDefaultIpRouteInterface takes output of the `ip route show default` command and returns the
+// interface/device name. If there are multiple default routes in the output, first one will be returned
+func getDefaultIpRouteInterface(ipRouteOutput string) (string, error) {
+	outputRows := strings.Split(ipRouteOutput, "\n")
+
+	if len(outputRows) < 1 || outputRows[0] == "" {
+		return "", errNoDefaultIpRoute
+	}
+
+	outputColumns := strings.Split(strings.Trim(outputRows[0], "\n"), " ")
+
+	if len(outputColumns) < 5 {
+		log.Printf("unexpected output of 'ip route show default': %s, dev value not found", outputRows[0])
+		return "", errUnrecognizedIpRouteOutput
+	}
+
+	return outputColumns[4], nil
+}
+
+// SetMTU for an interface.
+func SetMTU(iface net.Interface, headerSize int) error {
+	mtu := retrieveAndCalculateMTU(headerSize)
+
+	fd, err := unix.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(fd)
+
+	req, err := unix.NewIfreq(iface.Name)
+	if err != nil {
+		return err
+	}
+	req.SetUint32(uint32(mtu))
+
+	return unix.IoctlIfreq(fd, unix.SIOCSIFMTU, req)
+}
+
+func retrieveAndCalculateMTU(headerSize int) int {
+	c1 := exec.Command("ip", "route", "show", "default")
+	out, err := c1.Output()
+
+	if err != nil {
+		log.Println(internal.ErrorPrefix, "ip route show default failed: ", err)
+		out = nil
+	}
+
+	return calculateMTU(string(out), headerSize)
+}
+
+func calculateMTU(ipRouteOutput string, headerSize int) int {
+	defaultGatewayMTU := func() (int, error) {
+		defaultGatewayName, err := getDefaultIpRouteInterface(ipRouteOutput)
+
+		if err != nil {
+			return 0, err
+		}
+
+		defaultGateway, err := net.InterfaceByName(defaultGatewayName)
+		if err != nil {
+			return 0, err
+		}
+
+		// wireguard-quick does this
+		mtu := defaultGateway.MTU - headerSize
+		return mtu, nil
+	}
+
+	if ipRouteOutput != "" {
+		mtu, err := defaultGatewayMTU()
+		if err == nil {
+			return mtu
+		}
+
+		log.Println(internal.WarningPrefix, "using default MTU, failed to get default gateway MTU:", err)
+	}
+
+	return defaultMTU - headerSize
+}

--- a/daemon/vpn/mtu_test.go
+++ b/daemon/vpn/mtu_test.go
@@ -3,114 +3,58 @@ package vpn
 import (
 	"net"
 	"os/exec"
-	"strings"
+	"strconv"
 	"testing"
 
+	"github.com/NordSecurity/nordvpn-linux/daemon/device"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 )
 
 const testHeaderSize = 30
+const testInterfaceName = "testif"
 
-func TestCalculateMTU(t *testing.T) {
-	category.Set(t, category.Unit)
+func TestSetMTU(t *testing.T) {
+	category.Set(t, category.Link)
 
 	tests := []struct {
-		name          string
-		ipRouteOutput string
-		expectedMTU   int
+		name        string
+		currentMTU  int
+		expectedMTU int
 	}{
+		// {
+		// 	name:        "set MTU underlying MTU is 1500",
+		// 	currentMTU:  1500,
+		// 	expectedMTU: 1500 - testHeaderSize,
+		// },
 		{
-			name:        "no default route exist",
-			expectedMTU: defaultMTU - testHeaderSize,
-		},
-		{
-			name:          "incorrect ip route output",
-			ipRouteOutput: "default via interface_name proto dhcp metric 600",
-			expectedMTU:   defaultMTU - testHeaderSize,
+			name:        "set MTU underlying MTU is 1000",
+			currentMTU:  1450,
+			expectedMTU: 1450 - testHeaderSize,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mtu := calculateMTU(test.ipRouteOutput, testHeaderSize)
-			assert.Equal(t, mtu, test.expectedMTU)
+			defaultGateway, _ := device.DefaultGateway()
+			exec.Command("ip", "link", "set", "dev", defaultGateway.Name, "mtu", strconv.Itoa(test.currentMTU)).Run()
+			defer exec.Command("ip",
+				"link",
+				"set",
+				"dev",
+				defaultGateway.Name,
+				"mtu",
+				strconv.Itoa(defaultGateway.MTU)).Run()
+
+			exec.Command("ip", "link", "add", testInterfaceName, "type", "dummy").Run()
+			exec.Command("sudo", "ip", "addr", "add", "192.168.100.1/24", "dev", "mydummy0").Run()
+			exec.Command("sudo", "ip", "link", "set", "mydummy0", "up").Run()
+
+			iface, _ := net.InterfaceByName(testInterfaceName)
+			SetMTU(*iface, testHeaderSize)
+
+			iface, _ = net.InterfaceByName(testInterfaceName)
+			assert.Equal(t, test.expectedMTU, iface.MTU)
 		})
 	}
-}
-
-func TestRetrieveAndCalculateMTU(t *testing.T) {
-	category.Set(t, category.Link)
-
-	out, err := exec.Command("ip", "route", "show", "default").Output()
-	assert.NoError(t, err)
-
-	defaultGatewayName, err := getDefaultIpRouteInterface(string(out))
-	assert.NoError(t, err)
-
-	defaultGateway, err := net.InterfaceByName(defaultGatewayName)
-	assert.NoError(t, err)
-
-	mtu := retrieveAndCalculateMTU(testHeaderSize)
-	assert.Equal(t, defaultGateway.MTU-testHeaderSize, mtu)
-}
-
-func TestGetDefaultIpRouteInterface(t *testing.T) {
-	category.Set(t, category.Unit)
-
-	tests := []struct {
-		testName              string
-		ipRoutes              string
-		expectedInterfaceName string
-		expectedError         error
-	}{
-		{
-			testName:              "one route",
-			ipRoutes:              "default via 192.168.0.4 dev wlp0s2f4 proto dhcp metric 600\n",
-			expectedInterfaceName: "wlp0s2f4",
-			expectedError:         nil,
-		},
-		{
-			testName: "two routes",
-			ipRoutes: `default via 192.168.0.4 dev wlp0s2f4 proto dhcp metric 600\n
-					   default via 192.168.0.5 dev enp0s2f6 proto dhcp metric 600\n`,
-			expectedInterfaceName: "wlp0s2f4",
-			expectedError:         nil,
-		},
-		{
-			testName:              "no routes",
-			ipRoutes:              "",
-			expectedInterfaceName: "",
-			expectedError:         errNoDefaultIpRoute,
-		},
-		{
-			testName:              "unrecognized output",
-			ipRoutes:              "default via bad output",
-			expectedInterfaceName: "",
-			expectedError:         errUnrecognizedIpRouteOutput,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.testName, func(t *testing.T) {
-			ifName, err := getDefaultIpRouteInterface(test.ipRoutes)
-
-			assert.Equal(t, ifName, test.expectedInterfaceName)
-			assert.Equal(t, err, test.expectedError)
-		})
-	}
-}
-
-func TestGetDefaultIpRouteInterfaceFromCommandOutput(t *testing.T) {
-	category.Set(t, category.Route)
-
-	out, _ := exec.Command("ip", "route", "show", "default").Output()
-	outString := string(out)
-
-	// assume one default route
-	expectedIfName := strings.Split(outString, " ")[4]
-
-	ifName, _ := getDefaultIpRouteInterface(string(out))
-
-	assert.Equal(t, expectedIfName, ifName)
 }

--- a/daemon/vpn/mtu_test.go
+++ b/daemon/vpn/mtu_test.go
@@ -1,0 +1,116 @@
+package vpn
+
+import (
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/stretchr/testify/assert"
+)
+
+const testHeaderSize = 30
+
+func TestCalculateMTU(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name          string
+		ipRouteOutput string
+		expectedMTU   int
+	}{
+		{
+			name:        "no default route exist",
+			expectedMTU: defaultMTU - testHeaderSize,
+		},
+		{
+			name:          "incorrect ip route output",
+			ipRouteOutput: "default via interface_name proto dhcp metric 600",
+			expectedMTU:   defaultMTU - testHeaderSize,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mtu := calculateMTU(test.ipRouteOutput, testHeaderSize)
+			assert.Equal(t, mtu, test.expectedMTU)
+		})
+	}
+}
+
+func TestRetrieveAndCalculateMTU(t *testing.T) {
+	category.Set(t, category.Link)
+
+	out, err := exec.Command("ip", "route", "show", "default").Output()
+	assert.NoError(t, err)
+
+	defaultGatewayName, err := getDefaultIpRouteInterface(string(out))
+	assert.NoError(t, err)
+
+	defaultGateway, err := net.InterfaceByName(defaultGatewayName)
+	assert.NoError(t, err)
+
+	mtu := retrieveAndCalculateMTU(testHeaderSize)
+	assert.Equal(t, defaultGateway.MTU-testHeaderSize, mtu)
+}
+
+func TestGetDefaultIpRouteInterface(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		testName              string
+		ipRoutes              string
+		expectedInterfaceName string
+		expectedError         error
+	}{
+		{
+			testName:              "one route",
+			ipRoutes:              "default via 192.168.0.4 dev wlp0s2f4 proto dhcp metric 600\n",
+			expectedInterfaceName: "wlp0s2f4",
+			expectedError:         nil,
+		},
+		{
+			testName: "two routes",
+			ipRoutes: `default via 192.168.0.4 dev wlp0s2f4 proto dhcp metric 600\n
+					   default via 192.168.0.5 dev enp0s2f6 proto dhcp metric 600\n`,
+			expectedInterfaceName: "wlp0s2f4",
+			expectedError:         nil,
+		},
+		{
+			testName:              "no routes",
+			ipRoutes:              "",
+			expectedInterfaceName: "",
+			expectedError:         errNoDefaultIpRoute,
+		},
+		{
+			testName:              "unrecognized output",
+			ipRoutes:              "default via bad output",
+			expectedInterfaceName: "",
+			expectedError:         errUnrecognizedIpRouteOutput,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			ifName, err := getDefaultIpRouteInterface(test.ipRoutes)
+
+			assert.Equal(t, ifName, test.expectedInterfaceName)
+			assert.Equal(t, err, test.expectedError)
+		})
+	}
+}
+
+func TestGetDefaultIpRouteInterfaceFromCommandOutput(t *testing.T) {
+	category.Set(t, category.Route)
+
+	out, _ := exec.Command("ip", "route", "show", "default").Output()
+	outString := string(out)
+
+	// assume one default route
+	expectedIfName := strings.Split(outString, " ")[4]
+
+	ifName, _ := getDefaultIpRouteInterface(string(out))
+
+	assert.Equal(t, expectedIfName, ifName)
+}

--- a/daemon/vpn/nordlynx/kernel_space.go
+++ b/daemon/vpn/nordlynx/kernel_space.go
@@ -107,7 +107,7 @@ func (k *KernelSpace) Start(
 		return err
 	}
 
-	if err := SetMTU(tun.Interface()); err != nil {
+	if err := vpn.SetMTU(tun.Interface(), WireguardHeaderSize); err != nil {
 		if err := k.stop(); err != nil {
 			log.Println(internal.WarningPrefix, err)
 		}

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -700,7 +700,7 @@ func (l *Libtelio) openTunnel(prefix netip.Prefix, privateKey string) (err error
 		return fmt.Errorf("upping the interface: %w", err)
 	}
 
-	err = nordlynx.SetMTU(tun.Interface())
+	err = vpn.SetMTU(tun.Interface(), nordlynx.WireguardHeaderSize)
 	if err != nil {
 		return fmt.Errorf("setting mtu for the interface: %w", err)
 	}

--- a/daemon/vpn/nordlynx/nordlynx.go
+++ b/daemon/vpn/nordlynx/nordlynx.go
@@ -17,7 +17,6 @@ const (
 	// InterfaceName for various NordLynx implementations
 	InterfaceName       = "nordlynx"
 	defaultPort         = 51820
-	defaultMTU          = 1500
 	WireguardHeaderSize = 80
 )
 

--- a/daemon/vpn/nordlynx/nordlynx.go
+++ b/daemon/vpn/nordlynx/nordlynx.go
@@ -9,11 +9,8 @@ import (
 	"net/netip"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/NordSecurity/nordvpn-linux/internal"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -21,96 +18,14 @@ const (
 	InterfaceName       = "nordlynx"
 	defaultPort         = 51820
 	defaultMTU          = 1500
-	wireguardHeaderSize = 80
+	WireguardHeaderSize = 80
 )
 
 var (
-	errNoKernelModule            = errors.New("interface of type wireguard not supported")
-	errNoDefaultIpRoute          = errors.New("default gateway not found")
-	errUnrecognizedIpRouteOutput = errors.New("unrecognized output of 'ip route show default'")
+	errNoKernelModule = errors.New("interface of type wireguard not supported")
 )
 
 var DefaultPrefix = netip.MustParsePrefix("10.5.0.2/16")
-
-// getDefaultIpRouteInterface takes output of the `ip route show default` command and returns the
-// interface/device name. If there are multiple default routes in the output, first one will be returned
-func getDefaultIpRouteInterface(ipRouteOutput string) (string, error) {
-	outputRows := strings.Split(ipRouteOutput, "\n")
-
-	if len(outputRows) < 1 || outputRows[0] == "" {
-		return "", errNoDefaultIpRoute
-	}
-
-	outputColumns := strings.Split(strings.Trim(outputRows[0], "\n"), " ")
-
-	if len(outputColumns) < 5 {
-		log.Printf("unexpected output of 'ip route show default': %s, dev value not found", outputRows[0])
-		return "", errUnrecognizedIpRouteOutput
-	}
-
-	return outputColumns[4], nil
-}
-
-// SetMTU for an interface.
-func SetMTU(iface net.Interface) error {
-	mtu := retrieveAndCalculateMTU()
-
-	fd, err := unix.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
-	if err != nil {
-		return err
-	}
-	defer unix.Close(fd)
-
-	req, err := unix.NewIfreq(iface.Name)
-	if err != nil {
-		return err
-	}
-	req.SetUint32(uint32(mtu))
-
-	return unix.IoctlIfreq(fd, unix.SIOCSIFMTU, req)
-}
-
-func retrieveAndCalculateMTU() int {
-	c1 := exec.Command("ip", "route", "show", "default")
-	out, err := c1.Output()
-
-	if err != nil {
-		log.Println(internal.ErrorPrefix, "ip route show default failed: ", err)
-		out = nil
-	}
-
-	return calculateMTU(string(out))
-}
-
-func calculateMTU(ipRouteOutput string) int {
-	defaultGatewayMTU := func() (int, error) {
-		defaultGatewayName, err := getDefaultIpRouteInterface(ipRouteOutput)
-
-		if err != nil {
-			return 0, err
-		}
-
-		defaultGateway, err := net.InterfaceByName(defaultGatewayName)
-		if err != nil {
-			return 0, err
-		}
-
-		// wireguard-quick does this
-		mtu := defaultGateway.MTU - wireguardHeaderSize
-		return mtu, nil
-	}
-
-	if ipRouteOutput != "" {
-		mtu, err := defaultGatewayMTU()
-		if err == nil {
-			return mtu
-		}
-
-		log.Println(internal.WarningPrefix, "using default MTU, failed to get default gateway MTU:", err)
-	}
-
-	return defaultMTU - wireguardHeaderSize
-}
 
 func upWGInterface(iface string) error {
 	debug("ip", "link", "add", iface, "type", "wireguard")

--- a/daemon/vpn/nordlynx/nordlynx_test.go
+++ b/daemon/vpn/nordlynx/nordlynx_test.go
@@ -3,8 +3,6 @@ package nordlynx
 import (
 	"net"
 	"net/netip"
-	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/test/category"
@@ -12,69 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetDefaultIpRouteInterface(t *testing.T) {
-	category.Set(t, category.Unit)
-
-	tests := []struct {
-		testName              string
-		ipRoutes              string
-		expectedInterfaceName string
-		expectedError         error
-	}{
-		{
-			testName:              "one route",
-			ipRoutes:              "default via 192.168.0.4 dev wlp0s2f4 proto dhcp metric 600\n",
-			expectedInterfaceName: "wlp0s2f4",
-			expectedError:         nil,
-		},
-		{
-			testName: "two routes",
-			ipRoutes: `default via 192.168.0.4 dev wlp0s2f4 proto dhcp metric 600\n
-					   default via 192.168.0.5 dev enp0s2f6 proto dhcp metric 600\n`,
-			expectedInterfaceName: "wlp0s2f4",
-			expectedError:         nil,
-		},
-		{
-			testName:              "no routes",
-			ipRoutes:              "",
-			expectedInterfaceName: "",
-			expectedError:         errNoDefaultIpRoute,
-		},
-		{
-			testName:              "unrecognized output",
-			ipRoutes:              "default via bad output",
-			expectedInterfaceName: "",
-			expectedError:         errUnrecognizedIpRouteOutput,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.testName, func(t *testing.T) {
-			ifName, err := getDefaultIpRouteInterface(test.ipRoutes)
-
-			assert.Equal(t, ifName, test.expectedInterfaceName)
-			assert.Equal(t, err, test.expectedError)
-		})
-	}
-}
-
 func TestNordLynxDefaultIp(t *testing.T) {
 	category.Set(t, category.Unit)
 	assert.Equal(t, DefaultPrefix, netip.MustParsePrefix("10.5.0.2/16"))
-}
-
-func TestGetDefaultIpRouteInterfaceFromCommandOutput(t *testing.T) {
-	category.Set(t, category.Route)
-
-	out, _ := exec.Command("ip", "route", "show", "default").Output()
-	outString := string(out)
-
-	// assume one default route
-	expectedIfName := strings.Split(outString, " ")[4]
-
-	ifName, _ := getDefaultIpRouteInterface(string(out))
-
-	assert.Equal(t, expectedIfName, ifName)
 }
 
 func TestUpWGInterface(t *testing.T) {
@@ -124,47 +62,4 @@ func TestRemoveDevice(t *testing.T) {
 		_, err := removeDevice(device)
 		assert.Error(t, err)
 	})
-}
-
-func TestCalculateMTU(t *testing.T) {
-	category.Set(t, category.Unit)
-
-	tests := []struct {
-		name          string
-		ipRouteOutput string
-		expectedMTU   int
-	}{
-		{
-			name:        "no default route exist",
-			expectedMTU: defaultMTU - wireguardHeaderSize,
-		},
-		{
-			name:          "incorrect ip route output",
-			ipRouteOutput: "default via interface_name proto dhcp metric 600",
-			expectedMTU:   defaultMTU - wireguardHeaderSize,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			mtu := calculateMTU(test.ipRouteOutput)
-			assert.Equal(t, mtu, test.expectedMTU)
-		})
-	}
-}
-
-func TestRetrieveAndCalculateMTU(t *testing.T) {
-	category.Set(t, category.Link)
-
-	out, err := exec.Command("ip", "route", "show", "default").Output()
-	assert.NoError(t, err)
-
-	defaultGatewayName, err := getDefaultIpRouteInterface(string(out))
-	assert.NoError(t, err)
-
-	defaultGateway, err := net.InterfaceByName(defaultGatewayName)
-	assert.NoError(t, err)
-
-	mtu := retrieveAndCalculateMTU()
-	assert.Equal(t, defaultGateway.MTU-wireguardHeaderSize, mtu)
 }

--- a/daemon/vpn/nordlynx/user_space.go
+++ b/daemon/vpn/nordlynx/user_space.go
@@ -138,7 +138,7 @@ func (u *UserSpace) Start(
 		return err
 	}
 
-	if err := SetMTU(tun.Interface()); err != nil {
+	if err := vpn.SetMTU(tun.Interface(), WireguardHeaderSize); err != nil {
 		if err := u.stop(); err != nil {
 			log.Println(internal.DeferPrefix, err)
 		}

--- a/daemon/vpn/quench/libquench.go
+++ b/daemon/vpn/quench/libquench.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	quenchPrefix        = "[quench]"
-	quenchInterfaceAddr = "10.3.0.2/16"
+	quenchPrefix          = "[quench]"
+	quenchInterfaceAddr   = "10.3.0.2/16"
+	nordWhisperHeaderSize = 80
 )
 
 type Logger struct{}
@@ -192,6 +193,10 @@ func (q *Quench) Start(ctx context.Context, creds vpn.Credentials, server vpn.Se
 
 	if err := tun.Up(); err != nil {
 		return fmt.Errorf("adding ip address to vnic: %w", err)
+	}
+
+	if err := vpn.SetMTU(tun.Interface(), nordWhisperHeaderSize); err != nil {
+		return fmt.Errorf("setting MTU for the interface: %w", err)
 	}
 
 	addr := fmt.Sprintf("wt://%s:%d/", server.IP, server.NordWhisperPort)


### PR DESCRIPTION
Previously MTU was hardcoded to be 1500, but this would cause issues for singular packets whose size would exceed the actual MTU.