### PR TITLE
LVPN-9357: Make config migration to happen only once

### DIFF
--- a/daemon/rpc_settings.go
+++ b/daemon/rpc_settings.go
@@ -3,12 +3,15 @@ package daemon
 import (
 	"context"
 	"log"
+	"sync"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"google.golang.org/grpc/peer"
 )
+
+var adjustAutoconnectCfgOnce sync.Once
 
 // Settings returns system daemon settings
 func (r *RPC) Settings(ctx context.Context, in *pb.Empty) (*pb.SettingsResponse, error) {
@@ -35,32 +38,33 @@ func (r *RPC) Settings(ctx context.Context, in *pb.Empty) (*pb.SettingsResponse,
 
 	// Storing autoconnect parameters was introduced later on so they might not be save in a config yet. We need to
 	// perform an update in such cases to maintain compatibility.
-	autoconnectParamsNotSet := cfg.AutoConnectData.Country == "" &&
-		cfg.AutoConnectData.City == "" &&
-		cfg.AutoConnectData.Group == config.ServerGroup_UNDEFINED
-	if cfg.AutoConnect && cfg.AutoConnectData.ServerTag != "" && autoconnectParamsNotSet {
-		// use group tag as a second parameter once it is implemented
-		parameters := GetServerParameters(
-			cfg.AutoConnectData.ServerTag,
-			cfg.AutoConnectData.ServerTag,
-			r.dm.GetCountryData().Countries,
-		)
-		cfg.AutoConnectData.Country = parameters.Country
-		cfg.AutoConnectData.City = parameters.City
-		cfg.AutoConnectData.Group = parameters.Group
+	adjustAutoconnectCfgOnce.Do(func() {
+		autoconnectParamsNotSet := cfg.AutoConnectData.Country == "" &&
+			cfg.AutoConnectData.City == "" &&
+			cfg.AutoConnectData.Group == config.ServerGroup_UNDEFINED
+		if cfg.AutoConnect && cfg.AutoConnectData.ServerTag != "" && autoconnectParamsNotSet {
+			// use group tag as a second parameter once it is implemented
+			parameters := GetServerParameters(
+				cfg.AutoConnectData.ServerTag,
+				cfg.AutoConnectData.ServerTag,
+				r.dm.GetCountryData().Countries,
+			)
+			cfg.AutoConnectData.Country = parameters.Country
+			cfg.AutoConnectData.City = parameters.City
+			cfg.AutoConnectData.Group = parameters.Group
 
-		err := r.cm.SaveWith(func(c config.Config) config.Config {
-			c.AutoConnectData.Country = cfg.AutoConnectData.Country
-			c.AutoConnectData.City = cfg.AutoConnectData.City
-			c.AutoConnectData.Group = cfg.AutoConnectData.Group
+			err := r.cm.SaveWith(func(c config.Config) config.Config {
+				c.AutoConnectData.Country = cfg.AutoConnectData.Country
+				c.AutoConnectData.City = cfg.AutoConnectData.City
+				c.AutoConnectData.Group = cfg.AutoConnectData.Group
 
-			return c
-		})
-
-		if err != nil {
-			log.Println(internal.WarningPrefix, "failed to set autoconnect parameters during the settings RPC:", err)
+				return c
+			})
+			if err != nil {
+				log.Println(internal.WarningPrefix, "failed to set autoconnect parameters during the settings RPC:", err)
+			}
 		}
-	}
+	})
 
 	settings := configToProtobuf(&cfg, uid)
 

--- a/daemon/rpc_settings_test.go
+++ b/daemon/rpc_settings_test.go
@@ -1,0 +1,39 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	"gotest.tools/v3/assert"
+)
+
+func TestSettings_AutoconnectMigrationRunsOnlyOnce(t *testing.T) {
+	cm := mock.NewMockConfigManager()
+
+	// conditions for triggering migration of autoconnect
+	cm.Cfg.AutoConnect = true
+	cm.Cfg.AutoConnectData.ServerTag = "not-empty"
+	cm.Cfg.AutoConnectData.Country = ""
+	cm.Cfg.AutoConnectData.City = ""
+	cm.Cfg.AutoConnectData.Group = config.ServerGroup_UNDEFINED
+
+	r := testRPC()
+	r.cm = cm
+	assert.Equal(t, cm.SaveCallCount, 0)
+
+	ctx := context.Background()
+	_, err := r.Settings(ctx, &pb.Empty{})
+	assert.NilError(t, err, "first Settings() call returned error: %v", err)
+
+	// migration was performed
+	assert.Equal(t, cm.SaveCallCount, 1)
+
+	_, err = r.Settings(ctx, &pb.Empty{})
+	assert.NilError(t, err, "second Settings() call returned error: %v", err)
+
+	// still 1 - migration was not executed again
+	assert.Equal(t, cm.SaveCallCount, 1)
+}

--- a/test/mock/config_manager.go
+++ b/test/mock/config_manager.go
@@ -9,16 +9,18 @@ import (
 )
 
 type ConfigManager struct {
-	mu      sync.RWMutex
-	Cfg     *config.Config
-	SaveErr error
-	LoadErr error
-	Saved   bool
+	mu            sync.RWMutex
+	Cfg           *config.Config
+	SaveCallCount int
+	SaveErr       error
+	LoadErr       error
+	Saved         bool
 }
 
 func NewMockConfigManager() *ConfigManager {
 	m := ConfigManager{}
 	m.Cfg = &config.Config{
+		UsersData: &config.UsersData{NotifyOff: config.UidBoolMap{}, TrayOff: config.UidBoolMap{}},
 		TokensData: map[int64]config.TokenData{
 			0: {
 				Token:              "",
@@ -73,6 +75,7 @@ func (m *ConfigManager) SaveWith(fn config.SaveFunc) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.SaveCallCount += 1
 	if m.SaveErr != nil {
 		return m.SaveErr
 	}


### PR DESCRIPTION
Changes:
- use `sync.Once` to run config migration only once per process lifetime
- add test checking that config save is executed only once