### PR TITLE
LVPN-8930: Do not convert error messages to string

### DIFF
--- a/test/qa/test_allowlist_port.py
+++ b/test/qa/test_allowlist_port.py
@@ -86,13 +86,13 @@ def test_allowlist_port_twice_disconnected(tech, proto, obfuscated, port):
             sh.nordvpn(allowlist.get_alias(), "add", "port", port.value, "protocol", port.protocol)
 
     expected_message = allowlist.MSG_ALLOWLIST_PORT_ADD_ERROR % (port.value, port.protocol)
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
     assert str(sh.nordvpn.settings()).count(port.value) == 1
     assert not firewall.is_active([port])
 
 
-@dynamic_parametrize(["tech", "proto", "obfuscated", "port"], randomized_source=lib.TECHNOLOGIES, ordered_source=lib.PORTS,
-                     id_pattern="{ordered.protocol}-{ordered.value}-{randomized[0]}-{randomized[1]}-{randomized[2]}", always_pair=lib.TECHNOLOGIES_BASIC1[0])
+@dynamic_parametrize(["tech", "proto", "obfuscated", "port"], randomized_source=lib.TECHNOLOGIES_BASIC2, ordered_source=lib.PORTS,
+                     id_pattern="{ordered.protocol}-{ordered.value}-{randomized[0]}-{randomized[1]}-{randomized[2]}")
 def test_allowlist_port_twice_connected(tech, proto, obfuscated, port):
     """Manual TC: LVPN-8958"""
 
@@ -109,7 +109,7 @@ def test_allowlist_port_twice_connected(tech, proto, obfuscated, port):
             sh.nordvpn(allowlist.get_alias(), "add", "port", port.value, "protocol", port.protocol)
 
     expected_message = allowlist.MSG_ALLOWLIST_PORT_ADD_ERROR % (port.value, port.protocol)
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
     assert str(sh.nordvpn.settings()).count(port.value) == 1
     assert firewall.is_active([port])
 
@@ -161,7 +161,7 @@ def test_allowlist_port_remove_nonexistent_disconnected(tech, proto, obfuscated,
             sh.nordvpn(allowlist.get_alias(), "remove", "port", port.value, "protocol", port.protocol)
 
     expected_message = allowlist.MSG_ALLOWLIST_PORT_REMOVE_ERROR % (port.value, port.protocol)
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 @dynamic_parametrize(["tech", "proto", "obfuscated", "port"], randomized_source=lib.TECHNOLOGIES, ordered_source=lib.PORTS,
                      id_pattern="{ordered.protocol}-{ordered.value}-{randomized[0]}-{randomized[1]}-{randomized[2]}", always_pair=lib.TECHNOLOGIES_BASIC1[0])
@@ -179,7 +179,7 @@ def test_allowlist_port_remove_nonexistent_connected(tech, proto, obfuscated, po
             sh.nordvpn(allowlist.get_alias(), "remove", "port", port.value, "protocol", port.protocol)
 
     expected_message = allowlist.MSG_ALLOWLIST_PORT_REMOVE_ERROR % (port.value, port.protocol)
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 
 @dynamic_parametrize(["tech", "proto", "obfuscated", "port"], randomized_source=lib.TECHNOLOGIES, ordered_source=lib.PORTS_RANGE,
@@ -198,7 +198,7 @@ def test_allowlist_port_range_remove_nonexistent_disconnected(tech, proto, obfus
             sh.nordvpn(allowlist.get_alias(), "remove", "ports", port_range[0], port_range[1], "protocol", port.protocol)
 
     expected_message = allowlist.MSG_ALLOWLIST_PORT_RANGE_REMOVE_ERROR % (port.value.replace(":", " - "), port.protocol)
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 
 @dynamic_parametrize(["tech", "proto", "obfuscated", "port"], randomized_source=lib.TECHNOLOGIES, ordered_source=lib.PORTS_RANGE,
@@ -219,7 +219,7 @@ def test_allowlist_port_range_remove_nonexistent_connected(tech, proto, obfuscat
             sh.nordvpn(allowlist.get_alias(), "remove", "ports", port_range[0], port_range[1], "protocol", port.protocol)
 
     expected_message = allowlist.MSG_ALLOWLIST_PORT_RANGE_REMOVE_ERROR % (port.value.replace(":", " - "), port.protocol)
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 @dynamic_parametrize(["tech", "proto", "obfuscated", "port"], randomized_source=lib.TECHNOLOGIES, ordered_source=lib.PORTS_RANGE,
                      id_pattern="{ordered.protocol}-{ordered.value}-{randomized[0]}-{randomized[1]}-{randomized[2]}", always_pair=lib.TECHNOLOGIES_BASIC1[0])

--- a/test/qa/test_allowlist_subnet.py
+++ b/test/qa/test_allowlist_subnet.py
@@ -92,7 +92,7 @@ def test_allowlist_subnet_twice_disconnected(tech, proto, obfuscated, subnet):
         sh.nordvpn(allowlist.get_alias(), "add", "subnet", subnet)
 
     expected_message = allowlist.MSG_ALLOWLIST_SUBNET_ADD_ERROR % subnet
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
     assert str(sh.nordvpn.settings()).count(subnet) == 1
     assert not firewall.is_active(None, [subnet])
 
@@ -112,7 +112,7 @@ def test_allowlist_subnet_twice_connected(tech, proto, obfuscated, subnet):
         sh.nordvpn(allowlist.get_alias(), "add", "subnet", subnet)
 
     expected_message = allowlist.MSG_ALLOWLIST_SUBNET_ADD_ERROR % subnet
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
     assert str(sh.nordvpn.settings()).count(subnet) == 1
     assert firewall.is_active(None, [subnet])
 
@@ -170,7 +170,7 @@ def test_allowlist_subnet_remove_nonexistent_disconnected(tech, proto, obfuscate
         sh.nordvpn(allowlist.get_alias(), "remove", "subnet", subnet)
 
     expected_message = allowlist.MSG_ALLOWLIST_SUBNET_REMOVE_ERROR % subnet
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
@@ -186,4 +186,4 @@ def test_allowlist_subnet_remove_nonexistent_connected(tech, proto, obfuscated, 
         sh.nordvpn(allowlist.get_alias(), "remove", "subnet", subnet)
 
     expected_message = allowlist.MSG_ALLOWLIST_SUBNET_REMOVE_ERROR % subnet
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")

--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -192,7 +192,7 @@ def test_prevent_autoconnect_enable_to_non_obfuscated_servers_when_obfuscation_i
             sh.nordvpn.set.autoconnect.on(server_name)
         print(ex.value)
         error_message = "Your selected server doesn’t support obfuscation. Choose a different server or turn off obfuscation."
-        assert error_message in str(ex.value)
+        assert error_message in ex.value.stdout.decode("utf-8")
         assert "Auto-connect: disabled" in sh.nordvpn.settings()
         daemon.restart()
         assert network.is_disconnected()
@@ -215,7 +215,7 @@ def test_prevent_obfuscate_disable_with_autoconnect_enabled_to_obfuscated_server
         print(ex.value)
         error_message = "We couldn’t turn off obfuscation because your current auto-connect server is obfuscated by default. " \
             + "Set a different server for auto-connect, then turn off obfuscation."
-        assert error_message in str(ex.value)
+        assert error_message in ex.value.stdout.decode("utf-8")
         assert "Obfuscate: enabled" in sh.nordvpn.settings()
 
 
@@ -230,7 +230,7 @@ def test_prevent_autoconnect_enable_to_obfuscated_servers_when_obfuscation_is_of
         sh.nordvpn.set.autoconnect.on(server_name)
     print(ex.value)
     error_message = "Turn on obfuscation to connect to obfuscated servers."
-    assert error_message in str(ex.value)
+    assert error_message in ex.value.stdout.decode("utf-8")
     assert "Auto-connect: disabled" in sh.nordvpn.settings()
 
     daemon.restart()
@@ -258,5 +258,5 @@ def test_prevent_obfuscate_enable_with_autoconnect_set_to_nonobfuscated(tech, pr
         print(ex.value)
         error_message = "We couldn’t turn on obfuscation because the current auto-connect server doesn’t support it. " \
             + "Set a different server for auto-connect to use obfuscation."
-        assert error_message in str(ex.value)
+        assert error_message in ex.value.stdout.decode("utf-8")
         assert "Obfuscate: disabled" in sh.nordvpn.settings()

--- a/test/qa/test_dns.py
+++ b/test/qa/test_dns.py
@@ -226,7 +226,7 @@ def test_custom_dns_errors_disconnected(tech, proto, obfuscated, nameserver, exp
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set.dns(nameserver)
 
-    assert expected_error in str(ex)
+    assert expected_error in ex.value.stdout.decode("utf-8")
     assert settings.dns_visible_in_settings(["disabled"])
     assert dns.is_unset()
 
@@ -244,7 +244,7 @@ def test_custom_dns_errors_connected(tech, proto, obfuscated, nameserver, expect
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh.nordvpn.set.dns(nameserver)
 
-        assert expected_error in str(ex)
+        assert expected_error in ex.value.stdout.decode("utf-8")
         assert settings.dns_visible_in_settings(["disabled"])
         assert dns.is_set_for(dns.DNS_NORD)
 
@@ -267,7 +267,7 @@ def test_custom_dns_already_set_disconnected(tech, proto, obfuscated, nameserver
 
     full_error_message = dns.DNS_MSG_ERROR_ALREADY_SET % ", ".join(nameserver)
 
-    assert full_error_message in str(ex)
+    assert full_error_message in ex.value.stdout.decode("utf-8")
     assert settings.dns_visible_in_settings(nameserver)
     assert dns.is_unset()
 
@@ -291,7 +291,7 @@ def test_custom_dns_already_set_connected(tech, proto, obfuscated, nameserver):
             sh.nordvpn.set.dns(nameserver)
 
         full_error_message = dns.DNS_MSG_ERROR_ALREADY_SET % ", ".join(nameserver)
-        assert full_error_message in str(ex)
+        assert full_error_message in ex.value.stdout.decode("utf-8")
         assert settings.dns_visible_in_settings(nameserver)
         assert dns.is_set_for(nameserver)
 
@@ -307,7 +307,7 @@ def test_custom_dns_already_disabled_disconnected(tech, proto, obfuscated):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set.dns("off")
 
-    assert dns.DNS_MSG_ERROR_ALREADY_DISABLED in str(ex)
+    assert dns.DNS_MSG_ERROR_ALREADY_DISABLED in ex.value.stdout.decode("utf-8")
     assert settings.dns_visible_in_settings(["disabled"])
     assert dns.is_unset()
 
@@ -325,7 +325,7 @@ def test_custom_dns_already_disabled_connected(tech, proto, obfuscated):
             sh.nordvpn.set.dns("off")
 
         assert settings.dns_visible_in_settings(["disabled"])
-        assert dns.DNS_MSG_ERROR_ALREADY_DISABLED in str(ex)
+        assert dns.DNS_MSG_ERROR_ALREADY_DISABLED in ex.value.stdout.decode("utf-8")
         assert dns.is_set_for(dns.DNS_NORD)
 
     assert dns.is_unset()

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -822,7 +822,7 @@ def test_fileshare_cancel_file_not_in_flight(sender_cancels: bool):
     if sender_cancels:
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh.nordvpn.fileshare.cancel(local_transfer_id, file_to_cancel)
-        assert "This file is not in progress." in str(ex.value)
+        assert "This file is not in progress." in ex.value.stdout.decode("utf-8")
         sh.nordvpn.fileshare.cancel(local_transfer_id)
     else:  # receiver cancels
         with pytest.raises(RuntimeError) as ex:
@@ -852,7 +852,7 @@ def test_fileshare_file_limit_exceeded(background: bool, multiple_directories: b
         else:
             sh.nordvpn.fileshare.send(peer_address, *dirs)
 
-    assert "Number of files in a transfer cannot exceed 1000. Try archiving the directory." in str(ex.value)
+    assert "Number of files in a transfer cannot exceed 1000. Try archiving the directory." in ex.value.stdout.decode("utf-8")
 
     for directory_path in dirs:
         shutil.rmtree(directory_path)
@@ -873,7 +873,7 @@ def test_fileshare_file_directory_depth_exceeded(background: bool):
         else:
             sh.nordvpn.fileshare.send(peer_address, src_path)
 
-    assert "File depth cannot exceed 5 directories. Try archiving the directory." in str(ex.value)
+    assert "File depth cannot exceed 5 directories. Try archiving the directory." in ex.value.stdout.decode("utf-8")
 
     shutil.rmtree(src_path)
 
@@ -1048,7 +1048,7 @@ def test_permissions_send(peer_name, background):
         else:
             sh.nordvpn.fileshare.send(peer_address, filename).stdout.decode("utf-8")
 
-    assert "This peer does not allow file transfers from you." in str(ex.value)
+    assert "This peer does not allow file transfers from you." in ex.value.stdout.decode("utf-8")
 
     # Revert to the state before test
     fileshare_allowed_message = ssh_client.exec_command(f"nordvpn mesh peer fileshare allow {tester_address}")
@@ -1130,7 +1130,7 @@ def test_accept_destination_directory_does_not_exist():
         sh.nordvpn.fileshare.accept("--background", "--path", "invalid_dir", local_transfer_id).stdout.decode("utf-8")
 
     expected_dir = os.getcwd() + "/invalid_dir"
-    assert f"Download directory \"{expected_dir}\" does not exist. Make sure the directory exists or provide an alternative via --path" in str(ex.value)
+    assert f"Download directory \"{expected_dir}\" does not exist. Make sure the directory exists or provide an alternative via --path" in ex.value.stdout.decode("utf-8")
 
     sh.nordvpn.fileshare.cancel(local_transfer_id)
 
@@ -1159,7 +1159,7 @@ def test_accept_destination_directory_symlink():
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.fileshare.accept("--background", "--path", linkpath, local_transfer_id).stdout.decode("utf-8")
-    assert "A download path can’t be a symbolic link. Please provide a directory as a download path to accept the transfer" in str(ex.value)
+    assert "A download path can’t be a symbolic link. Please provide a directory as a download path to accept the transfer" in ex.value.stdout.decode("utf-8")
 
     sh.nordvpn.fileshare.cancel(local_transfer_id)
 
@@ -1184,7 +1184,7 @@ def test_accept_destination_directory_not_a_directory():
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.fileshare.accept("--background", "--path", path, local_transfer_id).stdout.decode("utf-8")
-    assert "Please provide a directory as a download path to accept the transfer" in str(ex.value)
+    assert "Please provide a directory as a download path to accept the transfer" in ex.value.stdout.decode("utf-8")
 
 
     sh.nordvpn.fileshare.cancel(local_transfer_id)

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -103,7 +103,7 @@ def test_invalid_token_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--token", "xyz%#")
 
-    assert "We couldn't log you in - the access token is not valid. Please check if you've entered the token correctly. If the issue persists, contact our customer support." in str(ex.value)
+    assert "We couldn't log you in - the access token is not valid. Please check if you've entered the token correctly. If the issue persists, contact our customer support." in ex.value.stdout.decode("utf-8")
 
 
 def test_repeated_login():
@@ -115,7 +115,7 @@ def test_repeated_login():
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             login.login_as("default")
 
-        assert "You are already logged in." in str(ex.value)
+        assert "You are already logged in." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.skip(reason="can't get login token for expired account")
@@ -130,10 +130,8 @@ def test_expired_account_connect():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.connect()
 
-    assert "Your account has expired." in str(ex.value)
-    assert "https://join.nordvpn.com/order/?utm_medium=app&utm_source=linux" in str(
-        ex.value
-    )
+    assert "Your account has expired." in ex.value.stdout.decode("utf-8")
+    assert "https://join.nordvpn.com/order/?utm_medium=app&utm_source=linux" in ex.value.stdout.decode("utf-8")
     sh.nordvpn.logout("--persist-token")
 
 
@@ -149,7 +147,7 @@ def test_login_while_connected():
             with pytest.raises(sh.ErrorReturnCode_1) as ex:
                 login.login_as("valid")
 
-        assert "You are already logged in." in str(ex.value)
+        assert "You are already logged in." in ex.value.stdout.decode("utf-8")
 
     assert network.is_disconnected()
 
@@ -171,7 +169,7 @@ def test_repeated_logout():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.logout("--persist-token")
 
-    assert "You are not logged in." in str(ex.value)
+    assert "You are not logged in." in ex.value.stdout.decode("utf-8")
 
 
 def test_logged_out_connect():
@@ -180,7 +178,7 @@ def test_logged_out_connect():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.connect()
 
-    assert "You are not logged in." in str(ex.value)
+    assert "You are not logged in." in ex.value.stdout.decode("utf-8")
 
 
 def test_logout_disconnects():
@@ -207,7 +205,7 @@ def test_missing_token_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--token")
 
-    assert "Token parameter value is missing." in str(ex.value)
+    assert "Token parameter value is missing." in ex.value.stdout.decode("utf-8")
 
 
 def test_missing_url_callback_login():
@@ -216,7 +214,7 @@ def test_missing_url_callback_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--callback")
 
-    assert "Expected a url." in str(ex.value)
+    assert "Expected a url." in ex.value.stdout.decode("utf-8")
 
 
 def test_invalid_url_callback_login():
@@ -225,7 +223,7 @@ def test_invalid_url_callback_login():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.login("--callback", "https://www.google.com/")
 
-    assert "Expected a url with nordvpn scheme." in str(ex.value)
+    assert "Expected a url with nordvpn scheme." in ex.value.stdout.decode("utf-8")
 
 
 def test_repeated_login_callback():
@@ -237,7 +235,7 @@ def test_repeated_login_callback():
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh.nordvpn.login("--callback")
 
-        assert "You are already logged in." in str(ex.value)
+        assert "You are already logged in." in ex.value.stdout.decode("utf-8")
 
 
 def test_repeated_login_callback_invalid_url():
@@ -249,7 +247,7 @@ def test_repeated_login_callback_invalid_url():
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh.nordvpn.login("--callback", "https://www.google.com/")
 
-        assert "You are already logged in." in str(ex.value)
+        assert "You are already logged in." in ex.value.stdout.decode("utf-8")
 
 
 def test_repeated_login_callback_nordvpn_scheme_url():
@@ -261,4 +259,4 @@ def test_repeated_login_callback_nordvpn_scheme_url():
         with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh.nordvpn.login("--callback", "nordvpn://")
 
-        assert "You are already logged in." in str(ex.value)
+        assert "You are already logged in." in ex.value.stdout.decode("utf-8")

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -162,7 +162,7 @@ def test_set_meshnet_on_when_logged_out(meshnet_allias):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh_no_tty.nordvpn.set(meshnet_allias, "on")
 
-    assert "You are not logged in." in str(ex.value)
+    assert "You are not logged in." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.skip(reason="LVPN-4590")
@@ -175,7 +175,7 @@ def test_set_meshnet_off_when_logged_out(meshnet_allias):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh_no_tty.nordvpn.set(meshnet_allias, "off")
 
-    assert "You are not logged in." in str(ex.value)
+    assert "You are not logged in." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.xfail
@@ -195,7 +195,7 @@ def test_set_meshnet_on_repeated(meshnet_allias):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh_no_tty.nordvpn.set(meshnet_allias, "on")
 
-    assert "Meshnet is already enabled." in str(ex.value)
+    assert "Meshnet is already enabled." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize("meshnet_allias", meshnet.MESHNET_ALIAS)
@@ -206,7 +206,7 @@ def test_set_meshnet_off_repeated(meshnet_allias):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
             sh_no_tty.nordvpn.set(meshnet_allias, "off")
 
-    assert "Meshnet is already disabled." in str(ex.value)
+    assert "Meshnet is already disabled." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize(("permission", "permission_state", "expected_message"), meshnet.PERMISSION_SUCCESS_MESSAGE_PARAMETER_SET, \
@@ -236,7 +236,7 @@ def test_permission_messages_error(permission, permission_state, expected_messag
 
     expected_message = expected_message % peer_hostname
 
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.xfail

--- a/test/qa/test_meshnet_invite.py
+++ b/test/qa/test_meshnet_invite.py
@@ -36,21 +36,21 @@ def test_invite_send_repeated():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite("test@test.com")
 
-    assert "Meshnet invitation for 'test@test.com' already exists." in str(ex.value)
+    assert "Meshnet invitation for 'test@test.com' already exists." in ex.value.stderr.decode("utf-8")
 
 
 def test_invite_send_own_email():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite(login.get_credentials("default").email)
 
-    assert "Email should belong to a different user." in str(ex.value)
+    assert "Email should belong to a different user." in ex.value.stderr.decode("utf-8")
 
 
 def test_invite_send_not_an_email():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite("test")
 
-    assert "Invalid email 'test'." in str(ex.value)
+    assert "Invalid email 'test'." in ex.value.stderr.decode("utf-8")
 
 
 @pytest.mark.skip(reason="A different error message is expected - LVPN-262")
@@ -61,7 +61,7 @@ def test_invite_send_long_email():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite(email)
 
-    assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in str(ex.value)
+    assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.skip(reason="A different error message is expected - LVPN-262")
@@ -69,7 +69,7 @@ def test_invite_send_email_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite("\u2222@test.com")
 
-    assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in str(ex.value)
+    assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.xfail
@@ -89,14 +89,14 @@ def test_invite_revoke_repeated():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.revoke("test@test.com")
 
-    assert "No invitation from 'test@test.com' was found." in str(ex.value)
+    assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
 def test_invite_revoke_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.revoke("test@test.com")
 
-    assert "No invitation from 'test@test.com' was found." in str(ex.value)
+    assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
 def test_invite_revoke_non_existent_long_email():
@@ -105,14 +105,14 @@ def test_invite_revoke_non_existent_long_email():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.revoke(email)
 
-    assert f"No invitation from '{email}' was found." in str(ex.value)
+    assert f"No invitation from '{email}' was found." in ex.value.stdout.decode("utf-8")
 
 
 def test_invite_revoke_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.revoke("\u2222@test.com")
 
-    assert "No invitation from '\u2222@test.com' was found." in str(ex.value)
+    assert "No invitation from '\u2222@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.xfail
@@ -134,7 +134,7 @@ def test_invite_deny_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.deny("test@test.com")
 
-    assert "No invitation from 'test@test.com' was found." in str(ex.value)
+    assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
 def test_invite_deny_non_existent_long_email():
@@ -143,14 +143,14 @@ def test_invite_deny_non_existent_long_email():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.deny(email)
 
-    assert f"No invitation from '{email}' was found." in str(ex.value)
+    assert f"No invitation from '{email}' was found." in ex.value.stdout.decode("utf-8")
 
 
 def test_invite_deny_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.deny("\u2222@test.com")
 
-    assert "No invitation from '\u2222@test.com' was found." in str(ex.value)
+    assert "No invitation from '\u2222@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.xfail
@@ -172,7 +172,7 @@ def test_invite_accept_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.accept("test@test.com")
 
-    assert "No invitation from 'test@test.com' was found." in str(ex.value)
+    assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
 def test_invite_accept_non_existent_long_email():
@@ -181,11 +181,11 @@ def test_invite_accept_non_existent_long_email():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.accept(email)
 
-    assert f"No invitation from '{email}' was found." in str(ex.value)
+    assert f"No invitation from '{email}' was found." in ex.value.stdout.decode("utf-8")
 
 
 def test_invite_accept_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.accept("\u2222@test.com")
 
-    assert "No invitation from '\u2222@test.com' was found." in str(ex.value)
+    assert "No invitation from '\u2222@test.com' was found." in ex.value.stdout.decode("utf-8")

--- a/test/qa/test_meshnet_other.py
+++ b/test/qa/test_meshnet_other.py
@@ -103,7 +103,7 @@ def test_set_post_quantum_on_meshnet_enabled():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.set(settings.get_pq_alias(), "on")
 
-    assert "Post-quantum encryption and Meshnet are not compatible. Please disable one feature to use the other." in str(ex.value)
+    assert "Post-quantum encryption and Meshnet are not compatible. Please disable one feature to use the other." in ex.value.stdout.decode("utf-8")
 
 
 # This doesn't directly test meshnet, but it uses it
@@ -116,4 +116,4 @@ def test_set_meshnet_on_post_quantum_enabled():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.set.meshnet("on")
 
-    assert "Post-quantum encryption and Meshnet are not compatible. Please disable one feature to use the other." in str(ex.value)
+    assert "Post-quantum encryption and Meshnet are not compatible. Please disable one feature to use the other." in ex.value.stdout.decode("utf-8")

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -130,7 +130,7 @@ def test_route_to_nonexistant_node():
 
     expected_message = meshnet.MSG_PEER_UNKNOWN % nonexistant_node_name
 
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.xfail
@@ -200,7 +200,7 @@ def test_route_to_peer_that_is_disconnected():
 
     expected_message = meshnet.MSG_PEER_OFFLINE % peer_hostname
 
-    assert expected_message in str(ex)
+    assert expected_message in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_NO_MESHNET)
@@ -212,4 +212,4 @@ def test_route_traffic_to_peer_wrong_tech(tech, proto, obfuscated):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.mesh.peer.connect(peer_hostname)
 
-    assert meshnet.MSG_ROUTING_NEED_NORDLYNX in str(ex)
+    assert meshnet.MSG_ROUTING_NEED_NORDLYNX in ex.value.stdout.decode("utf-8")

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -27,7 +27,7 @@ def test_obfuscate_nonobfucated(tech, proto, obfuscated):
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set.obfuscate("on")
-        assert "Obfuscation is not available with the current technology. Change the technology to OpenVPN to use obfuscation." in str(ex.value)
+        assert "Obfuscation is not available with the current technology. Change the technology to OpenVPN to use obfuscation." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_BASIC2 + lib.TECHNOLOGIES_BASIC1 + lib.NORDWHISPER_TECHNOLOGY)
@@ -354,7 +354,7 @@ def test_set_post_quantum_on_open_vpn(tech, proto, obfuscated):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set(settings.get_pq_alias(), "on")
 
-    assert "Post-quantum encryption is unavailable with OpenVPN. Switch to NordLynx to activate post-quantum protection." in str(ex.value)
+    assert "Post-quantum encryption is unavailable with OpenVPN. Switch to NordLynx to activate post-quantum protection." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.NORDWHISPER_TECHNOLOGY)
@@ -366,7 +366,7 @@ def test_set_post_quantum_on_nordwhisper(tech, proto, obfuscated):
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set(settings.get_pq_alias(), "on")
 
-    assert "Post-quantum encryption is unavailable with NordWhisper. Switch to NordLynx to activate post-quantum protection." in str(ex.value)
+    assert "Post-quantum encryption is unavailable with NordWhisper. Switch to NordLynx to activate post-quantum protection." in ex.value.stdout.decode("utf-8")
 
 
 def test_set_technology_openvpn_post_quantum_enabled():
@@ -377,7 +377,7 @@ def test_set_technology_openvpn_post_quantum_enabled():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set.technology("OPENVPN")
 
-    assert "This setting is not compatible with post-quantum encryption. To use OpenVPN, disable post-quantum encryption first." in str(ex.value)
+    assert "This setting is not compatible with post-quantum encryption. To use OpenVPN, disable post-quantum encryption first." in ex.value.stdout.decode("utf-8")
 
 
 def test_set_technology_nordwhisper_post_quantum_enabled():
@@ -388,7 +388,7 @@ def test_set_technology_nordwhisper_post_quantum_enabled():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set.technology("NORDWHISPER")
 
-    assert "This setting is not compatible with post-quantum encryption. To use NordWhisper, disable post-quantum encryption first." in str(ex.value)
+    assert "This setting is not compatible with post-quantum encryption. To use NordWhisper, disable post-quantum encryption first." in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
@@ -422,7 +422,7 @@ def test_set_defaults_killswitch_interaction(killswitch_initial, killswitch_flag
     try:
         sh.nordvpn.set.killswitch(str(killswitch_initial))
     except sh.ErrorReturnCode_1 as ex:
-        assert "Kill Switch is already set to" in str(ex.value), "Unexpected error returned by 'set killswitch'. Expected 'Killswitch already set to enabled/disabled."
+        assert "Kill Switch is already set to" in ex.value.stdout.decode("utf-8"), "Unexpected error returned by 'set killswitch'. Expected 'Killswitch already set to enabled/disabled."
 
     if killswitch_flag:
         sh.nordvpn.set.defaults("--off-killswitch")
@@ -443,7 +443,7 @@ def test_set_protocol_openvpn_only(tech, proto, obfuscated):
 
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh.nordvpn.set.protocol("TCP")
-        assert "Protocol setting is not available when the set technology is not OpenVPN" in str(ex.value)
+        assert "Protocol setting is not available when the set technology is not OpenVPN" in ex.value.stdout.decode("utf-8")
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)


### PR DESCRIPTION
When we are converting `Exception` to `str`, if output is long, it sometimes gets compressed a bit. Once the time comes to compare output to predefined values, the values do not match. As a result, tests fail.

Need to stop converting `Exception` to `str` where possible, and instead use `ex.value.stdout.decode("utf-8")`