### PR TITLE
LVPN-9760: Fix `test_fileshare_transfer` failure at transfer progress checking

### DIFF
--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -309,7 +309,7 @@ def validate_transfer_progress(transfer_log: str):
     return increasing
 
 
-class TransferState(Enum):
+class TransferState(str, Enum):
     DOWNLOADING = "downloading"
     UPLOADING = "uploading"
 


### PR DESCRIPTION
`test_fileshare_transfer` is flaky at `assert transfer_progress_local.transfer_progress_valid`. Attempt to change logic, to address the ongoing issue.