### PR TITLE
Fix the url of deb package with apt sources used in nordvpn Dockerfile

### DIFF
--- a/ci/docker/nordvpn/Dockerfile
+++ b/ci/docker/nordvpn/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ARG version
 RUN apt-get update && \
     apt-get install -y wget iputils-ping curl && \
-    wget -O /tmp/nordrepo.deb https://repo.nordvpn.com/deb/nordvpn/debian/pool/main/nordvpn-release_1.0.0_all.deb && \
+    wget -O /tmp/nordrepo.deb https://repo.nordvpn.com/deb/nordvpn/debian/pool/main/n/nordvpn-release/nordvpn-release_1.0.0_all.deb && \
     apt-get install -y /tmp/nordrepo.deb && \
     apt-get update && \
     apt-get install -y nordvpn=$version && \


### PR DESCRIPTION
Changes:
- change URL for deb package containing apt sources in `nordvpn` Dockerfile - current URL is wrong

This package is installed to update apt sources so next commands can install `nordvpn` with specified version.