### PR TITLE
LVPN-8657: Fix working dir in build scripts

### DIFF
--- a/gui/rps.yaml
+++ b/gui/rps.yaml
@@ -91,16 +91,16 @@ scripts:
           $script: |
             set -eux
             # build application
-            APP_DIR=/code/app
+            APP_DIR=/code/app/gui
             flutter clean
             PLATFORM="${2}"
             ARCH=${PLATFORM#"linux/"}
-            docker run -v `pwd`/../:/code/app --platform ${PLATFORM} --workdir ${APP_DIR}  ghcr.io/nordsecurity/nordvpn-linux/flutter-3.32.8:1.0.1 gui/scripts/build_application.sh ${1}
+            docker run -v `pwd`/../:/code/app --platform ${PLATFORM} --workdir ${APP_DIR}  ghcr.io/nordsecurity/nordvpn-linux/flutter-3.32.8:1.0.1 scripts/build_application.sh ${1}
             # Generate package
-            docker run -v `pwd`/../:${APP_DIR} \
+            docker run -v `pwd`/../:/code/app \
                     --workdir ${APP_DIR} \
                     --user 1000:1000 \
                     ghcr.io/nordsecurity/nordvpn-linux/packager:1.3.0 \
-                    ${APP_DIR}/gui/scripts/build_package.sh ${1} ${0} ${ARCH}
+                    ${APP_DIR}/scripts/build_package.sh ${1} ${0} ${ARCH}
             # clean the build folder otherwise local builds will not work because of CMake error
             flutter clean

--- a/gui/scripts/build_application.sh
+++ b/gui/scripts/build_application.sh
@@ -11,8 +11,6 @@ fi
 # NOTE: Updating of the app version should happen before `scripts/env.sh`
 # is sourced to export updated version
 
-pushd ./gui
-
 # update version info in pubspec.yaml
 scripts/update_app_version.sh
 
@@ -23,7 +21,6 @@ cleanup() {
 		mv -f "${file}.bak" "${file}"
 		echo "Reverted changes to ${file}"
 	fi
-  popd
 }
 trap cleanup EXIT ERR INT TERM
 

--- a/gui/scripts/build_package.sh
+++ b/gui/scripts/build_package.sh
@@ -12,8 +12,6 @@ fi
 # NOTE: Updating of the app version should happen before `scripts/env.sh`
 # is sourced to export updated version
 
-pushd ./gui
-
 # update version info in pubspec.yaml
 scripts/update_app_version.sh
 
@@ -24,7 +22,6 @@ cleanup() {
 		mv -f "${file}.bak" "${file}"
 		echo "Reverted changes to ${file}"
 	fi
-  popd
 }
 trap cleanup EXIT ERR INT TERM
 


### PR DESCRIPTION
Changes:
- don't switch working dir in scripts because running it locally vs in docker is then problematic
- instead, set the proper working dir when running docker