### PR TITLE
LVPN-9755: For testing set moose env to prod for fileshare

### DIFF
--- a/norduser/fileshare.go
+++ b/norduser/fileshare.go
@@ -41,7 +41,7 @@ func fileshareManagementLoop(managementChan <-chan FileshareManagementMsg, shutd
 				log.Println(internal.ErrorPrefix, "failed to stop fileshare:", err)
 			}
 		case Shutdown:
-			log.Println(internal.InfoPrefix, "stopping fileshare")
+			log.Println(internal.InfoPrefix, "Shutdown: stopping fileshare")
 			if err := fileshareProcessManager.StopProcess(true); err != nil {
 				log.Println(internal.ErrorPrefix, "failed to stop fileshare on shutdown:", err)
 			}


### PR DESCRIPTION
In tests set environment to prod for libdrop. In this way it will not fail to initialize moose.
