### PR TITLE
LVPN-9525: Trigger CodeQL only on pulls to the main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,6 @@ name: CodeQL Security Scan
 permissions: {}
 
 on:
-    push:
-        branches:
-            - "**"
     pull_request:
         branches: [main]
     schedule:


### PR DESCRIPTION
Changes:
- The pipeline now runs only for branches that target the main.