### PR TITLE
LVPN-8530: Mark Meshnet tests as allow to fail

### DIFF
--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -203,7 +203,6 @@ def test_accept(accept_directories):
     assert sender_files_status_ok is True, f"invalid file status on sender side, transfer {transfer}, files {accept_directories} should be uploaded"
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("path_flag", [True, False], ids=["accept_custom_path", "accept_downloads"])
 @pytest.mark.parametrize("background_accept", ["", "--background"], ids=["accept_int", "accept_bg"])
 @pytest.mark.parametrize("background_send", [True, False], ids=["send_bg", "send_int"])
@@ -550,7 +549,6 @@ def test_fileshare_transfer_multiple_files_selective_accept(background: bool, ac
     ssh_client.exec_command(f"sudo rm -rf {peer_filepath}/*tmp*")
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("transfer_entity", list(fileshare.FileSystemEntity), ids = [f"send_{entity.value}" for entity in list(fileshare.FileSystemEntity)])
 def test_fileshare_graceful_cancel(transfer_entity: fileshare.FileSystemEntity):
     wdir = fileshare.create_directory(0)
@@ -722,7 +720,6 @@ def test_fileshare_graceful_cancel_transfer_ongoing(sender_cancels: bool, transf
     shutil.rmtree(wdir.dir_path)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("background", [False, True], ids=["send_int", "send_bg"])
 @pytest.mark.parametrize("sender_cancels", [False, True], ids=["receiver_cancels", "sender_cancels"])
 @pytest.mark.parametrize("transfer_entity", list(fileshare.FileSystemEntity), ids = [f"send_{entity.value}" for entity in list(fileshare.FileSystemEntity)])
@@ -1192,7 +1189,6 @@ def test_accept_destination_directory_not_a_directory():
     sh.rm(path)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("transfer_entity", list(fileshare.FileSystemEntity), ids = [f"send_{entity.value}" for entity in list(fileshare.FileSystemEntity)])
 def test_autoaccept(transfer_entity: fileshare.FileSystemEntity):
     peer_list = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list())
@@ -1464,7 +1460,6 @@ def test_fileshare_process_monitoring_cuts_the_port_access_even_when_it_was_take
         fileshare.ensure_mesh_is_on()
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("background_accept", [True, False], ids=["accept_bg", "accept_int"])
 @pytest.mark.parametrize("background_send", [True, False], ids=["send_bg", "send_int"])
 def test_all_permissions_denied_send_file(background_send: bool, background_accept: bool):

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -31,7 +31,6 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
-@pytest.mark.xfail
 def test_meshnet_connect():
     peer = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer()
     this_device = meshnet.PeerList.from_str(ssh_client.exec_command("nordvpn mesh peer list")).get_external_peer()
@@ -183,7 +182,6 @@ def test_set_meshnet_off_when_logged_out(meshnet_allias):
     assert "You are not logged in." in ex.value.stdout.decode("utf-8")
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("meshnet_allias", meshnet.MESHNET_ALIAS)
 def test_set_meshnet_off_on(meshnet_allias):
 
@@ -248,7 +246,6 @@ def test_permission_messages_error(permission, permission_state, expected_messag
     assert expected_message in ex.value.stdout.decode("utf-8")
 
 
-@pytest.mark.xfail
 def test_derp_server_selection_logic():
     def has_duplicates(lst):
         return len(lst) != len(set(lst))
@@ -321,7 +318,6 @@ def test_direct_connection_rtt_and_loss():
         base_test(log_content, qapeer_hostname)
 
 
-@pytest.mark.xfail
 def test_incoming_connections():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -57,6 +57,7 @@ def test_meshnet_connect():
     assert nickname == this_device.nickname
 
 
+@pytest.mark.xfail
 def test_mesh_removed_machine_by_other():
     # find my token from cli
     mytoken = ""
@@ -94,6 +95,7 @@ def test_mesh_removed_machine_by_other():
     meshnet.add_peer(ssh_client)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("routing", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 @pytest.mark.parametrize("incoming", [True, False])
@@ -125,6 +127,7 @@ def test_exitnode_permissions(routing: bool, local: bool, incoming: bool, filesh
         assert f"-A POSTROUTING -s {peer_ip}/32 ! -d 100.64.0.0/10 -m comment --comment nordvpn -j MASQUERADE" not in rules
 
 
+@pytest.mark.xfail
 def test_remove_peer_firewall_update():
     peer_ip = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().ip
     meshnet.set_permissions(peer_ip, True, True, True, True)
@@ -147,12 +150,14 @@ def test_remove_peer_firewall_update():
     assert result, message
 
 
+@pytest.mark.xfail
 def test_account_switch():
     sh_no_tty.nordvpn.logout("--persist-token")
     login.login_as("qa-peer")
     sh_no_tty.nordvpn.set.mesh.on()  # expecting failure here
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("meshnet_allias", meshnet.MESHNET_ALIAS)
 def test_set_meshnet_on_when_logged_out(meshnet_allias):
 
@@ -189,6 +194,7 @@ def test_set_meshnet_off_on(meshnet_allias):
     assert settings.is_meshnet_enabled()
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("meshnet_allias", meshnet.MESHNET_ALIAS)
 def test_set_meshnet_on_repeated(meshnet_allias):
 
@@ -198,6 +204,7 @@ def test_set_meshnet_on_repeated(meshnet_allias):
     assert "Meshnet is already enabled." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("meshnet_allias", meshnet.MESHNET_ALIAS)
 def test_set_meshnet_off_repeated(meshnet_allias):
 
@@ -209,6 +216,7 @@ def test_set_meshnet_off_repeated(meshnet_allias):
     assert "Meshnet is already disabled." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(("permission", "permission_state", "expected_message"), meshnet.PERMISSION_SUCCESS_MESSAGE_PARAMETER_SET, \
                          ids=[f"{line[0]}-{line[1]}" for line in meshnet.PERMISSION_SUCCESS_MESSAGE_PARAMETER_SET])
 def test_permission_messages_success(permission, permission_state, expected_message):
@@ -224,6 +232,7 @@ def test_permission_messages_success(permission, permission_state, expected_mess
     assert expected_message in got_message
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(("permission", "permission_state", "expected_message"), meshnet.PERMISSION_ERROR_MESSAGE_PARAMETER_SET, \
                          ids=[f"{line[0]}-{line[1]}" for line in meshnet.PERMISSION_ERROR_MESSAGE_PARAMETER_SET])
 def test_permission_messages_error(permission, permission_state, expected_message):

--- a/test/qa/test_meshnet_invite.py
+++ b/test/qa/test_meshnet_invite.py
@@ -22,7 +22,6 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
-@pytest.mark.xfail
 def test_invite_send():
 
     assert "Meshnet invitation to 'test@test.com' was sent." in meshnet.send_meshnet_invite("test@test.com")
@@ -75,7 +74,6 @@ def test_invite_send_email_special_character():
     assert "It's not you, it's us. We're having trouble with our servers. If the issue persists, please contact our customer support." not in ex.value.stdout.decode("utf-8")
 
 
-@pytest.mark.xfail
 def test_invite_revoke():
 
     meshnet.send_meshnet_invite("test@test.com")
@@ -122,7 +120,6 @@ def test_invite_revoke_non_existent_special_character():
     assert "No invitation from '\u2222@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
-@pytest.mark.xfail
 def test_invite_deny():
 
     meshnet.remove_all_peers()
@@ -163,7 +160,6 @@ def test_invite_deny_non_existent_special_character():
     assert "No invitation from '\u2222@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
-@pytest.mark.xfail
 def test_invite_accept():
 
     meshnet.remove_all_peers()

--- a/test/qa/test_meshnet_invite.py
+++ b/test/qa/test_meshnet_invite.py
@@ -30,6 +30,7 @@ def test_invite_send():
     assert "test@test.com" in sh_no_tty.nordvpn.meshnet.invite.list()
 
 
+@pytest.mark.xfail
 def test_invite_send_repeated():
     meshnet.send_meshnet_invite("test@test.com")
 
@@ -47,6 +48,7 @@ def test_invite_send_own_email():
     assert "Email should belong to a different user." in ex.value.stderr.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_send_not_an_email():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         meshnet.send_meshnet_invite("test")
@@ -83,6 +85,7 @@ def test_invite_revoke():
     assert "test@test.com" not in sh_no_tty.nordvpn.meshnet.invite.list()
 
 
+@pytest.mark.xfail
 def test_invite_revoke_repeated():
     meshnet.send_meshnet_invite("test@test.com")
     sh_no_tty.nordvpn.meshnet.invite.revoke("test@test.com")
@@ -93,6 +96,7 @@ def test_invite_revoke_repeated():
     assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_revoke_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.revoke("test@test.com")
@@ -100,6 +104,7 @@ def test_invite_revoke_non_existent():
     assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_revoke_non_existent_long_email():
     email = "test" * 65 + "@test.com"
 
@@ -109,6 +114,7 @@ def test_invite_revoke_non_existent_long_email():
     assert f"No invitation from '{email}' was found." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_revoke_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.revoke("\u2222@test.com")
@@ -131,6 +137,7 @@ def test_invite_deny():
     assert f"Meshnet invitation from '{email}' was denied." in meshnet.deny_meshnet_invite(ssh_client)
 
 
+@pytest.mark.xfail
 def test_invite_deny_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.deny("test@test.com")
@@ -138,6 +145,7 @@ def test_invite_deny_non_existent():
     assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_deny_non_existent_long_email():
     email = "test" * 65 + "@test.com"
 
@@ -147,6 +155,7 @@ def test_invite_deny_non_existent_long_email():
     assert f"No invitation from '{email}' was found." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_deny_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.deny("\u2222@test.com")
@@ -169,6 +178,7 @@ def test_invite_accept():
     assert f"Meshnet invitation from '{email}' was accepted." in meshnet.accept_meshnet_invite(ssh_client)
 
 
+@pytest.mark.xfail
 def test_invite_accept_non_existent():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.accept("test@test.com")
@@ -176,6 +186,7 @@ def test_invite_accept_non_existent():
     assert "No invitation from 'test@test.com' was found." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_accept_non_existent_long_email():
     email = "test" * 65 + "@test.com"
 
@@ -185,6 +196,7 @@ def test_invite_accept_non_existent_long_email():
     assert f"No invitation from '{email}' was found." in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 def test_invite_accept_non_existent_special_character():
     with pytest.raises(sh.ErrorReturnCode_1) as ex:
         sh_no_tty.nordvpn.meshnet.invite.accept("\u2222@test.com")

--- a/test/qa/test_meshnet_peer_list.py
+++ b/test/qa/test_meshnet_peer_list.py
@@ -50,6 +50,7 @@ def base_test_peer_list(filter_list: list[str] | None = None) -> None:
         assert local_formed_list == local_peer_list.split("\n")
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("external", [True, False], ids=lambda value: "external" if value else "")
 @pytest.mark.parametrize("internal", [True, False], ids=lambda value: "internal" if value else "")
 @pytest.mark.parametrize("offline", [True, False], ids=lambda value: "offline" if value else "")
@@ -63,6 +64,7 @@ def test_meshnet_peer_list_state_filters(external, internal, offline, online):
     base_test_peer_list(filter_list)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("allows_incoming_traffic", [True, False], ids=lambda value: "allows_incoming_traffic" if value else "")
 @pytest.mark.parametrize("allows_routing", [True, False], ids=lambda value: "allows_routing" if value else "")
 @pytest.mark.parametrize("allows_sending_files", [True, False], ids=lambda value: "allows_sending_files" if value else "")

--- a/test/qa/test_meshnet_peer_list.py
+++ b/test/qa/test_meshnet_peer_list.py
@@ -80,7 +80,6 @@ def test_meshnet_peer_list_permission_filters(allows_incoming_traffic, allows_ro
     base_test_peer_list(filter_list)
 
 
-@pytest.mark.xfail
 def test_meshnet_peer_list_peer_connected():
     def is_peer_connected():
         local_peer_list = sh_no_tty.nordvpn.mesh.peer.list(_tty_out=False)

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -136,7 +136,7 @@ def test_route_to_nonexistant_node():
 
     assert expected_message in ex.value.stdout.decode("utf-8")
 
-
+@pytest.mark.skip("TOOD: LVPN-9459")
 def test_route_to_peer_status_valid():
     peer_hostname = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
 

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -137,7 +137,6 @@ def test_route_to_nonexistant_node():
     assert expected_message in ex.value.stdout.decode("utf-8")
 
 
-@pytest.mark.xfail
 def test_route_to_peer_status_valid():
     peer_hostname = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
 

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -27,6 +27,7 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("lan_discovery", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 def test_killswitch_exitnode(lan_discovery: bool, local: bool):
@@ -88,6 +89,7 @@ def test_killswitch_exitnode(lan_discovery: bool, local: bool):
     assert network.is_available()
 
 
+@pytest.mark.xfail
 def test_route_traffic_to_each_other():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     peer_hostname = peer_list.get_external_peer().hostname
@@ -107,6 +109,7 @@ def test_route_traffic_to_each_other():
     ssh_client.exec_command("nordvpn disconnect")
 
 
+@pytest.mark.xfail
 def test_routing_deny_for_peer_is_peer_no_netting():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     peer_hostname = peer_list.get_external_peer().hostname
@@ -122,6 +125,7 @@ def test_routing_deny_for_peer_is_peer_no_netting():
     ssh_client.exec_command("nordvpn disconnect")
 
 
+@pytest.mark.xfail
 def test_route_to_nonexistant_node():
     nonexistant_node_name = "penguins-are-cool.nord"
 
@@ -203,6 +207,7 @@ def test_route_to_peer_that_is_disconnected():
     assert expected_message in ex.value.stdout.decode("utf-8")
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_NO_MESHNET)
 def test_route_traffic_to_peer_wrong_tech(tech, proto, obfuscated):
     lib.set_technology_and_protocol(tech, proto, obfuscated)

--- a/test/qa/test_meshnet_vpn.py
+++ b/test/qa/test_meshnet_vpn.py
@@ -186,7 +186,6 @@ def test_set_defaults_when_connected_2nd_set(tech, proto, obfuscated):
     assert settings.app_has_defaults_settings()
 
 
-@pytest.mark.xfail
 def test_route_to_peer_that_is_connected_to_vpn():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname
@@ -249,7 +248,6 @@ def test_route_to_peer_that_disconnects_from_vpn():
     lib.is_disconnect_successful(ssh_client.exec_command("nordvpn disconnect"))
 
 
-@pytest.mark.xfail
 def test_route_traffic_to_peer_once_again_when_already_routing():
     peer_hostname = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
 

--- a/test/qa/test_meshnet_vpn.py
+++ b/test/qa/test_meshnet_vpn.py
@@ -25,6 +25,7 @@ def teardown_function(function):  # noqa: ARG001
     meshnet.TestUtils.teardown_function(ssh_client)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("lan_discovery", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 def test_lan_discovery_exitnode(lan_discovery: bool, local: bool):
@@ -65,6 +66,7 @@ def test_lan_discovery_exitnode(lan_discovery: bool, local: bool):
         assert result, message
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("lan_discovery", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 def test_killswitch_exitnode_vpn(lan_discovery: bool, local: bool):
@@ -130,6 +132,7 @@ def test_killswitch_exitnode_vpn(lan_discovery: bool, local: bool):
     assert network.is_available()
 
 
+@pytest.mark.xfail
 def test_connect_set_mesh_off():
     peer = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
     assert network.is_available()
@@ -153,6 +156,7 @@ def test_connect_set_mesh_off():
     assert network.is_available()
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 # This doesn't directly test meshnet, but it uses it
 def test_set_defaults_when_connected_2nd_set(tech, proto, obfuscated):
@@ -211,6 +215,7 @@ def test_route_to_peer_that_is_connected_to_vpn():
     lib.is_disconnect_successful(sh_no_tty.nordvpn.disconnect())
 
 
+@pytest.mark.xfail
 def test_route_to_peer_that_disconnects_from_vpn():
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname
@@ -244,6 +249,7 @@ def test_route_to_peer_that_disconnects_from_vpn():
     lib.is_disconnect_successful(ssh_client.exec_command("nordvpn disconnect"))
 
 
+@pytest.mark.xfail
 def test_route_traffic_to_peer_once_again_when_already_routing():
     peer_hostname = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().hostname
 

--- a/test/qa/test_update.py
+++ b/test/qa/test_update.py
@@ -81,7 +81,6 @@ def teardown_function(function):  # noqa: ARG001
     assert network.is_disconnected()
 
 
-@pytest.mark.xfail
 def test_meshnet_available_after_update():
     """Manual TC: LVPN-3204"""
 


### PR DESCRIPTION
Need to add `xfail` decorator to all of the Meshnet tests, except the ones that belong to Smoke test set.

Tests inside of file `test_meshnet_other.py` were not marked with `xfail` decorator, since they do not directly test Meshnet.