### PR TITLE
LVPN-7482: Update error messages in GUI

### DIFF
--- a/daemon/rpc_login.go
+++ b/daemon/rpc_login.go
@@ -15,10 +15,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/session"
 )
 
-// ErrMissingExchangeToken is returned when login was successful but
-// there is not enough data to request the token
-var ErrMissingExchangeToken = errors.New("The exchange token is missing. Please try logging in again. If the issue persists, contact our customer support.")
-
 type customCallbackType func() (*core.LoginResponse, *pb.LoginResponse, error)
 
 var lastLoginAttemptTime time.Time
@@ -218,8 +214,8 @@ func (r *RPC) LoginOAuth2Callback(ctx context.Context, in *pb.LoginOAuth2Callbac
 	}()
 
 	if in.GetToken() == "" {
-		r.publisher.Publish(ErrMissingExchangeToken.Error())
-		return nil, ErrMissingExchangeToken
+		r.publisher.Publish(internal.ErrMissingExchangeToken.Error())
+		return nil, internal.ErrMissingExchangeToken
 	}
 
 	resp, err := r.authentication.Token(in.GetToken())

--- a/gui/lib/data/mocks/daemon/mock_account_info.dart
+++ b/gui/lib/data/mocks/daemon/mock_account_info.dart
@@ -28,7 +28,7 @@ final class MockAccountInfo extends CancelableDelayed {
     }
 
     if (!_isLoggedIn) {
-      throw error ?? "you are not logged in";
+      throw error ?? DaemonStatusCode.notLoggedInErrorMsg;
     }
     return _account!;
   }

--- a/gui/lib/data/repository/daemon_status_codes.dart
+++ b/gui/lib/data/repository/daemon_status_codes.dart
@@ -46,11 +46,14 @@ final class DaemonStatusCode {
   // generic error when application is not able to connect to VPN, but it returns failure=3000
   static const failedToConnectToVpn = 5015;
 
+  static const notLoggedInErrorMsg = "You're not logged in";
+
   static final Map<String, int> _errorsMap = {
-    "exchange token not provided": missingExchangeToken,
-    "you are already logged in": alreadyLoggedIn,
+    "The exchange token is missing. Please try logging in again. If the issue persists, contact our customer support.":
+        missingExchangeToken,
+    "You're already logged in": alreadyLoggedIn,
     "Token parameter value is missing": tokenLoginFailure,
-    "you are not logged in": notLoggedIn,
+    notLoggedInErrorMsg: notLoggedIn,
     "Please check your internet connection and try again.": offline,
   };
 

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -45,14 +45,22 @@ var (
 	ErrTagDoesNotExist         = errors.New(TagNonexistentErrorMessage)
 	ErrGroupDoesNotExist       = errors.New(GroupNonexistentErrorMessage)
 	ErrDoubleGroup             = errors.New(DoubleGroupErrorMessage)
-	// ErrAlreadyLoggedIn is returned on repeated logins
-	ErrAlreadyLoggedIn = errors.New("You're already logged in")
-	// ErrNotLoggedIn is returned when the caller is expected to be logged in
-	// but is not
-	ErrNotLoggedIn = errors.New("You're not logged in")
 	// ErrAnalyticsConsentMissing is returned when user tries to login via tray
 	// but settings analytics consent failed for some reason. This should not happen.
 	ErrAnalyticsConsentMissing = errors.New("analytics consent is required before continuing")
 	ErrVirtualServerSelected   = errors.New(SpecifiedServerIsVirtualLocation)
 	ErrNoNetWhenLoggingIn      = errors.New("You’re offline.\nWe can’t run this action without an internet connection. Please check it and try again.")
+
+	// WARN: The error messages below are also used to detect error states in GUI.
+	// When updating, make sure to double check the GUI errors here:
+	// https://github.com/NordSecurity/nordvpn-linux/blob/main/gui/lib/data/repository/daemon_status_codes.dart#L49-L49
+
+	// ErrAlreadyLoggedIn is returned on repeated logins
+	ErrAlreadyLoggedIn = errors.New("You're already logged in")
+	// ErrNotLoggedIn is returned when the caller is expected to be logged in
+	// but is not
+	ErrNotLoggedIn = errors.New("You're not logged in")
+	// ErrMissingExchangeToken is returned when login was successful but
+	// there is not enough data to request the token
+	ErrMissingExchangeToken = errors.New("The exchange token is missing. Please try logging in again. If the issue persists, contact our customer support.")
 )


### PR DESCRIPTION
Changes:
- Update error messages modified in https://github.com/NordSecurity/nordvpn-linux/pull/1125 also in GUI
- Move two errors to `internal/errors.go` to have it in one place and add warn comment with info that those error messages are important from GUI perspective