### PR TITLE
LVPN-8994: Improve static config

### DIFF
--- a/config/static_config.go
+++ b/config/static_config.go
@@ -4,37 +4,29 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/NordSecurity/nordvpn-linux/internal"
 )
 
-var staticConfigFilename = filepath.Join(internal.DatFilesPathCommon, "install_static.dat")
 var (
 	ErrStaticValueAlreadySet    = errors.New("static value already configured")
 	ErrStaticValueNotConfigured = errors.New("static value was not configured")
-	ErrFailedToReadConfigFile   = errors.New("failed to read static config file")
 	ErrRolloutGroupOutOfBounds  = errors.New("rollout group out of bounds")
 )
 
-type configState int
-
 const (
-	staticConfigState_noFile configState = iota
-	staticConfigState_failedToInitialize
-	staticConfigState_initialized
+	rolloutGroupUnsetValue = 0
+	rolloutGroupMin        = 1
+	rolloutGroupMax        = 100
 )
-
-const rolloutGroupUnsetValue = 0
 
 type StaticConfig struct {
 	RolloutGroup int `json:"rollout_group,omitempty"`
 }
 
-// StaticConfigManager stores values which remain constant thoroughout app's lifetime
+// StaticConfigManager stores values which remain constant throughout app's lifetime
 type StaticConfigManager interface {
 	GetRolloutGroup() (int, error)
 	SetRolloutGroup(int) error
@@ -42,73 +34,56 @@ type StaticConfigManager interface {
 
 // FilesystemStaticConfigManager saves and reads values to a config file
 type FilesystemStaticConfigManager struct {
-	fs    FilesystemHandle
-	state configState
-	cfg   StaticConfig
-	mu    sync.RWMutex
-}
-
-func tryInitStaticConfig(fs FilesystemHandle) (StaticConfig, configState) {
-	cfgFile, err := fs.ReadFile(staticConfigFilename)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// file not existing is normal on first start, dont log as error
-			return StaticConfig{}, staticConfigState_noFile
-		}
-		log.Println(internal.ErrorPrefix, "failed to load static config:", err)
-		return StaticConfig{}, staticConfigState_failedToInitialize
-	}
-
-	var cfg StaticConfig
-	err = json.Unmarshal(cfgFile, &cfg)
-	if err != nil {
-		log.Println(internal.ErrorPrefix, "failed to unmarshal static config:", err)
-		return cfg, staticConfigState_failedToInitialize
-	}
-
-	return cfg, staticConfigState_initialized
+	fs FilesystemHandle
+	mu sync.RWMutex
 }
 
 func NewFilesystemStaticConfigManager() *FilesystemStaticConfigManager {
-	fs := StdFilesystemHandle{}
-	cfg, state := tryInitStaticConfig(fs)
-
 	return &FilesystemStaticConfigManager{
-		fs:    fs,
-		state: state,
-		cfg:   cfg,
+		fs: StdFilesystemHandle{},
 	}
 }
 
-func (s *FilesystemStaticConfigManager) getConfig() (StaticConfig, error) {
-	if s.state == staticConfigState_initialized {
-		return s.cfg, nil
-	}
-
-	if s.state == staticConfigState_failedToInitialize {
-		return s.cfg, ErrFailedToReadConfigFile
-	}
-
-	if s.state == staticConfigState_noFile {
-		cfg, state := tryInitStaticConfig(s.fs)
-		s.cfg = cfg
-		s.state = state
-
-		if state == staticConfigState_failedToInitialize {
-			return cfg, ErrFailedToReadConfigFile
+// loadConfig reads the config from disk
+func (s *FilesystemStaticConfigManager) loadConfig() (StaticConfig, error) {
+	data, err := s.fs.ReadFile(internal.StaticConfigFilename)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// file doesn't exist yet, return empty config
+			return StaticConfig{}, nil
 		}
+		return StaticConfig{}, fmt.Errorf("reading config file: %w", err)
 	}
 
-	return s.cfg, nil
+	var cfg StaticConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return StaticConfig{}, fmt.Errorf("unmarshaling config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// saveConfig writes the config to disk
+func (s *FilesystemStaticConfigManager) saveConfig(cfg StaticConfig) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := s.fs.WriteFile(internal.StaticConfigFilename, data, internal.PermUserRW); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	return nil
 }
 
 func (s *FilesystemStaticConfigManager) GetRolloutGroup() (int, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cfg, err := s.getConfig()
+	cfg, err := s.loadConfig()
 	if err != nil {
-		return 0, fmt.Errorf("failed to read config: %w", err)
+		return 0, err
 	}
 
 	if cfg.RolloutGroup == rolloutGroupUnsetValue {
@@ -122,16 +97,13 @@ func (s *FilesystemStaticConfigManager) SetRolloutGroup(rolloutGroup int) error 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	const rolloutGroupMin = 1
-	const rolloutGroupMax = 100
-
 	if rolloutGroup < rolloutGroupMin || rolloutGroup > rolloutGroupMax {
 		return ErrRolloutGroupOutOfBounds
 	}
 
-	cfg, err := s.getConfig()
+	cfg, err := s.loadConfig()
 	if err != nil {
-		return fmt.Errorf("failed to read config: %w", err)
+		return err
 	}
 
 	if cfg.RolloutGroup != rolloutGroupUnsetValue {
@@ -139,17 +111,5 @@ func (s *FilesystemStaticConfigManager) SetRolloutGroup(rolloutGroup int) error 
 	}
 
 	cfg.RolloutGroup = rolloutGroup
-	json, err := json.Marshal(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to serialize json: %w", err)
-	}
-
-	err = s.fs.WriteFile(staticConfigFilename, json, internal.PermUserRW)
-	if err != nil {
-		return fmt.Errorf("failed to save static config file: %w", err)
-	}
-
-	s.cfg = cfg
-	s.state = staticConfigState_initialized
-	return nil
+	return s.saveConfig(cfg)
 }


### PR DESCRIPTION
Issues addressed:
- do not do init twice;
- do not report error if on first start file is not present yet (which is normal case, not error);