### PR TITLE
LVPN-9736: set app to defaults in meshnet test setup

### DIFF
--- a/test/qa/lib/meshnet.py
+++ b/test/qa/lib/meshnet.py
@@ -58,9 +58,11 @@ class TestUtils:
 
         # if setup_function fails, teardown won't be executed, so daemon is not stopped
         if daemon.is_running():
+            sh_no_tty.nordvpn.set.defaults("--logout", "--off-killswitch")
             daemon.stop()
 
         if daemon.is_peer_running(ssh_client):
+            ssh_client.exec_command("nordvpn set defaults --logout --off-killswitch")
             daemon.stop_peer(ssh_client)
 
         delete_machines_by_identifier(token=LOCAL_TOKEN)


### PR DESCRIPTION
When a test fails in setup, the teardown will not be performed. In such cases we need to perform the necessary teardown in the setup function, otherwise next test will be started in invalid state. Primarily, this concerns setting the app to default/logging out as otherwise the next test will fail at the login attempt.