### PR TITLE
Remove %v from logs

### DIFF
--- a/norduser/service/fork.go
+++ b/norduser/service/fork.go
@@ -145,7 +145,7 @@ func (c *ChildProcessNorduser) Enable(uid uint32, gid uint32, home string) (err 
 
 	err = mergeUserSessionEnv(uid, gid, &cmd.Env, NewSystemEnvConfigurator())
 	if err != nil {
-		log.Println(internal.WarningPrefix, "failed to retrieve user session's environment: %v", err)
+		log.Println(internal.WarningPrefix, "failed to retrieve user session's environment:", err)
 	}
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
The %v is not needed because Println is used and the error is automatically displayed.