### PR TITLE
LVPN-9404: Deny by default all the permissions for protochecker workflow

### DIFF
--- a/.github/workflows/protochecker.yml
+++ b/.github/workflows/protochecker.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   protochecker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove by default any permissions to the protochecker workflow configuration.