### PR TITLE
LVPN-9454: Increase SSH timeout value

### DIFF
--- a/test/qa/lib/ssh.py
+++ b/test/qa/lib/ssh.py
@@ -27,7 +27,7 @@ class Ssh:
         self.client.connect(self.hostname, 22, username=self.username, password=self.password)
 
     def exec_command(self, command: str) -> str:
-        _, stdout, stderr = self.client.exec_command(command, timeout=10)
+        _, stdout, stderr = self.client.exec_command(command, timeout=16)
         try:
             output = stdout.read().decode()
             error = stderr.read().decode()


### PR DESCRIPTION
Setup & teardown of Meshnet tests and Meshnet tests in general fail in weird ways, due to fact, that SSH command line execution timeout is set to value which too low. The timeout value has to be increased, in order to remedy the situation.