### PR TITLE
LVPN-9304: Disable tray communication to fileshare socket when mesh off

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -93,8 +93,8 @@ func main() {
 	clientIDMetadataInterceptor := clientid.NewInsertClientIDInterceptor(pb.ClientID_CLI)
 
 	loaderInterceptor := cli.LoaderInterceptor{}
-	//nolint:staticcheck
-	conn, err := grpc.Dial(
+
+	conn, _ := grpc.NewClient(
 		DaemonURL,
 		// Insecure credentials are OK because the connection is completely local and
 		// protected by file permissions
@@ -104,8 +104,7 @@ func main() {
 		grpc.WithChainStreamInterceptor(loaderInterceptor.StreamInterceptor,
 			clientIDMetadataInterceptor.SetMetadataStreamInterceptor),
 	)
-	//nolint:staticcheck
-	fileshareConn, err := grpc.Dial(
+	fileshareConn, _ := grpc.NewClient(
 		fileshare_process.FileshareURL,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithUnaryInterceptor(loaderInterceptor.UnaryInterceptor),

--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -23,8 +23,6 @@ import (
 	childprocess "github.com/NordSecurity/nordvpn-linux/child_process"
 	"github.com/NordSecurity/nordvpn-linux/clientid"
 	daemonpb "github.com/NordSecurity/nordvpn-linux/daemon/pb"
-	"github.com/NordSecurity/nordvpn-linux/fileshare/fileshare_process"
-	filesharepb "github.com/NordSecurity/nordvpn-linux/fileshare/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	meshpb "github.com/NordSecurity/nordvpn-linux/meshnet/pb"
 	"github.com/NordSecurity/nordvpn-linux/norduser"
@@ -85,21 +83,7 @@ func startTray(quitChan chan<- norduser.StopRequest) {
 	}
 	ReportTelemetry(conn, ReportOnStart, false)
 
-	//nolint:staticcheck
-	fileshareConn, err := grpc.Dial(
-		fileshare_process.FileshareURL,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-
-	var fileshareClient filesharepb.FileshareClient
-	if err == nil {
-		fileshareClient = filesharepb.NewFileshareClient(fileshareConn)
-	} else {
-		log.Println(internal.ErrorPrefix, "Error connecting to the NordVPN fileshare daemon:", err)
-		return
-	}
-
-	ti := tray.NewTrayInstance(client, fileshareClient, quitChan)
+	ti := tray.NewTrayInstance(client, quitChan)
 	ti.Start()
 
 	topLevelCtx, topLevelCancelFunc := context.WithCancel(context.Background())

--- a/tray/actions.go
+++ b/tray/actions.go
@@ -14,7 +14,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/cli"
 	"github.com/NordSecurity/nordvpn-linux/client"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
-	filesharepb "github.com/NordSecurity/nordvpn-linux/fileshare/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/godbus/dbus/v5"
 )
@@ -230,10 +229,7 @@ func (ti *Instance) disconnect() bool {
 }
 
 func (ti *Instance) setNotify(flag bool) bool {
-	flagText := "off"
-	if flag {
-		flagText = "on"
-	}
+	flagText := getFlagText(flag)
 	resp, err := ti.client.SetNotify(context.Background(), &pb.SetNotifyRequest{
 		Notify: flag,
 	})
@@ -252,10 +248,7 @@ func (ti *Instance) setNotify(flag bool) bool {
 	case internal.CodeSuccess:
 	}
 
-	_, err = ti.fileshareClient.SetNotifications(context.Background(), &filesharepb.SetNotificationsRequest{Enable: flag})
-	if err != nil {
-		log.Printf("%s Setting fileshare notifications %s error: %s", internal.ErrorPrefix, flagText, err)
-	}
+	ti.fileshare.SetNotifications(flag)
 
 	if resp.Type == internal.CodeNothingToDo {
 		ti.notify(NoForce, "Notifications already %s", flagText)
@@ -265,10 +258,7 @@ func (ti *Instance) setNotify(flag bool) bool {
 }
 
 func (ti *Instance) setTray(flag bool) bool {
-	flagText := "off"
-	if flag {
-		flagText = "on"
-	}
+	flagText := getFlagText(flag)
 
 	if !flag {
 		log.Printf("%s Tray icon disabled. To enable it again, run the \"nordvpn set tray on\" command.", internal.InfoPrefix)
@@ -296,4 +286,11 @@ func (ti *Instance) setTray(flag bool) bool {
 	}
 
 	return true
+}
+
+func getFlagText(flag bool) string {
+	if flag {
+		return "on"
+	}
+	return "off"
 }

--- a/tray/fileshare_manager.go
+++ b/tray/fileshare_manager.go
@@ -1,0 +1,54 @@
+package tray
+
+import (
+	"context"
+	"log"
+
+	"github.com/NordSecurity/nordvpn-linux/fileshare/fileshare_process"
+	filesharepb "github.com/NordSecurity/nordvpn-linux/fileshare/pb"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type FileshareManager struct {
+	fileshareClient filesharepb.FileshareClient
+}
+
+// NewFileshare manager builds an empty FileshareManager
+func NewFileshareManager() FileshareManager {
+	return FileshareManager{fileshareClient: nil}
+}
+
+// UpdateFileshareConnection updates the fileshare gRPC connection based on the meshnetEnabled status
+func (fs *FileshareManager) UpdateFileshareConnection(meshnetEnabled bool) {
+	log.Println(internal.InfoPrefix, "Updating tray's fileshare connection", getFlagText(meshnetEnabled))
+	if !meshnetEnabled {
+		fs.fileshareClient = nil
+		return
+	}
+
+	if fs.fileshareClient == nil {
+		// Meshnet is enabled, we must connect to the fileshare daemon
+		fileShareConn, err := grpc.NewClient(
+			fileshare_process.FileshareURL,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err == nil {
+			fs.fileshareClient = filesharepb.NewFileshareClient(fileShareConn)
+		} else {
+			log.Println(internal.ErrorPrefix, "Error connecting to the NordVPN fileshare daemon:", err)
+		}
+	}
+}
+
+// SetNotifications sets the fileshare notifications on/off
+func (fs *FileshareManager) SetNotifications(flag bool) {
+	if fs.fileshareClient == nil {
+		log.Println(internal.WarningPrefix, "fileshare client not initialized")
+		return
+	}
+	if _, err := fs.fileshareClient.SetNotifications(context.Background(), &filesharepb.SetNotificationsRequest{Enable: flag}); err != nil {
+		log.Printf("%s Setting fileshare notifications %s error: %s\n", internal.ErrorPrefix, getFlagText(flag), err)
+	}
+}

--- a/tray/monitor.go
+++ b/tray/monitor.go
@@ -137,11 +137,17 @@ func (ti *Instance) updateLoginStatus() bool {
 
 	loggedIn := resp.GetIsLoggedIn()
 
-	if !loggedIn && ti.state.loggedIn && ti.state.vpnStatus == pb.ConnectionState_CONNECTED {
-		// reset the VPN info if the user logs out while connected to VPN
-		changedVpn := ti.setVpnStatus(pb.ConnectionState_DISCONNECTED, "", "", "", "", false)
-		if changedVpn {
-			changed = true
+	if !loggedIn {
+		// If logged out, meshnet will be disabled therefore
+		// the communication with fileshare is not needed
+		ti.fileshare.UpdateFileshareConnection(false)
+
+		if ti.state.loggedIn && ti.state.vpnStatus == pb.ConnectionState_CONNECTED {
+			// reset the VPN info if the user logs out while connected to VPN
+			changedVpn := ti.setVpnStatus(pb.ConnectionState_DISCONNECTED, "", "", "", "", false)
+			if changedVpn {
+				changed = true
+			}
 		}
 	}
 
@@ -240,6 +246,8 @@ func (ti *Instance) setSettings(settings *pb.Settings) bool {
 	if userSettings == nil {
 		return false
 	}
+
+	ti.fileshare.UpdateFileshareConnection(settings.Meshnet)
 
 	changed := false
 	var notificationsText, trayText string

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
-	filesharepb "github.com/NordSecurity/nordvpn-linux/fileshare/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/norduser"
 	"github.com/NordSecurity/nordvpn-linux/notify"
@@ -119,7 +118,7 @@ func sortedConnections(sgs []*pb.ServerGroup) []Server {
 
 type Instance struct {
 	client              pb.DaemonClient
-	fileshareClient     filesharepb.FileshareClient
+	fileshare           FileshareManager
 	accountInfo         accountInfo
 	debugMode           bool
 	notifier            dbusNotifier
@@ -168,10 +167,10 @@ func (state *trayState) serverName() string {
 	return vpnServerName
 }
 
-func NewTrayInstance(client pb.DaemonClient, fileshareClient filesharepb.FileshareClient, quitChan chan<- norduser.StopRequest) *Instance {
+func NewTrayInstance(client pb.DaemonClient, quitChan chan<- norduser.StopRequest) *Instance {
 	obj := &Instance{
 		client:            client,
-		fileshareClient:   fileshareClient,
+		fileshare:         NewFileshareManager(),
 		quitChan:          quitChan,
 		connSensor:        newConnectionSettingsChangeSensor(),
 		recentConnections: newRecentConnectionsManager(client),


### PR DESCRIPTION
I found 3 places where there is communication with the fileshare socket:
- The tray, that keeps the connection active while it's running. The most "dangerous" one, which I already fixed so the connection is established only when the meshnet is enabled.
- The norduser, which holds the management system for fileshare, which tries to communicate over it only to send the stop command, which closes the fileshare process. Now it tries to connect and send the close command only if the socket exists so we get rid of the not found error when the fileshare is already disabled.
-  The cli, which connects to fileshare to be able to execute the fileshare commands. The trick here is that if we want to avoid the connection when meshnet is off, we will need to do an aditional rpc call for every command to fetch the settings and see if the meshnet is enabled which doesn’t make sense in my opinion.

Decided with @devzbysiu  to call it a day just with the tray fixes.