### PR TITLE
LVPN-9945: Fix skipping of system monitoring

### DIFF
--- a/test/qa/conftest.py
+++ b/test/qa/conftest.py
@@ -121,6 +121,7 @@ def start_system_monitoring():
     if os.getenv("SKIP_SYSTEM_MONITORING"):
         print("Skipping monitoring...")
         yield
+        return
 
     print("Run start_system_monitoring")
 


### PR DESCRIPTION
Forgot to add `return` statement. If we decide to skip system monitoring by specifying `SKIP_SYSTEM_MONITORING` environment variable, test suite fails because of two `yield`'s in a row.