### PR TITLE
LVPN-9708: Remove `smoke` mark

### DIFF
--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -44,7 +44,6 @@ def disconnect_base_test():
     assert "nordlynx" not in sh.ip.a() and "nordtun" not in sh.ip.a() and "qtun" not in sh.ip.a()
 
 
-@pytest.mark.smoke
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
 def test_quick_connect(tech, proto, obfuscated):
     """Manual TC: LVPN-559, LVPN-530"""

--- a/test/qa/test_login.py
+++ b/test/qa/test_login.py
@@ -261,7 +261,7 @@ def test_repeated_login_callback_nordvpn_scheme_url():
 
         assert "You're already logged in." in ex.value.stdout.decode("utf-8")
 
-@pytest.mark.smoke
+
 def test_logout_not_connected():
     """
     :details    Verify that app has a possibility to logout


### PR DESCRIPTION
Remove occurrences of `@pytest.mark.smoke`, to avoid warnings after running tests.