### PR TITLE
LVPN-9638: Updates for nfpm template to fix rpm-ostree

### DIFF
--- a/ci/nfpm/template.yaml
+++ b/ci/nfpm/template.yaml
@@ -126,11 +126,18 @@ contents:
     file_info:
       mode: 0744
 
-  - src: ${WORKDIR}/bin/deps/lib/current-dump/${ARCH}
-    dst: /usr/lib/${NAME}
-    type: tree
+  # create first the folder and then copy the files inside the folder,
+  # otherwise rpm-ostree will reject the package because attributes are incorrect
+  # https://github.com/NordSecurity/nordvpn-linux/issues/393#issuecomment-3555598183
+  - dst: /usr/lib/${NAME}
+    type: dir
     file_info:
       mode: 0755
+
+  - src: ${WORKDIR}/bin/deps/lib/current-dump/${ARCH}/
+    dst: /usr/lib/${NAME}/
+    file_info:
+      mode: 0644
 
 # All fields above marked as `overridable` can be overridden for a given package format in this section.
 overrides:


### PR DESCRIPTION
* When using "type: tree" to copy all the content into /usr/lib/nordvpn the folder ends up with some wrong attributes into the rpm package. Because of this the package fails to be installed with rpm-ostree. 
* Change attributes for the libraries copiend in /usr/lib/nordvpn to 0644.