### PR TITLE
LVPN-8657: Adjust protobuf generation and build

### DIFF
--- a/gui/rps.yaml
+++ b/gui/rps.yaml
@@ -68,8 +68,7 @@ scripts:
       protobuf:
         $description: Regenerate protobufs using docker image
         $script: |
-          IMAGE_NAME_AND_VERSION="${1}" # specify this in a format <name>:<version>
-          docker run -v `pwd`:/code/app ${IMAGE_NAME_AND_VERSION} scripts/generate_protobuf.sh
+          docker run -v `pwd`/../:/code/app ghcr.io/nordsecurity/nordvpn-linux/protobuf_dart-3.8.1:1.0.1 ./gui/scripts/generate_protobuf.sh
 
     build:
       package:
@@ -93,18 +92,15 @@ scripts:
             set -eux
             # build application
             APP_DIR=/code/app
-            IMAGE_VERSION=0.0.2
-            IMAGE_NAME=flutter
             flutter clean
             PLATFORM="${2}"
             ARCH=${PLATFORM#"linux/"}
-            docker/generate_docker_image.sh ${IMAGE_NAME} ${IMAGE_VERSION} ${PLATFORM} docker/flutter
-            docker run -v `pwd`:/code/app --platform ${PLATFORM} --workdir ${APP_DIR} ${IMAGE_NAME}:${IMAGE_VERSION} scripts/build_application.sh ${1}
+            docker run -v `pwd`/../:/code/app --platform ${PLATFORM} --workdir ${APP_DIR}  ghcr.io/nordsecurity/nordvpn-linux/flutter-3.32.8:1.0.1 gui/scripts/build_application.sh ${1}
             # Generate package
-            docker run -v `pwd`:${APP_DIR} \
+            docker run -v `pwd`/../:${APP_DIR} \
                     --workdir ${APP_DIR} \
                     --user 1000:1000 \
                     ghcr.io/nordsecurity/nordvpn-linux/packager:1.3.0 \
-                    ${APP_DIR}/scripts/build_package.sh ${1} ${0} ${ARCH}
+                    ${APP_DIR}/gui/scripts/build_package.sh ${1} ${0} ${ARCH}
             # clean the build folder otherwise local builds will not work because of CMake error
             flutter clean

--- a/gui/scripts/build_application.sh
+++ b/gui/scripts/build_application.sh
@@ -11,6 +11,8 @@ fi
 # NOTE: Updating of the app version should happen before `scripts/env.sh`
 # is sourced to export updated version
 
+pushd ./gui
+
 # update version info in pubspec.yaml
 scripts/update_app_version.sh
 
@@ -21,6 +23,7 @@ cleanup() {
 		mv -f "${file}.bak" "${file}"
 		echo "Reverted changes to ${file}"
 	fi
+  popd
 }
 trap cleanup EXIT ERR INT TERM
 

--- a/gui/scripts/build_package.sh
+++ b/gui/scripts/build_package.sh
@@ -12,6 +12,8 @@ fi
 # NOTE: Updating of the app version should happen before `scripts/env.sh`
 # is sourced to export updated version
 
+pushd ./gui
+
 # update version info in pubspec.yaml
 scripts/update_app_version.sh
 
@@ -22,6 +24,7 @@ cleanup() {
 		mv -f "${file}.bak" "${file}"
 		echo "Reverted changes to ${file}"
 	fi
+  popd
 }
 trap cleanup EXIT ERR INT TERM
 

--- a/gui/scripts/generate_protobuf.sh
+++ b/gui/scripts/generate_protobuf.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e 
-OUT="${PWD}/lib/pb"
+OUT="${PWD}/gui/lib/pb"
 echo $OUT
 rm -fr "$OUT"
 mkdir -p "$OUT"
@@ -14,7 +14,6 @@ for FILE in "timestamp.proto"; do
     protoc -I="$GOOGLE_PROTO_ROOT_DIR" --dart_out="$OUT" "$GOOGLE_PROTO_ROOT_DIR/google/protobuf/$FILE"
 done
 
-pushd nordvpn-linux > /dev/null
 # used GRPC files
 GRPC_FILES=(
     "protobuf/daemon/service.proto"
@@ -35,11 +34,13 @@ for i in "${GRPC_FILES[@]}"; do
     popd >/dev/null
 done
 
+PROTO_FILES=$(find ../ -name "*.proto" ! -name service.proto -not -path "*/snapconf/*" -not -path "*/norduser/*" -not -path "*/libtelio/*" -not -path "*/parts/*")
+
 echo "**** Generate files *****"
-for i in $(find . -name "*.proto" ! -name service.proto  -not -path "*/snapconf/*" -not -path "*/norduser/*" ); do
+for i in ${PROTO_FILES}; do
     DIR=$(dirname "$i")
     FILE=$(basename "$i")
-    DIR_NAME_WITHOUT_PROTOBUF=$(echo $DIR | cut -d'/' -f3-)
+    DIR_NAME_WITHOUT_PROTOBUF=$(echo $DIR | cut -d'/' -f4-)
     PROTO_OUT="$OUT/$DIR_NAME_WITHOUT_PROTOBUF"
 
     FILENAME="${FILE%.*}"
@@ -57,7 +58,7 @@ for i in $(find . -name "*.proto" ! -name service.proto  -not -path "*/snapconf/
     if [ ! -L "$PROTO_OUT/google" ]; then
         ln -s "../google" "$PROTO_OUT/google"
     fi
-    
+
     # using protoc --dart_out="$PROTO_OUT" "$FILE" "$GOOGLE_PROTO_ROOT_DIR/google/protobuf/timestamp.proto" creates google multiple times
     protoc --dart_out="$PROTO_OUT" "$FILE"
 
@@ -65,5 +66,3 @@ for i in $(find . -name "*.proto" ! -name service.proto  -not -path "*/snapconf/
 
     popd > /dev/null
 done
-
-popd > /dev/null


### PR DESCRIPTION
Changes:
- adjust protobuf generation to use original protobufs instead of submodule
- use migrated docker images available on ghcr.io