### PR TITLE
LVPN-9097: Fix tests failing due to the new version available message

### DIFF
--- a/test/qa/lib/__init__.py
+++ b/test/qa/lib/__init__.py
@@ -307,7 +307,7 @@ def flush_allowlist():
 def is_connect_successful(output: str, name: str = "", hostname: str = ""):
     if not name and not hostname:
         pattern = r'Connecting to (.*?) \((.*?)\)'
-        match = re.match(pattern, str(output))
+        match = re.search(pattern, str(output))
 
         if match:
             name = match.group(1)


### PR DESCRIPTION
This replaces re.match with re.search when checking the connect command output.
* re.match will try to match starting from the beginning of the stdout. 
* re.search will try to find the first match in the entire stdout.

In this way, the test will no longer be affected by additional messages like the one informing the user about a new version available.