### PR TITLE
LVPN-9414: Add RecommendationUuid into connect and disconnect events

### DIFF
--- a/daemon/access/access_disconnect.go
+++ b/daemon/access/access_disconnect.go
@@ -15,6 +15,7 @@ type DisconnectInput struct {
 	Networker                  networker.Networker
 	ConfigManager              config.Manager
 	PublishDisconnectEventFunc func(events.DataDisconnect)
+	RecommendationUUID         string
 }
 
 // Disconnect disconnects the user from the current VPN server. Returning boolean indicates
@@ -47,6 +48,7 @@ func Disconnect(input DisconnectInput) (bool, error) {
 			ThreatProtectionLite: cfg.AutoConnectData.ThreatProtectionLite,
 			Duration:             time.Since(startTime),
 			Error:                err,
+			RecommendationUUID:   input.RecommendationUUID,
 		})
 	}()
 

--- a/daemon/job_servers_test.go
+++ b/daemon/job_servers_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const TestRecommendedUUID string = "c0b4c990-3000-457f-8b81-6850b8cdb54e"
+
 type mockServersAPI struct{}
 
 func (mockServersAPI) Servers() (core.Servers, http.Header, error) {
@@ -39,7 +41,10 @@ func (mockServersAPI) RecommendedServers(filter core.ServersFilter, _ float64, _
 		servers = append(servers, server)
 	}
 
-	return servers, nil, nil
+	header := http.Header{}
+	header.Set("X-Recommendation-Uuid", TestRecommendedUUID)
+
+	return servers, header, nil
 }
 
 func (mockServersAPI) Server(serverID int64) (*core.Server, error) {

--- a/daemon/rpc_disconnect.go
+++ b/daemon/rpc_disconnect.go
@@ -24,10 +24,19 @@ func (r *RPC) Disconnect(_ *pb.Empty, srv pb.Daemon_DisconnectServer) error {
 
 // DoDisconnect is the non-gRPC function for Disconect to be used directly.
 func (r *RPC) DoDisconnect() (bool, error) {
+	var recommendationUUID string
+	// Not sure if it can be nil in the real scenarios
+	if r.connectionInfo != nil {
+		recommendationUUID = r.connectionInfo.Status().RecommendationUUID
+	} else {
+		log.Println(internal.WarningPrefix, "connection info is nil and it shouldn't be")
+	}
+
 	wasConnected, err := access.Disconnect(access.DisconnectInput{
 		Networker:                  r.netw,
 		ConfigManager:              r.cm,
 		PublishDisconnectEventFunc: r.events.Service.Disconnect.Publish,
+		RecommendationUUID:         recommendationUUID,
 	})
 
 	if wasConnected {

--- a/daemon/rpc_set_autoconnect.go
+++ b/daemon/rpc_set_autoconnect.go
@@ -56,7 +56,7 @@ func (r *RPC) SetAutoConnect(ctx context.Context, in *pb.SetAutoconnectRequest) 
 	if in.GetEnabled() {
 		insights := r.dm.GetInsightsData().Insights
 
-		server, _, err := selectServer(r, &insights, cfg, serverTag, serverGroup)
+		serverSelection, err := selectServer(r, &insights, cfg, serverTag, serverGroup)
 		if err != nil {
 			log.Println(internal.ErrorPrefix, "no server found for autoconnect", serverTag, err)
 
@@ -69,7 +69,7 @@ func (r *RPC) SetAutoConnect(ctx context.Context, in *pb.SetAutoconnectRequest) 
 
 			return nil, err
 		}
-		log.Println(internal.InfoPrefix, "server for autoconnect found", server)
+		log.Println(internal.InfoPrefix, "server for autoconnect found", serverSelection.server)
 		parameters = GetServerParameters(serverTag, serverGroup, r.dm.GetCountryData().Countries)
 
 		if err := r.cm.SaveWith(func(c config.Config) config.Config {

--- a/daemon/state/connection_info.go
+++ b/daemon/state/connection_info.go
@@ -102,20 +102,21 @@ func (c *ConnectionInfo) ConnectionStatusNotifyConnect(e events.DataConnect) err
 	}
 
 	status := types.ConnectionStatus{
-		State:             connectionStatus,
-		Technology:        e.Technology,
-		Protocol:          e.Protocol,
-		IP:                e.TargetServerIP,
-		Name:              e.TargetServerName,
-		Hostname:          e.TargetServerDomain,
-		Country:           e.TargetServerCountry,
-		CountryCode:       e.TargetServerCountryCode,
-		City:              e.TargetServerCity,
-		StartTime:         startTime,
-		IsVirtualLocation: e.IsVirtualLocation,
-		IsPostQuantum:     e.IsPostQuantum,
-		IsObfuscated:      e.IsObfuscated,
-		IsMeshnetPeer:     e.IsMeshnetPeer,
+		State:              connectionStatus,
+		Technology:         e.Technology,
+		Protocol:           e.Protocol,
+		IP:                 e.TargetServerIP,
+		Name:               e.TargetServerName,
+		Hostname:           e.TargetServerDomain,
+		Country:            e.TargetServerCountry,
+		CountryCode:        e.TargetServerCountryCode,
+		City:               e.TargetServerCity,
+		StartTime:          startTime,
+		IsVirtualLocation:  e.IsVirtualLocation,
+		IsPostQuantum:      e.IsPostQuantum,
+		IsObfuscated:       e.IsObfuscated,
+		IsMeshnetPeer:      e.IsMeshnetPeer,
+		RecommendationUUID: e.RecommendationUUID,
 	}
 
 	c.setStatus(status, fullyConnected)
@@ -128,9 +129,10 @@ func (c *ConnectionInfo) ConnectionStatusNotifyDisconnect(e events.DataDisconnec
 		return nil
 	}
 	status := types.ConnectionStatus{
-		State:      pb.ConnectionState_DISCONNECTED,
-		TunnelName: "",
-		StartTime:  nil,
+		State:              pb.ConnectionState_DISCONNECTED,
+		TunnelName:         "",
+		StartTime:          nil,
+		RecommendationUUID: "",
 	}
 
 	c.setStatus(status, false)

--- a/daemon/state/connection_info_test.go
+++ b/daemon/state/connection_info_test.go
@@ -87,6 +87,7 @@ func TestConnectionInfo_VerifyDataConnectConversionToConnectionStatus(t *testing
 		IsPostQuantum:           false,
 		IsObfuscated:            true,
 		IsMeshnetPeer:           false,
+		RecommendationUUID:      "c0b4c990-3000-457f-8b81-6850b8cdb54e",
 	}
 
 	go func() {
@@ -113,6 +114,7 @@ func TestConnectionInfo_VerifyDataConnectConversionToConnectionStatus(t *testing
 	assert.Equal(t, event.IsObfuscated, status.IsObfuscated)
 	assert.Equal(t, "", status.TunnelName)
 	assert.Equal(t, event.IsMeshnetPeer, status.IsMeshnetPeer)
+	assert.Equal(t, event.RecommendationUUID, status.RecommendationUUID)
 }
 
 func TestConnectionInfo_VerifyDataDisconnectConversionToConnectionStatus(t *testing.T) {
@@ -133,6 +135,7 @@ func TestConnectionInfo_VerifyDataDisconnectConversionToConnectionStatus(t *test
 	assert.Equal(t, pb.ConnectionState_DISCONNECTED, status.State)
 	assert.False(t, tf.sut.fullyConnected)
 	assert.Nil(t, status.StartTime)
+	assert.Equal(t, status.RecommendationUUID, "")
 }
 
 func TestConnectionInfo_TracksStateProperly(t *testing.T) {

--- a/daemon/state/types/connection_status.go
+++ b/daemon/state/types/connection_status.go
@@ -44,4 +44,6 @@ type ConnectionStatus struct {
 	Rx uint64
 	// Number of bytes uploaded
 	Tx uint64
+	// RecommendationUUID used for analytics purposes
+	RecommendationUUID string
 }

--- a/events/events.go
+++ b/events/events.go
@@ -85,6 +85,7 @@ type DataConnect struct {
 	IsVirtualLocation       bool
 	IsObfuscated            bool
 	IsPostQuantum           bool
+	RecommendationUUID      string
 }
 
 // DataConnectChangeNotif is used to provide notifications for internal listeners of ConnectionStatus
@@ -157,6 +158,7 @@ type DataDisconnect struct {
 	Duration              time.Duration
 	Error                 error
 	IsRefresh             bool
+	RecommendationUUID    string
 }
 
 type ReasonCode int32


### PR DESCRIPTION
RecommendationUuid is returned as a header "X-Recommendation-UUID" by the RecommendedServers API.
When this is available it must be set in the connect events (it has a special field in the event) and in the disconnect events (here it doesn't have a special field so it is added in the context).