### PR TITLE
LVPN-8125: Accomodate remote config python tests to work with local c…

### DIFF
--- a/test/qa/conftest.py
+++ b/test/qa/conftest.py
@@ -20,6 +20,7 @@ from lib import logging, network, daemon, login, info, firewall
 from lib.remote_config_manager import RemoteConfigManager, LOCAL_CACHE_DIR, REMOTE_DIR
 from lib.logging import FILE
 from lib.log_reader import LogReader
+from lib.daemon import enable_rc_local_config_usage
 
 pytest_plugins = ("lib.pytest_timeouts.pytest_timeouts")
 
@@ -35,16 +36,24 @@ def pytest_configure(config):
     If the CI_PIPELINE_SCHEDULE_DESCRIPTION environment variable is set to "Nightly":
       - Sets "maxfail" to 0 (disables the maximum failure limit, allowing all tests to run)
       - Sets "exitfirst" to False (prevents exiting after the first test failure)
-
     This ensures that on nightly scheduled CI runs, the test suite evaluates all test cases,
     rather than stopping early due to failures.
 
+    If the USE_LOCAL_CONFIG environment variable is set:
+      - Calls the enable_rc_local_config_usage() function
+    This enables usage of only local remote config files in tests.
+
     :param config: The pytest config object, which holds command-line options and internal state.
     """
-    desc = os.getenv("CI_PIPELINE_SCHEDULE_DESCRIPTION")
-    if desc and desc.lower().strip() == "nightly":
+    is_nightly = os.getenv("CI_PIPELINE_SCHEDULE_DESCRIPTION")
+    if is_nightly and is_nightly.lower().strip() == "nightly":
         config.option.maxfail=0
         config.option.exitfirst=False
+
+    is_local_rc_usage = os.getenv("USE_LOCAL_CONFIG")
+    if is_local_rc_usage:
+        enable_rc_local_config_usage()
+
 
 def print_to_string(*args, **kwargs):
     output = io.StringIO()

--- a/test/qa/lib/daemon.py
+++ b/test/qa/lib/daemon.py
@@ -205,3 +205,38 @@ def get_env() ->str:
     if Env.DEV in result:
         return Env.DEV
     return Env.PROD
+
+def enable_rc_local_config_usage():
+    """
+    Modifies the nordvpn service file to enable usage of local remote config.
+
+    This function is typically used to force the application to use locally cached remote config files.
+    """
+    service_path = "/etc/init.d/nordvpn"
+
+    # Print original service file for reference
+    print(f"Service original:\n {sh.cat(service_path)}")
+
+    # Insert environment variable into systemd service file
+    sh.sudo("sed", "-i", r"1a export RC_USE_LOCAL_CONFIG=1", service_path)
+
+    sh.sudo.systemctl("daemon-reload", _ok_code=(0, 1))
+
+    # Print service file after modification
+    print(f"Service after:\n {sh.cat(service_path)}")
+
+def disable_rc_local_config_usage():
+    """
+    Restores the original nordvpn service file by removing the forced local config env variable.
+
+    This function is typically used to clean up the service file after testing,
+    ensuring that the local remote config behavior is disabled.
+    """
+    service_path = "/etc/init.d/nordvpn"
+    # Cleanup: remove the injected environment variable line
+    sh.sudo("sed", "-i", r"/^export RC_USE_LOCAL_CONFIG=1$/d", service_path)
+
+    sh.sudo.systemctl("daemon-reload", _ok_code=(0, 1))
+
+    # Print restored service file for verification
+    print(f"Service restored:\n {sh.cat(service_path)}")

--- a/test/qa/test_remote_config.py
+++ b/test/qa/test_remote_config.py
@@ -3,11 +3,11 @@ import subprocess
 import uuid
 
 import pytest
-import sh
 
 from lib import daemon
 from lib.log_reader import LogReader
 from lib.remote_config_manager import LOCAL_CACHE_DIR
+from lib.daemon import enable_rc_local_config_usage, disable_rc_local_config_usage
 
 RC_REMOTE_MESSAGES = [
     f"[Info] feature [meshnet] remote config downloaded to: {LOCAL_CACHE_DIR}",
@@ -57,28 +57,11 @@ def enable_local_config_in_service():
     This fixture injects 'export RC_USE_LOCAL_CONFIG=1' into the 'nordvpn' service file, simulating enabling the local config usage for tests.
     After the test, it removes the injected line and reloads the systemd daemon to restore the initial system state.
     """
-    service_path = "/etc/init.d/nordvpn"
-
-    # Print original service file for reference
-    print(f"Service original:\n {sh.cat(service_path)}")
-
-    # Insert environment variable into systemd service file
-    sh.sudo("sed", "-i", r"1a export RC_USE_LOCAL_CONFIG=1", service_path)
-
-    sh.sudo.systemctl("daemon-reload", _ok_code=(0, 1))
-
-    # Print service file after modification
-    print(f"Service after:\n {sh.cat(service_path)}")
+    enable_rc_local_config_usage()
 
     yield
 
-    # Cleanup: remove the injected environment variable line
-    sh.sudo("sed", "-i", r"/^export RC_USE_LOCAL_CONFIG=1$/d", service_path)
-
-    sh.sudo.systemctl("daemon-reload", _ok_code=(0, 1))
-
-    # Print restored service file for verification
-    print(f"Service restored:\n {sh.cat(service_path)}")
+    disable_rc_local_config_usage()
 
 
 def test_remote_config_consumed_and_logged(initialized_app_with_remote_config) -> None:


### PR DESCRIPTION
- Modified 'pytest_configure' to use env var for enabling only local usage of config files