### PR TITLE
LVPN-8968: Fix http3 data race

### DIFF
--- a/cmd/daemon/transports.go
+++ b/cmd/daemon/transports.go
@@ -101,7 +101,7 @@ func createH3Transport() http.RoundTripper {
 	// as of quic-go 0.40.1, GSO handling causes race conditions
 	_ = os.Setenv("QUIC_GO_DISABLE_GSO", "1")
 	// #nosec G402 -- minimum tls version is controlled by the standard library
-	return &http3.Transport{
+	h3Transport := &http3.Transport{
 		QUICConfig: &quic.Config{
 			MaxIdleTimeout: request.TransportTimeout,
 		},
@@ -109,6 +109,10 @@ func createH3Transport() http.RoundTripper {
 			RootCAs: pool,
 		},
 	}
+
+	// wrap the transport to prevent data races during concurrent connection establishment
+	// TODO: remove when `quic-go` issue is resolved: https://github.com/quic-go/quic-go/issues/5307
+	return request.NewH3TransportWrapper(h3Transport)
 }
 
 var validTransportTypes = []string{"http1", "http3"}

--- a/request/h3_reproduce_race_test.go
+++ b/request/h3_reproduce_race_test.go
@@ -66,7 +66,7 @@ func TestReproduceHTTP3DataRace(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 10; i++ {
 			// note: no need for real url, we are testing initialization logic only
-			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://rc.example.com", nil)
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://rc.nordvpn.com", nil)
 			// this will trigger the race in http3.Transport.dial() at line 308 (in v0.48.2)
 			_, _ = cdnTransport.RoundTrip(req)
 			time.Sleep(10 * time.Millisecond)
@@ -78,7 +78,7 @@ func TestReproduceHTTP3DataRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 10; i++ {
-			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.example.com", nil)
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.nordvpn.com", nil)
 			// this will trigger the race in http3.Transport.dial() at line 313 (in v0.48.2)
 			_, _ = apiTransport.RoundTrip(req)
 			time.Sleep(10 * time.Millisecond)
@@ -91,7 +91,7 @@ func TestReproduceHTTP3DataRace(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < 5; j++ {
-				req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.example.com", nil)
+				req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.nordvpn.com", nil)
 				_, _ = h3Transport.RoundTrip(req)
 				time.Sleep(5 * time.Millisecond)
 			}
@@ -130,10 +130,10 @@ func TestDirectHTTP3TransportRace(t *testing.T) {
 
 			// use different hosts to trigger new dial operations
 			hosts := []string{
-				"host1.example.com",
-				"host2.example.com",
-				"host3.example.com",
-				"host4.example.com",
+				"host1.nordpnv.com",
+				"host2.nordvpn.com",
+				"host3.nordvpn.com",
+				"host4.nordvpn.com",
 			}
 			host := hosts[id%len(hosts)]
 

--- a/request/h3_reproduce_race_test.go
+++ b/request/h3_reproduce_race_test.go
@@ -1,0 +1,158 @@
+//go:build race_repro
+// +build race_repro
+
+package request
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+)
+
+// TestReproduceHTTP3DataRace reproduces the original data race that occurs
+// when using http3.Transport directly without our wrapper.
+//
+// Run this test with: go test -race -tags=race_repro ./request -run TestReproduceHTTP3DataRace
+//
+// This test should FAIL with a data race when run with the race detector,
+// demonstrating the problem that existed before our fix.
+func TestReproduceHTTP3DataRace(t *testing.T) {
+	t.Log("WARNING: This test is expected to fail with a data race!")
+	t.Log("It demonstrates the problem that existed before our fix.")
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		t.Fatalf("Failed to get system cert pool: %v", err)
+	}
+
+	h3Transport := &http3.Transport{
+		QUICConfig: &quic.Config{
+			MaxIdleTimeout: 30 * time.Second,
+		},
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
+	defer h3Transport.Close()
+
+	createTransport := func() http.RoundTripper {
+		return NewHTTPReTransport(
+			3,
+			0,
+			"HTTP/3",
+			func() http.RoundTripper { return h3Transport },
+			nil,
+		)
+	}
+
+	cdnTransport := createTransport()
+	apiTransport := createTransport()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// simulate concurrent requests from CDN client (like remote config loader)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			// note: no need for real url, we are testing initialization logic only
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://rc.example.com", nil)
+			// this will trigger the race in http3.Transport.dial() at line 308 (in v0.48.2)
+			_, _ = cdnTransport.RoundTrip(req)
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// simulate concurrent requests from API client (like insights job)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.example.com", nil)
+			// this will trigger the race in http3.Transport.dial() at line 313 (in v0.48.2)
+			_, _ = apiTransport.RoundTrip(req)
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// add more concurrent goroutines to increase the chance of hitting the race
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 5; j++ {
+				req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.example.com", nil)
+				_, _ = h3Transport.RoundTrip(req)
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	t.Log("If you see this message without a data race, try running the test multiple times")
+	t.Log("The race condition is timing-dependent and may not always trigger")
+}
+
+// TestDirectHTTP3TransportRace shows the race even more directly
+// by using the raw http3.Transport without any wrappers
+func TestDirectHTTP3TransportRace(t *testing.T) {
+	t.Log("Direct test of http3.Transport race condition")
+
+	transport := &http3.Transport{
+		QUICConfig: &quic.Config{
+			MaxIdleTimeout: 30 * time.Second,
+		},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	defer transport.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			// use different hosts to trigger new dial operations
+			hosts := []string{
+				"host1.example.com",
+				"host2.example.com",
+				"host3.example.com",
+				"host4.example.com",
+			}
+			host := hosts[id%len(hosts)]
+
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+host+"/test", nil)
+
+			// this is where the race occurs - multiple goroutines calling
+			// transport.RoundTrip() which internally calls dial() and accesses
+			// t.transport without proper synchronization
+			_, _ = transport.RoundTrip(req)
+		}(i)
+	}
+
+	wg.Wait()
+
+	t.Log("Expected data race output:")
+	t.Log("  Read at 0x... by goroutine X:")
+	t.Log("    github.com/quic-go/quic-go/http3.(*Transport).dial()")
+	t.Log("      .../http3/transport.go:308")
+	t.Log("  Previous write at 0x... by goroutine Y:")
+	t.Log("    github.com/quic-go/quic-go/http3.(*Transport).dial()")
+	t.Log("      .../http3/transport.go:313")
+}

--- a/request/h3_transport_wrapper.go
+++ b/request/h3_transport_wrapper.go
@@ -1,0 +1,80 @@
+package request
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+)
+
+// This is workaround solution for `quic-go` external library's
+// issue: https://github.com/quic-go/quic-go/issues/5307
+// TODO: remove this wrapper when `quic-go` issue is resolved.
+
+// H3TransportWrapper provides a thread-safe wrapper around http3.Transport
+// that ensures the internal QUIC transport is initialized only once,
+// preventing data races during concurrent connection establishment.
+type H3TransportWrapper struct {
+	once      sync.Once
+	transport *http3.Transport
+	// quicTransport is initialized once and reused for all connections
+	quicTransport *quic.Transport
+	initErr       error
+}
+
+// NewH3TransportWrapper creates a new thread-safe wrapper for http3.Transport
+func NewH3TransportWrapper(transport *http3.Transport) *H3TransportWrapper {
+	return &H3TransportWrapper{
+		transport: transport,
+	}
+}
+
+// initializeQuicTransport ensures the QUIC transport is initialized only once
+func (w *H3TransportWrapper) initializeQuicTransport() {
+	w.once.Do(func() {
+		udpConn, err := net.ListenUDP("udp", nil)
+		if err != nil {
+			w.initErr = err
+			return
+		}
+		w.quicTransport = &quic.Transport{Conn: udpConn}
+		w.transport.Dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+			udpAddr, err := net.ResolveUDPAddr("udp", addr)
+			if err != nil {
+				return nil, err
+			}
+			return w.quicTransport.DialEarly(ctx, udpAddr, tlsCfg, cfg)
+		}
+	})
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (w *H3TransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	w.initializeQuicTransport()
+	if w.initErr != nil {
+		return nil, w.initErr
+	}
+	return w.transport.RoundTrip(req)
+}
+
+// Close closes the underlying transports
+func (w *H3TransportWrapper) Close() error {
+	// First close the HTTP/3 transport
+	if err := w.transport.Close(); err != nil {
+		return err
+	}
+	// Then close our QUIC transport if it was initialized
+	if w.quicTransport != nil {
+		if err := w.quicTransport.Close(); err != nil {
+			return err
+		}
+		if err := w.quicTransport.Conn.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/request/h3_transport_wrapper_test.go
+++ b/request/h3_transport_wrapper_test.go
@@ -51,9 +51,9 @@ func TestHTTP3TransportRaceCondition(t *testing.T) {
 
 			for j := 0; j < numRequestsPerGoroutine; j++ {
 				// create requests to different hosts to trigger the dial race
-				host := "example.com"
+				host := "nordcdn.com"
 				if goroutineID%2 == 0 {
-					host = "api.example.com"
+					host = "api.nordvpn.com"
 				}
 
 				req, err := http.NewRequestWithContext(

--- a/request/h3_transport_wrapper_test.go
+++ b/request/h3_transport_wrapper_test.go
@@ -1,0 +1,85 @@
+package request
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+)
+
+func TestHTTP3TransportRaceCondition(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	// this test simulates the exact scenario from the race detector output:
+	// multiple goroutines making concurrent HTTP/3 requests through the same transport
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		t.Fatalf("Failed to get system cert pool: %v", err)
+	}
+	h3Transport := &http3.Transport{
+		QUICConfig: &quic.Config{
+			MaxIdleTimeout: 30 * time.Second,
+		},
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
+
+	wrapper := NewH3TransportWrapper(h3Transport)
+	defer wrapper.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	numGoroutines := 10
+	numRequestsPerGoroutine := 5
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(goroutineID int) {
+			defer wg.Done()
+
+			for j := 0; j < numRequestsPerGoroutine; j++ {
+				// create requests to different hosts to trigger the dial race
+				host := "example.com"
+				if goroutineID%2 == 0 {
+					host = "api.example.com"
+				}
+
+				req, err := http.NewRequestWithContext(
+					ctx,
+					http.MethodGet,
+					"https://"+host+"/test",
+					nil,
+				)
+				if err != nil {
+					t.Logf("Failed to create request: %v", err)
+					continue
+				}
+
+				// this would trigger the race if no fix applied
+				rsp, err := wrapper.RoundTrip(req)
+				// we expect connection errors since these are not real servers
+				// the important thing is no data race occurs
+				if err != nil {
+					continue
+				}
+				rsp.Body.Close()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	t.Log("Concurrent HTTP/3 requests completed without data races")
+}


### PR DESCRIPTION
This is workaround solution for `quic-go` external library's
issue: https://github.com/quic-go/quic-go/issues/5307
TODO: remove this wrapper when `quic-go` issue is resolved.