### PR TITLE
LVPN-9582: Update install scripts used in tests

### DIFF
--- a/ci/test_install_deb.sh
+++ b/ci/test_install_deb.sh
@@ -6,4 +6,4 @@ default_tool=curl
 apt-get update && apt-get -y install apt-utils "${1-$default_tool}"
 mkdir -p "${REPO_DIR}" && cp -t "${REPO_DIR}" "${WORKDIR}"/dist/app/deb/*.deb
 cd "${REPO_DIR}" && apt-ftparchive packages . > Packages
-"${WORKDIR}"/test/qa/install.sh -n -b "" -k "" -d "[trusted=true] file:///$REPO_DIR/" -w "./"
+"${WORKDIR}"/test/qa/install.sh -n -b "" -k "" -d "[trusted=true] file:$REPO_DIR/" -w "./"

--- a/ci/test_install_rpm.sh
+++ b/ci/test_install_rpm.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+# store the path where the local repository for the application is
+REPO_PATH="${REPO_DIR}"
+
 case "$1" in
     centos) yum -y install yum-utils createrepo ;;
     fedora) dnf -y install dnf-plugins-core createrepo ;;
-    opensuse) zypper refresh && zypper -n install curl createrepo_c ;;
-    *) echo "Can't recognise the OS" && exit 1 ;;
+    opensuse) 
+        zypper refresh && zypper -n install curl createrepo_c
+        # with zypper the path needs to be updated to point to the nordvpn.repo file, inside the local repo folder
+        REPO_PATH="${REPO_DIR}/nordvpn.repo"
+    ;;
+    *) echo "Can't recognize the OS" && exit 1 ;;
 esac
 
 mkdir -p "${REPO_DIR}/$(arch)" && cp -t "${REPO_DIR}/$(arch)" "${WORKDIR}/dist/app/rpm/"*".$(arch).rpm"
@@ -15,4 +22,4 @@ name=nordvpn
 baseurl=file:///$REPO_DIR/$(arch)
 enabled=1
 gpgcheck=0" | tee "${REPO_DIR}"/nordvpn.repo 
-"${WORKDIR}"/test/qa/install.sh -n -b "" -r "${REPO_DIR}/nordvpn.repo"
+"${WORKDIR}"/test/qa/install.sh -n -b "" -r "${REPO_PATH}"


### PR DESCRIPTION
In the latest OS versions the package managers changed how local packages are configured to be installed. 
The updates are made to support the newer and the older package managers versions.