### PR TITLE
LVPN-9615: Bump MaxBytesLimit to 20MB

### DIFF
--- a/internal/constants.go
+++ b/internal/constants.go
@@ -99,7 +99,7 @@ const (
 
 	NordWhisperInterfaceName = "qtun"
 
-	MaxBytesLimit int64 = 1024*1024*20 + 1 // 10MB + 1 because we allow for values which are equal to the limit
+	MaxBytesLimit int64 = 1024*1024*20 + 1 // + 1 because we allow for values which are equal to the limit
 )
 
 var (


### PR DESCRIPTION
Changes:
- bump max response limit to 20mb