### PR TITLE
LVPN-5404: Save daemon logs when running the tests in snap

### DIFF
--- a/ci/check_dependencies.sh
+++ b/ci/check_dependencies.sh
@@ -14,6 +14,8 @@ libmoose_nordvpnapp_artifact_url="${LIBMOOSE_NORDVPNAPP_ARTIFACTS_URL}/${LIBMOOS
 libmoose_worker_artifact_url="${LIBMOOSE_WORKER_ARTIFACTS_URL}/${LIBMOOSE_WORKER_VERSION}/linux.zip"
 libquench_artifact_url="${LIBQUENCH_ARTIFACTS_URL}/${LIBQUENCH_VERSION}/linux.zip"
 
+echo "XXX ${libtelio_artifact_url}"
+
 # Uncomment this when all libraries migrate artifacts
 # if [[ ${CI+x} ]]; then
 #   header="JOB-TOKEN:${CI_JOB_TOKEN}"

--- a/ci/qa_run_tests.sh
+++ b/ci/qa_run_tests.sh
@@ -48,9 +48,9 @@ esac
 
 # check that the nordvpn group exists in the system and that the current user is part of it
 GROUP="nordvpn"
-if ! getent group "$GROUP" > /dev/null; then
+if ! getent group "${GROUP}" > /dev/null; then
 	# application installer must create the group
-	echo "Group '$GROUP' does not exist."
+	echo "Group '${GROUP}' does not exist."
 	exit 1
 fi
 
@@ -58,11 +58,11 @@ fi
 : "${USER:=$(whoami)}"
 
 # add current user into nordvpn group if needed
-if id -nG "$USER" | grep -qw "$GROUP"; then
-	echo "User '$USER' is part of the in group '$GROUP'."
+if id -nG "${USER}" | grep -qw "${GROUP}"; then
+	echo "User '${USER}' is part of the in group '${GROUP}'."
 else
-	echo "Adding user '$USER'to group '$GROUP'..."
-	sudo usermod -aG "$GROUP" "$USER"
+	echo "Adding user '${USER}'to group '${GROUP}'..."
+	sudo usermod -aG "${GROUP}" "${USER}"
 fi
 
 ARTIFACTS_FOLDER="${WORKDIR}"/dist/test_artifacts

--- a/ci/qa_run_tests.sh
+++ b/ci/qa_run_tests.sh
@@ -46,8 +46,23 @@ case "${pattern}" in
 esac
 
 
+# check that the nordvpn group exists in the system and that the current user is part of it
+GROUP="nordvpn"
+if ! getent group "$GROUP" > /dev/null; then
+	# application installer must create the group
+	echo "Group '$GROUP' does not exist."
+	exit 1
+fi
+
+# add current user into nordvpn group if needed
+if id -nG "$USER" | grep -qw "$GROUP"; then
+	echo "User '$USER' is part of the in group '$GROUP'."
+else
+	echo "Adding user '$USER'to group '$GROUP'..."
+	sudo usermod -aG "$GROUP" "$USER"
+fi
+
 ARTIFACTS_FOLDER="${WORKDIR}"/dist/test_artifacts
-LOGS_FOLDER="${WORKDIR}"/dist/logs
 
 mkdir -p "${LOGS_FOLDER}"
 mkdir -p "${ARTIFACTS_FOLDER}"

--- a/ci/qa_run_tests.sh
+++ b/ci/qa_run_tests.sh
@@ -54,6 +54,9 @@ if ! getent group "$GROUP" > /dev/null; then
 	exit 1
 fi
 
+# if user variable is not set, set it with whoami result
+: "${USER:=$(whoami)}"
+
 # add current user into nordvpn group if needed
 if id -nG "$USER" | grep -qw "$GROUP"; then
 	echo "User '$USER' is part of the in group '$GROUP'."

--- a/ci/qa_tests_env.sh
+++ b/ci/qa_tests_env.sh
@@ -10,3 +10,4 @@ export DISABLE_TUI_LOADER=1
 # go code cover dir
 export COVERDIR="covdatafiles"
 export GOCOVERDIR="${WORKDIR}/$COVERDIR"
+export LOGS_FOLDER="${WORKDIR}"/dist/logs

--- a/ci/snap/vagrant/Vagrantfile
+++ b/ci/snap/vagrant/Vagrantfile
@@ -5,17 +5,39 @@ Vagrant.configure("2") do |config|
   # libvirt uses rsync and there are issues with the snap folders
   # Because of this for libvirt override sync to exclude problematic folders
   config.vm.provider "libvirt" do |lv, override|
-    override.vm.synced_folder ENV["WORKDIR"], "/vagrant",
-      type: "rsync",
-      rsync__auto: true,
-      rsync__args: ["--archive", "--delete", "--compress"],
-      rsync__exclude: ["parts", "prime", ".git"]
+    override.vm.synced_folder ENV["WORKDIR"], "/vagrant", type: "nfs", nfs_version: 4
   end
 
   config.vm.network "private_network", type: "dhcp"
 
   # install dependencies
   config.vm.provision "shell", path: "provision_snap.sh"
+
+  # Add support for a custom box that can be downloaded from an https server
+  config.vm.define "custom" do |box|
+    box_url = ENV["SNAP_TEST_BOX_URL"]
+    if box_url.nil? || box_url.empty?
+      abort "SNAP_TEST_BOX_URL must be set in .env or as an environment variable"
+    end
+
+    # set credentials to download the box, if needed
+    username = ENV["SNAP_TEST_BOX_USER"]
+    password=ENV["SNAP_TEST_BOX_PASS"]
+    puts "Using box: #{box_url}"
+
+    # set download options
+    box.vm.box_download_options = {
+      'user': "#{username}:#{password}",
+    }
+
+    box.vm.provider :libvirt do |libvirt|
+      libvirt.cpus = 3
+      libvirt.memory = 4096
+    end
+  
+    box.vm.box = "custom_snap"
+    box.vm.box_url = box_url
+  end
 
   config.vm.define "ubuntu2204", autostart: false do |ubuntu|
     ubuntu.vm.box = "generic/ubuntu2204"

--- a/ci/snap/vagrant/Vagrantfile
+++ b/ci/snap/vagrant/Vagrantfile
@@ -15,28 +15,31 @@ Vagrant.configure("2") do |config|
 
   # Add support for a custom box that can be downloaded from an https server
   config.vm.define "custom" do |box|
-    box_url = ENV["SNAP_TEST_BOX_URL"]
-    if box_url.nil? || box_url.empty?
-      abort "SNAP_TEST_BOX_URL must be set in .env or as an environment variable"
-    end
+    # only execute if custom configuration is used, e.g. vagrant up custom
+    if ARGV.include?("custom")
+      box_url = ENV["SNAP_TEST_BOX_URL"]
+      if box_url.nil? || box_url.empty?
+        abort "SNAP_TEST_BOX_URL must be set in .env or as an environment variable"
+      end
 
-    # set credentials to download the box, if needed
-    username = ENV["SNAP_TEST_BOX_USER"]
-    password=ENV["SNAP_TEST_BOX_PASS"]
-    puts "Using box: #{box_url}"
+      # set credentials to download the box, if needed
+      username = ENV["SNAP_TEST_BOX_USER"]
+      password=ENV["SNAP_TEST_BOX_PASS"]
+      puts "Using box: #{box_url}"
 
-    # set download options
-    box.vm.box_download_options = {
-      'user': "#{username}:#{password}",
-    }
+      # set download options
+      box.vm.box_download_options = {
+        'user': "#{username}:#{password}",
+      }
 
-    box.vm.provider :libvirt do |libvirt|
-      libvirt.cpus = 3
-      libvirt.memory = 4096
-    end
-  
-    box.vm.box = "custom_snap"
-    box.vm.box_url = box_url
+      box.vm.provider :libvirt do |libvirt|
+        libvirt.cpus = 3
+        libvirt.memory = 4096
+      end
+    
+      box.vm.box = "custom_snap"
+      box.vm.box_url = box_url
+    end 
   end
 
   config.vm.define "ubuntu2204", autostart: false do |ubuntu|

--- a/ci/snap/vagrant/provision_snap.sh
+++ b/ci/snap/vagrant/provision_snap.sh
@@ -30,5 +30,3 @@ done
 echo "Installing tester dependencies..."
 sudo pip3 install -r /vagrant/ci/docker/tester/requirements.txt
 
-sudo groupadd nordvpn
-sudo usermod -aG nordvpn vagrant

--- a/ci/snap_functions.sh
+++ b/ci/snap_functions.sh
@@ -7,12 +7,12 @@ snap_connect_interfaces() {
     echo "Make the snap connections"
 
     wait_for_daemon
-    output=$(nordvpn status || true)
+    SNAP_CONNECT_CMDS=$(nordvpn status | grep -o '^sudo snap connect .*' || true)
 
-    echo "$output" | grep -o '^sudo snap connect .*' | while read -r cmd; do
-        echo "Executing: $cmd"
+    echo "${SNAP_CONNECT_CMDS}" | while read -r CMD; do
+        echo "Executing: ${CMD}"
         # Run the command
-        $cmd
+        ${CMD}
     done
     echo "All permissions granted successfully."
 
@@ -27,13 +27,13 @@ snap_connect_interfaces() {
 # wait until daemon is running
 wait_for_daemon() {
     for i in {1..10}; do
-        output=$(nordvpn status || true)
+        STATUS=$(nordvpn status || true)
         # cannot use return code 0 because snap interfaces are not connected
         # instead check that the output have "nordvpnd.sock not found"
-        if [[ "$output" != *"nordvpnd.sock"* ]]; then
+        if [[ "${STATUS}" != *"nordvpnd.sock"* ]]; then
             return
         fi
-        echo "Attempt $i failed: $output"
+        echo "Attempt ${i} failed: ${STATUS}"
         sleep 1
     done
 }

--- a/ci/snap_functions.sh
+++ b/ci/snap_functions.sh
@@ -1,40 +1,39 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euxo pipefail
 
+# using nordvpn status connect the needed snap interfaces
 snap_connect_interfaces() {
-    local SNAP_NAME=nordvpn
-
     # List all connections for the Snap
-    echo "Checking connections for Snap package: ${SNAP_NAME}"
-    connections=$(snap connections "${SNAP_NAME}")
+    echo "Make the snap connections"
 
-    # Display and process unconnected interfaces
-    echo
-    echo "Unconnected connections for ${SNAP_NAME}:"
-    unconnected=$(echo "${connections}" | awk '
-    NR > 1 && $3 == "-" {
-        print $1
-    }')
+    wait_for_daemon
+    output=$(nordvpn status || true)
 
-    if [ -z "${unconnected}" ]; then
-        echo "All connections are already connected."
-        return
-    fi
-
-    echo "${unconnected}"
-
-    # Attempt to connect each unconnected interface
-    echo
-    for interface in ${unconnected}; do
-        echo "Connecting interface: ${interface}"
-        if sudo snap connect "${SNAP_NAME}:${interface}"; then
-            echo "Successfully connected: ${interface}"
-        else
-            echo "Failed to connect: ${interface}"
-        fi
+    echo "$output" | grep -o '^sudo snap connect .*' | while read -r cmd; do
+        echo "Executing: $cmd"
+        # Run the command
+        $cmd
     done
+    echo "All permissions granted successfully."
 
-    echo
-    echo "Connection process completed for ${SNAP_NAME}."
-    # Show current connections state
-    snap connections "${SNAP_NAME}"
+    wait_for_daemon
+
+    # recheck that the nordvpn status is successful
+    nordvpn status
+
+    echo "Snap connection process completed."
+}
+
+# wait until daemon is running
+wait_for_daemon() {
+    for i in {1..10}; do
+        output=$(nordvpn status || true)
+        # cannot use return code 0 because snap interfaces are not connected
+        # instead check that the output have "nordvpnd.sock not found"
+        if [[ "$output" != *"nordvpnd.sock"* ]]; then
+            return
+        fi
+        echo "Attempt $i failed: $output"
+        sleep 1
+    done
 }

--- a/ci/test_snap.sh
+++ b/ci/test_snap.sh
@@ -17,10 +17,13 @@ GOCOVERDIR="/tmp/"
 
 add_daemon_logs() {
     # append the snap daemon logs into the daemon.log file
-    echo "----------------------------------------- " >> "${LOGS_FOLDER}/daemon.log"
-    echo "----------- start daemon log ------------ " >> "${LOGS_FOLDER}/daemon.log"
-    echo "----------------------------------------- " >> "${LOGS_FOLDER}/daemon.log"
-    sudo journalctl -b -u snap.nordvpn.nordvpnd.service >> "${LOGS_FOLDER}/daemon.log"
+    {
+        echo "----------------------------------------- "
+        echo "----------- start daemon log ------------ "
+        echo "----------------------------------------- "
+    } >> "${LOGS_FOLDER}/daemon.log"
+
+    sudo journalctl -b -u snap.nordvpn.nordvpnd.service | tee -a "${LOGS_FOLDER}/daemon.log" > /dev/null
 }
 
 trap add_daemon_logs EXIT INT TERM

--- a/ci/test_snap.sh
+++ b/ci/test_snap.sh
@@ -15,6 +15,16 @@ rm -fr "${GOCOVERDIR}"
 ORIG_COVERDIR="$GOCOVERDIR"
 GOCOVERDIR="/tmp/"
 
+add_daemon_logs() {
+    # append the snap daemon logs into the daemon.log file
+    echo "----------------------------------------- " >> "${LOGS_FOLDER}/daemon.log"
+    echo "----------- start daemon log ------------ " >> "${LOGS_FOLDER}/daemon.log"
+    echo "----------------------------------------- " >> "${LOGS_FOLDER}/daemon.log"
+    sudo journalctl -b -u snap.nordvpn.nordvpnd.service >> "${LOGS_FOLDER}/daemon.log"
+}
+
+trap add_daemon_logs EXIT INT TERM
+
 "${WORKDIR}/ci/qa_run_tests.sh" "$@"
 
 # restore to original value

--- a/magefiles/vagrant.go
+++ b/magefiles/vagrant.go
@@ -49,14 +49,22 @@ type VagrantEnv struct {
 	ShouldDestroyVM bool   // when true, the VM created will be destroyed after tests are executed
 	RemoteCwd       string // where was the project synced in VM, by default /vagrant
 	TestCredentials secret // testing credentials, env[NA_TESTS_CREDENTIALS]
+	CustomBoxUrl    string // the URL for a box when testing with custom build boxes
+	CustomBoxUser   secret // custom box username
+	CustomBoxPass   secret // custom box password
 }
 
 // runVagrantCmd - run vagrant commands
 func runVagrantCmd(vagrantEnv VagrantEnv, args ...string) error {
 	cmd := exec.Command("vagrant", args...)
 	cmd.Dir = vagrantEnv.VagrantFileDir
+
+	// add all the needed environment variables to run vagrant commands
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("WORKDIR=%s", vagrantEnv.Cwd),
+		fmt.Sprintf("SNAP_TEST_BOX_URL=%s", vagrantEnv.CustomBoxUrl),
+		fmt.Sprintf("SNAP_TEST_BOX_USER=%s", vagrantEnv.CustomBoxUser.getValue()),
+		fmt.Sprintf("SNAP_TEST_BOX_PASS=%s", vagrantEnv.CustomBoxPass.getValue()),
 	)
 
 	stdout, err := cmd.StdoutPipe()
@@ -79,16 +87,23 @@ func runVagrantCmd(vagrantEnv VagrantEnv, args ...string) error {
 	return cmd.Wait()
 }
 
-func streamLines(r io.Reader, out io.Writer) {
-	sc := bufio.NewScanner(r)
-	for sc.Scan() {
-		fmt.Fprintln(out, sc.Text())
+func streamLines(reader io.Reader, out io.Writer) {
+	r := bufio.NewReader(reader)
+	for {
+		line, err := r.ReadString('\n')
+		if err == io.EOF {
+			// print last line if it didn't end with '\n'
+			if len(line) > 0 {
+				fmt.Print(line)
+			}
+			break
+		}
+		if err != nil {
+			fmt.Println("streamLines error:", err)
+			break
+		}
+		fmt.Print(line)
 	}
-
-	if err := sc.Err(); err != nil {
-		fmt.Printf("Scanner error: %s", err)
-	}
-
 }
 
 // runCommandInVM - runs a command using vagrant ssh inside the VM
@@ -165,6 +180,9 @@ func buildVagrantEnv() (VagrantEnv, error) {
 		ShouldDestroyVM: shouldDestroyVM,
 		RemoteCwd:       "/vagrant",
 		TestCredentials: newSecret(env["NA_TESTS_CREDENTIALS"]),
+		CustomBoxUrl:    env["SNAP_TEST_BOX_URL"],
+		CustomBoxUser:   newSecret(env["SNAP_TEST_BOX_USER"]),
+		CustomBoxPass:   newSecret(env["SNAP_TEST_BOX_PASS"]),
 	}
 	return vagrantEnv, nil
 }

--- a/test/qa/lib/daemon.py
+++ b/test/qa/lib/daemon.py
@@ -150,7 +150,9 @@ def wait_for_autoconnect():
 def is_running():
     try:
         sh.nordvpn.status()
-    except sh.ErrorReturnCode_1:
+    except sh.ErrorReturnCode_1 as ex:
+        # if user is not part of the nordvpn group assert
+        assert "Permission needed" not in ex.stdout.decode()
         return False
     else:
         return True


### PR DESCRIPTION
* After the tests are executed save the daemon log into daemon.log
* Add support to use a custom vagrant box for running the tests
* Replace for libvirt sync to nfs to bring the daemon.log to the host
* When running the tests add the current user into the nordvpn group