### PR TITLE
LVPN-9229: Remove Meshnet deprecation banner

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -450,7 +450,6 @@ func meshnetCommand(c *cmd) *cli.Command {
 		Name:    "meshnet",
 		Aliases: []string{"mesh"},
 		Usage:   MsgMeshnetUsage,
-		After:   meshnetDeprecationBanner,
 		Subcommands: []*cli.Command{
 			{
 				Name:        "peer",
@@ -940,7 +939,6 @@ func getSetSubcommands(cmd *cmd, isMeshnetEnabled bool) []*cli.Command {
 		Description:  MsgSetMeshnetDescription,
 		Action:       cmd.MeshSet,
 		BashComplete: cmd.SetBoolAutocomplete,
-		After:        meshnetDeprecationBanner,
 	}
 
 	if isMeshnetEnabled {
@@ -1439,9 +1437,4 @@ func composeAppVersion(buildVersion string, environment string, isSnap bool) str
 func isMeshnetEnabled(cmd *cmd) bool {
 	featureToggles := cmd.GetFeatureToggles()
 	return featureToggles.meshnetEnabled
-}
-
-func meshnetDeprecationBanner(ctx *cli.Context) error {
-	fmt.Println("Meshnet is leaving NordVPN on December 1. Learn more: https://nordvpn.com/blog/meshnet-shutdown")
-	return nil
 }


### PR DESCRIPTION
Changes:
- Removing Meshnet deprecation banner from CLI