### PR TITLE
LVPN-9096: Create symlink for sqlite in posttrans script

### DIFF
--- a/contrib/scriptlets/rpm/post
+++ b/contrib/scriptlets/rpm/post
@@ -27,13 +27,6 @@ helpMessage="If you need help using the app, use the command 'nordvpn --help'."
 # update configuration and shared library cache for linker to find .so files
 echo "/usr/lib/nordvpn" > /etc/ld.so.conf.d/nordvpn.conf
 
-# NOTE: We found some really strange behavior with `ldconfig` cache refresh here.
-# On .deb systems, using just `ldconfig` causes the nordvpnd daemon to fail on
-# the first start with error that .so are missing. On restart, it's working again.
-# Adding ANY flag to `ldconfig` (even the one we added on our own which does
-# literally nothing) fixes the issue.
-ldconfig
-
 groupadd --system "$NORDVPN_GROUP" 1>/dev/null 2> /dev/null
 groupCreated=$?
 

--- a/contrib/scriptlets/rpm/posttrans
+++ b/contrib/scriptlets/rpm/posttrans
@@ -10,6 +10,11 @@ ENV=$(ps --no-headers -o comm 1)
 export XDG_RUNTIME_DIR="/run/user/${DEFAULT_USER_ID}"
 export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
 
+# NOTE: We found some really strange behavior with `ldconfig` cache refresh here.
+# On .deb systems, using just `ldconfig` causes the nordvpnd daemon to fail on
+# the first start with error that .so are missing. On restart, it's working again.
+# Adding ANY flag to `ldconfig` (even the one we added on our own which does
+# literally nothing) fixes the issue.
 ldconfig
 
 # move the symlink file creation later, otherwise the update scripts will delete it


### PR DESCRIPTION
For RPM packets are 2 different scripts that are executed at package install/update: `postinstall` and `posttrans`. 
They are executed in different times while installing. The `posttrans` is executed the latest, after the update/install process takes place.  `postinstall` is executed before new package replaces the files of the old one with its own.
Since sqlite symlink is not part of the new package the file is deleted after `postinstall` is executed. Creating it into `posttrans` ensures that the file is not deleted.