### PR TITLE
LVPN-9124: Tray does not start after reboot

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,7 @@ apps:
   nordvpn:
     command: bin/nordvpn
     desktop: usr/share/applications/nordvpn.desktop
+    autostart: nordvpn.desktop
     environment:
       PREFIX_COMMON: $SNAP_COMMON
       PREFIX_DATA: $SNAP_DATA


### PR DESCRIPTION
Changes:
- add `autostart` section to snapcraft template

NOTE:
- it looks like this is needed now for snap to allow to trigger this [autostart](https://github.com/NordSecurity/nordvpn-linux/blob/main/cmd/norduser/main.go#L46)
- it runs `nordvpn user` to trigger CLI which starts `norduserd` process and it starts the tray 