### PR TITLE
LVPN-9021: Nightly pipelines should run all the tests

### DIFF
--- a/test/qa/conftest.py
+++ b/test/qa/conftest.py
@@ -28,6 +28,24 @@ _CHECK_FREQUENCY=5
 sys.path.append(os.path.abspath(os.path.join(
     os.path.dirname(__file__), 'lib/protobuf/daemon')))
 
+def pytest_configure(config):
+    """
+    Pytest hook to dynamically adjust test run options based on pipeline schedule.
+
+    If the CI_PIPELINE_SCHEDULE_DESCRIPTION environment variable is set to "Nightly":
+      - Sets "maxfail" to 0 (disables the maximum failure limit, allowing all tests to run)
+      - Sets "exitfirst" to False (prevents exiting after the first test failure)
+
+    This ensures that on nightly scheduled CI runs, the test suite evaluates all test cases,
+    rather than stopping early due to failures.
+
+    :param config: The pytest config object, which holds command-line options and internal state.
+    """
+    desc = os.getenv("CI_PIPELINE_SCHEDULE_DESCRIPTION")
+    if desc and desc.lower().strip() == "nightly":
+        config.option.maxfail=0
+        config.option.exitfirst=False
+
 def print_to_string(*args, **kwargs):
     output = io.StringIO()
     _original_print(*args, file=output, **kwargs)


### PR DESCRIPTION
Added pytest hook to prevent exiting after the first test failure.