### PR TITLE
LVPN-9775: Add monitoring on the channel connection

### DIFF
--- a/test/qa/test_grpc.py
+++ b/test/qa/test_grpc.py
@@ -82,7 +82,6 @@ def collect_state_changes(channel: grpc.Channel, stop_at: int, tracked_states: S
             if change.WhichOneof('state') in tracked_states:
                 result.append(change)
                 if len(result) >= stop_at:
-                    logging.log(f"Events received listener {result}")
                     break
         return result
 


### PR DESCRIPTION
From the logs it seams that the gRPC connection is closed from the daemon side. Monitor the channel connection for more info.