### PR TITLE
Disable test for countries and cities names in GUI

### DIFF
--- a/gui/test/country_names_test.dart
+++ b/gui/test/country_names_test.dart
@@ -37,6 +37,7 @@ void main() async {
 
   test(
     'All cities, country codes and names from API exist in translation files',
+    skip: true,
     () async {
       List<dynamic> jsonResponse = json.decode(response.body);
       for (final item in jsonResponse) {


### PR DESCRIPTION
Because the cities and countries where servers exist are added at any time is hard to keep the test always updated, the test is disabled.
Also since the app has only one language is not relevant this test, since GUI will always display the names in English.