### PR TITLE
LVPN-9863: Review and unify overlapping autotests

### DIFF
--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -20,6 +20,9 @@ def autoconnect_base_test(group):
     daemon.wait_for_autoconnect()
     assert network.is_connected()
 
+    status_info = daemon.get_status_data()
+    assert "Connected" in status_info["status"]
+
     output = sh_no_tty.nordvpn.set.autoconnect.off()
     print(output)
     assert settings.MSG_AUTOCONNECT_DISABLE_SUCCESS in output
@@ -111,8 +114,15 @@ def test_autoconnect_to_standard_group(tech, proto, obfuscated, group):
     autoconnect_base_test(group)
 
 
-@pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES_NO_NORDWHISPER)
+@dynamic_parametrize(
+    [
+        "tech", "proto", "obfuscated", "group",
+    ],
+    ordered_source=[lib.STANDARD_TECHNOLOGIES_NO_NORDWHISPER],
+    randomized_source=[lib.ADDITIONAL_GROUPS],
+    generate_all=IS_NIGHTLY,
+    id_pattern="{tech}-{proto}-{obfuscated}-{group}",
+)
 def test_autoconnect_to_additional_group(tech, proto, obfuscated, group):
     """Manual TC: LVPN-6786"""
 
@@ -120,8 +130,15 @@ def test_autoconnect_to_additional_group(tech, proto, obfuscated, group):
     autoconnect_base_test(group)
 
 
-@pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS_NORDWHISPER)
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.NORDWHISPER_TECHNOLOGY)
+@dynamic_parametrize(
+    [
+        "tech", "proto", "obfuscated", "group",
+    ],
+    ordered_source=[lib.NORDWHISPER_TECHNOLOGY],
+    randomized_source=[lib.ADDITIONAL_GROUPS_NORDWHISPER],
+    generate_all=IS_NIGHTLY,
+    id_pattern="{tech}-{proto}-{obfuscated}-{group}",
+)
 def test_nordwhisper_autoconnect_to_additional_group(tech, proto, obfuscated, group):
     """Manual TC: LVPN-6786"""
 

--- a/test/qa/test_combinations.py
+++ b/test/qa/test_combinations.py
@@ -52,13 +52,23 @@ def test_reconnect_matrix(
         source_obfuscated,
         target_obfuscated,
 ):
-    """Manual TC: LVPN-8674"""
-
+    """Manual TC: LVPN-8674, LVPN-8694"""
     lib.set_technology_and_protocol(source_tech, source_proto, source_obfuscated)
     connect_base_test()
 
     lib.set_technology_and_protocol(target_tech, target_proto, target_obfuscated)
     connect_base_test()
+
+    status_info = daemon.get_status_data()
+
+    assert target_tech.upper() in status_info["current technology"]
+
+    if target_tech == "openvpn":
+        assert target_proto.upper() in status_info["current protocol"]
+    elif target_tech == "nordwhisper":
+        assert "Webtunnel" in status_info["current protocol"]
+    else:
+        assert "UDP" in status_info["current protocol"]
 
     disconnect_base_test()
 
@@ -126,47 +136,6 @@ def test_status_change_technology_and_protocol(
     if source_tech == "openvpn":
         assert source_proto.upper() in status_info["current protocol"]
     elif source_tech == "nordwhisper":
-        assert "Webtunnel" in status_info["current protocol"]
-    else:
-        assert "UDP" in status_info["current protocol"]
-
-    disconnect_base_test()
-
-
-@dynamic_parametrize(
-    [
-        "target_tech", "target_proto", "target_obfuscated",
-        "source_tech", "source_proto", "source_obfuscated",
-    ],
-    ordered_source=[lib.STANDARD_TECHNOLOGIES],
-    randomized_source=[lib.STANDARD_TECHNOLOGIES],
-    generate_all=IS_NIGHTLY,
-    id_pattern="{source_tech}-{source_proto}-{source_obfuscated}-"
-              "{target_tech}-{target_proto}-{target_obfuscated}",
-)
-def test_status_change_technology_and_protocol_reconnect(
-        source_tech,
-        target_tech,
-        source_proto,
-        target_proto,
-        source_obfuscated,
-        target_obfuscated,
-):
-    """Manual TC: LVPN-8694"""
-
-    lib.set_technology_and_protocol(source_tech, source_proto, source_obfuscated)
-    sh.nordvpn(get_alias())
-
-    lib.set_technology_and_protocol(target_tech, target_proto, target_obfuscated)
-
-    sh.nordvpn(get_alias())
-    status_info = daemon.get_status_data()
-
-    assert target_tech.upper() in status_info["current technology"]
-
-    if target_tech == "openvpn":
-        assert target_proto.upper() in status_info["current protocol"]
-    elif target_tech == "nordwhisper":
         assert "Webtunnel" in status_info["current protocol"]
     else:
         assert "UDP" in status_info["current protocol"]

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -81,8 +81,15 @@ def test_connect_to_server_random_by_name(tech, proto, obfuscated):
     disconnect_base_test()
 
 
-@pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES_NO_NORDWHISPER)
+@dynamic_parametrize(
+    [
+        "tech", "proto", "obfuscated", "group",
+    ],
+    ordered_source=[lib.STANDARD_TECHNOLOGIES_NO_NORDWHISPER],
+    randomized_source=[lib.ADDITIONAL_GROUPS],
+    generate_all=IS_NIGHTLY,
+    id_pattern="{tech}-{proto}-{obfuscated}-{group}",
+)
 def test_connect_to_group_random_server_by_name_additional(tech, proto, obfuscated, group):
     """Manual TC: LVPN-8847"""
 
@@ -298,8 +305,15 @@ def test_connect_to_flag_group_standard(tech, proto, obfuscated, group):
     assert lib.is_connect_unsuccessful(ex)
 
 
-@pytest.mark.parametrize("group", lib.ADDITIONAL_GROUPS)
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES_NO_NORDWHISPER)
+@dynamic_parametrize(
+    [
+        "tech", "proto", "obfuscated", "group",
+    ],
+    ordered_source=[lib.STANDARD_TECHNOLOGIES_NO_NORDWHISPER],
+    randomized_source=[lib.ADDITIONAL_GROUPS],
+    generate_all=IS_NIGHTLY,
+    id_pattern="{tech}-{proto}-{obfuscated}-{group}",
+)
 def test_connect_to_flag_group_additional(tech, proto, obfuscated, group):
     """Manual TC: LVPN-8615"""
 


### PR DESCRIPTION
- removed 'test_reconnect_matrix' and added its logic to the 'test_status_change_technology_and_protocol_reconnect'
- optimized tests from 'test_connect', 'test_autoconnect', 'test_fileshare' modules
