### PR TITLE
LVPN-8095: ensure a proper version string in prod

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -138,6 +138,13 @@ func main() {
 				log.Println(internal.ErrorPrefix, err)
 			}
 		}()
+	} else {
+		// Ensure that there is no commit SHA added to the version string in prod.
+		var err error
+		Version, err = internal.CleanUpVersionString(Version)
+		if err != nil {
+			log.Println(internal.ErrorPrefix, "failed to clean up version string:", err)
+		}
 	}
 
 	// Logging

--- a/internal/version_string.go
+++ b/internal/version_string.go
@@ -1,0 +1,16 @@
+package internal
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func CleanUpVersionString(versionString string) (string, error) {
+	r := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
+	result := r.FindString(versionString)
+	if result == "" {
+		return "", fmt.Errorf("invalid version string")
+	}
+
+	return result, nil
+}

--- a/internal/version_string_test.go
+++ b/internal/version_string_test.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanUpVersionString(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name           string
+		versionString  string
+		expectedResult string
+		shouldFail     bool
+	}{
+		{
+			name:           "string after version string",
+			versionString:  "3.20.1+b05658b99a42e01d",
+			expectedResult: "3.20.1",
+		},
+		{
+			name:           "string before version string",
+			versionString:  "b05658b99a42e01d+3.20.1",
+			expectedResult: "3.20.1",
+		},
+		{
+			name:           "string before and after version string",
+			versionString:  "b05658b99a42e01d+3.20.1+b05658b99a42e01d",
+			expectedResult: "3.20.1",
+		},
+		{
+			name:           "string before and after version string no separator",
+			versionString:  "b05658b99a42e01d3.20.1b05658b99a42e01d",
+			expectedResult: "3.20.1",
+		},
+		{
+			name:           "no extra strings",
+			versionString:  "3.20.1",
+			expectedResult: "3.20.1",
+		},
+		{
+			name:          "garbage string",
+			versionString: "aaaaa",
+			shouldFail:    true,
+		},
+		{
+			name:          "invalid version string",
+			versionString: "3.aaa.1",
+			shouldFail:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := CleanUpVersionString(test.versionString)
+
+			assert.Equal(t, test.expectedResult, result)
+
+			if test.shouldFail {
+				assert.Error(t, err, "CleanUpVersionString returned an unexpected error.")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sometimes a dev style app version is configured in the analytics context(x.x.x+<commit SHA>) in prod builds. This results in garbage data. A cleanup mechanism was added, so that only proper version string will be used in prod.