### PR TITLE
LVPN-8530: Mark Meshnet/Fileshare tests as 'allow to fail' v2

### DIFF
--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -203,7 +203,6 @@ def test_accept(accept_directories):
     assert sender_files_status_ok is True, f"invalid file status on sender side, transfer {transfer}, files {accept_directories} should be uploaded"
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("path_flag", [True, False], ids=["accept_custom_path", "accept_downloads"])
 @pytest.mark.parametrize("background_accept", ["", "--background"], ids=["accept_int", "accept_bg"])
 @pytest.mark.parametrize("background_send", [True, False], ids=["send_bg", "send_int"])
@@ -550,7 +549,6 @@ def test_fileshare_transfer_multiple_files_selective_accept(background: bool, ac
     ssh_client.exec_command(f"sudo rm -rf {peer_filepath}/*tmp*")
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("transfer_entity", list(fileshare.FileSystemEntity), ids = [f"send_{entity.value}" for entity in list(fileshare.FileSystemEntity)])
 def test_fileshare_graceful_cancel(transfer_entity: fileshare.FileSystemEntity):
     wdir = fileshare.create_directory(0)
@@ -722,7 +720,6 @@ def test_fileshare_graceful_cancel_transfer_ongoing(sender_cancels: bool, transf
     shutil.rmtree(wdir.dir_path)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("background", [False, True], ids=["send_int", "send_bg"])
 @pytest.mark.parametrize("sender_cancels", [False, True], ids=["receiver_cancels", "sender_cancels"])
 @pytest.mark.parametrize("transfer_entity", list(fileshare.FileSystemEntity), ids = [f"send_{entity.value}" for entity in list(fileshare.FileSystemEntity)])
@@ -1192,7 +1189,6 @@ def test_accept_destination_directory_not_a_directory():
     sh.rm(path)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("transfer_entity", list(fileshare.FileSystemEntity), ids = [f"send_{entity.value}" for entity in list(fileshare.FileSystemEntity)])
 def test_autoaccept(transfer_entity: fileshare.FileSystemEntity):
     peer_list = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list())
@@ -1464,7 +1460,6 @@ def test_fileshare_process_monitoring_cuts_the_port_access_even_when_it_was_take
         fileshare.ensure_mesh_is_on()
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("background_accept", [True, False], ids=["accept_bg", "accept_int"])
 @pytest.mark.parametrize("background_send", [True, False], ids=["send_bg", "send_int"])
 def test_all_permissions_denied_send_file(background_send: bool, background_accept: bool):

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1460,6 +1460,7 @@ def test_fileshare_process_monitoring_cuts_the_port_access_even_when_it_was_take
         fileshare.ensure_mesh_is_on()
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("background_accept", [True, False], ids=["accept_bg", "accept_int"])
 @pytest.mark.parametrize("background_send", [True, False], ids=["send_bg", "send_int"])
 def test_all_permissions_denied_send_file(background_send: bool, background_accept: bool):

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -31,7 +31,6 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
-@pytest.mark.xfail
 def test_meshnet_connect():
     peer = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer()
     this_device = meshnet.PeerList.from_str(ssh_client.exec_command("nordvpn mesh peer list")).get_external_peer()
@@ -178,7 +177,6 @@ def test_set_meshnet_off_when_logged_out(meshnet_allias):
     assert "You are not logged in." in str(ex.value)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("meshnet_allias", meshnet.MESHNET_ALIAS)
 def test_set_meshnet_off_on(meshnet_allias):
 
@@ -239,7 +237,6 @@ def test_permission_messages_error(permission, permission_state, expected_messag
     assert expected_message in str(ex)
 
 
-@pytest.mark.xfail
 def test_derp_server_selection_logic():
     def has_duplicates(lst):
         return len(lst) != len(set(lst))
@@ -275,7 +272,7 @@ def test_derp_server_selection_logic():
     ssh_client.exec_command("sudo iptables -D OUTPUT -p tcp -m tcp --dport 8765 -j DROP")
 
 
-@pytest.mark.skip("LVPN-3428, need a discussion here") # @pytest.mark.xfail
+@pytest.mark.skip("LVPN-3428, need a discussion here")
 def test_direct_connection_rtt_and_loss():
     def get_loss(ping_output: str) -> float:
         """Pass `ping_output`, and get loss returned."""
@@ -312,7 +309,6 @@ def test_direct_connection_rtt_and_loss():
         base_test(log_content, qapeer_hostname)
 
 
-@pytest.mark.xfail
 def test_incoming_connections():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname

--- a/test/qa/test_meshnet_invite.py
+++ b/test/qa/test_meshnet_invite.py
@@ -22,7 +22,6 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
-@pytest.mark.xfail
 def test_invite_send():
 
     assert "Meshnet invitation to 'test@test.com' was sent." in meshnet.send_meshnet_invite("test@test.com")
@@ -72,7 +71,6 @@ def test_invite_send_email_special_character():
     assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in str(ex.value)
 
 
-@pytest.mark.xfail
 def test_invite_revoke():
 
     meshnet.send_meshnet_invite("test@test.com")
@@ -115,7 +113,6 @@ def test_invite_revoke_non_existent_special_character():
     assert "No invitation from '\u2222@test.com' was found." in str(ex.value)
 
 
-@pytest.mark.xfail
 def test_invite_deny():
 
     meshnet.remove_all_peers()
@@ -153,7 +150,6 @@ def test_invite_deny_non_existent_special_character():
     assert "No invitation from '\u2222@test.com' was found." in str(ex.value)
 
 
-@pytest.mark.xfail
 def test_invite_accept():
 
     meshnet.remove_all_peers()

--- a/test/qa/test_meshnet_other.py
+++ b/test/qa/test_meshnet_other.py
@@ -39,6 +39,7 @@ def test_allowlist_incoming_connection():
     ssh_client.exec_command("nordvpn set killswitch off")
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 # This doesn't directly test meshnet, but it uses it
 def test_set_defaults_when_logged_in_2nd_set(tech, proto, obfuscated):

--- a/test/qa/test_meshnet_peer_list.py
+++ b/test/qa/test_meshnet_peer_list.py
@@ -41,6 +41,8 @@ def base_test_peer_list(filter_list: list[str] | None = None) -> None:
 
     local_peer_list = meshnet.get_clean_peer_list(sh_no_tty.nordvpn.mesh.peer.list())
     local_formed_list = meshnet.PeerList.from_str(local_peer_list).parse_peer_list(filter_list)
+    local_formed_list.append("Meshnet is leaving NordVPN on December 1. Learn more: https://nordvpn.com/blog/meshnet-shutdown")
+
 
     if len(filter_list) != 0:
         local_peer_list_filtered = meshnet.get_clean_peer_list(str(sh_no_tty.nordvpn.mesh.peer.list("-f", ",".join(filter_list)))).split("\n")

--- a/test/qa/test_meshnet_peer_list.py
+++ b/test/qa/test_meshnet_peer_list.py
@@ -78,7 +78,6 @@ def test_meshnet_peer_list_permission_filters(allows_incoming_traffic, allows_ro
     base_test_peer_list(filter_list)
 
 
-@pytest.mark.xfail
 def test_meshnet_peer_list_peer_connected():
     def is_peer_connected():
         local_peer_list = sh_no_tty.nordvpn.mesh.peer.list(_tty_out=False)

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -133,7 +133,6 @@ def test_route_to_nonexistant_node():
     assert expected_message in str(ex)
 
 
-@pytest.mark.xfail
 def test_route_to_peer_status_valid():
     peer_hostname = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
 

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -27,6 +27,7 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("lan_discovery", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 def test_killswitch_exitnode(lan_discovery: bool, local: bool):
@@ -88,6 +89,7 @@ def test_killswitch_exitnode(lan_discovery: bool, local: bool):
     assert network.is_available()
 
 
+@pytest.mark.xfail
 def test_route_traffic_to_each_other():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     peer_hostname = peer_list.get_external_peer().hostname
@@ -107,6 +109,7 @@ def test_route_traffic_to_each_other():
     ssh_client.exec_command("nordvpn disconnect")
 
 
+@pytest.mark.xfail
 def test_routing_deny_for_peer_is_peer_no_netting():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     peer_hostname = peer_list.get_external_peer().hostname
@@ -133,6 +136,7 @@ def test_route_to_nonexistant_node():
     assert expected_message in str(ex)
 
 
+@pytest.mark.xfail
 def test_route_to_peer_status_valid():
     peer_hostname = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
 

--- a/test/qa/test_meshnet_vpn.py
+++ b/test/qa/test_meshnet_vpn.py
@@ -25,6 +25,7 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("lan_discovery", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 def test_lan_discovery_exitnode(lan_discovery: bool, local: bool):
@@ -65,6 +66,7 @@ def test_lan_discovery_exitnode(lan_discovery: bool, local: bool):
         assert result, message
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("lan_discovery", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 def test_killswitch_exitnode_vpn(lan_discovery: bool, local: bool):
@@ -210,6 +212,7 @@ def test_route_to_peer_that_is_connected_to_vpn():
     lib.is_disconnect_successful(sh_no_tty.nordvpn.disconnect())
 
 
+@pytest.mark.xfail
 def test_route_to_peer_that_disconnects_from_vpn():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname
@@ -243,6 +246,7 @@ def test_route_to_peer_that_disconnects_from_vpn():
     lib.is_disconnect_successful(ssh_client.exec_command("nordvpn disconnect"))
 
 
+@pytest.mark.xfail
 def test_route_traffic_to_peer_once_again_when_already_routing():
     peer_hostname = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
 

--- a/test/qa/test_meshnet_vpn.py
+++ b/test/qa/test_meshnet_vpn.py
@@ -182,7 +182,6 @@ def test_set_defaults_when_connected_2nd_set(tech, proto, obfuscated):
     assert settings.app_has_defaults_settings()
 
 
-@pytest.mark.xfail
 def test_route_to_peer_that_is_connected_to_vpn():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname

--- a/test/qa/test_update.py
+++ b/test/qa/test_update.py
@@ -81,7 +81,6 @@ def teardown_function(function):  # noqa: ARG001
     assert network.is_disconnected()
 
 
-@pytest.mark.xfail
 def test_meshnet_available_after_update():
     """Manual TC: LVPN-3204"""
 
@@ -106,7 +105,6 @@ def test_meshnet_available_after_update():
     assert network.is_available()
 
 
-@pytest.mark.xfail
 def test_fileshare_available_after_update():
     """Manual TC: LVPN-3205"""
 


### PR DESCRIPTION
Wrong tests were marked with xfail decorator in v1 commit, that is merged into main now.