### PR TITLE
LVPN-9720: Incorrectly set specific server's hostname

### DIFF
--- a/gui/lib/vpn/recent_connections_item_factory.dart
+++ b/gui/lib/vpn/recent_connections_item_factory.dart
@@ -165,11 +165,11 @@ final class RecentConnectionsItemFactory {
     bool isSpecialtyServer,
   ) {
     if (model.connectionType == ServerSelectionRule.SPECIFIC_SERVER &&
-        model.specificServerName.isNotEmpty) {
+        model.specificServer.isNotEmpty) {
       return ConnectArguments(
         server: ServerInfo(
           id: 0,
-          hostname: model.specificServerName,
+          hostname: "${model.specificServer}.nordvpn.com",
           isVirtual: model.isVirtual,
         ),
       );


### PR DESCRIPTION
### Purpose/Problem
Connecting to a specific server did not work as intended because the server ID extracted from the recent connection was misused. As a result, connection attempts that were supposed to target a chosen server were falling back to the generic recommended/quick-connect path. This caused user-initiated server selection to be ignored and produced misleading connection behavior.

### Solution
The hostname setting logic has been corrected to properly extract and propagate the selected server’s hostname. The connection flow now reliably distinguishes between a user-specified server and the default recommended option.