### PR TITLE
LVPN-9355: Reset ServerTag in AutoConnectData config

### DIFF
--- a/daemon/rpc_settings.go
+++ b/daemon/rpc_settings.go
@@ -53,6 +53,8 @@ func (r *RPC) Settings(ctx context.Context, in *pb.Empty) (*pb.SettingsResponse,
 			c.AutoConnectData.Country = cfg.AutoConnectData.Country
 			c.AutoConnectData.City = cfg.AutoConnectData.City
 			c.AutoConnectData.Group = cfg.AutoConnectData.Group
+			// resetting ServerTag - not supported anymore, to be removed in LVPN-9355
+			c.AutoConnectData.ServerTag = ""
 
 			return c
 		})


### PR DESCRIPTION
Context:
- when settings endpoint is called, we are modifying config to adjust for new auto-connect format
- this was run every time the settings endpoint was called (with tray - every 5 seconds with current implementation)
- this config change generates log message which spoils the log in the long run

Changes:
- when we update for new Auto-Connect format, now I'm resetting `ServerTag` field so this update is done only once