### PR TITLE
LVPN-9535: Add changelog for release 4.2.2

### DIFF
--- a/contrib/changelog/prod/4.2.2.md
+++ b/contrib/changelog/prod/4.2.2.md
@@ -1,1 +1,1 @@
-* TODO
+* When auto-connect was on, some logs would get stuck in déjà vu — writing the same message every few seconds. We fixed the bug responsible and freed them from eternal repetition.


### PR DESCRIPTION
Changelog: 
* When auto-connect was on, some logs would get stuck in déjà vu — writing the same message every few seconds. We fixed the bug responsible and freed them from eternal repetition.