### PR TITLE
LVPN-10004: Fix allowlist not working alongside lan discovery

### DIFF
--- a/networker/allowlist_lan.go
+++ b/networker/allowlist_lan.go
@@ -15,8 +15,7 @@ func addLANPermissions(allowlist config.Allowlist) config.Allowlist {
 		"192.168.0.0/16",
 		"169.254.0.0/16"}
 
-	var newSubnets []string
-	copy(newSubnets, allowlist.Subnets)
+	newSubnets := append([]string{}, allowlist.Subnets...)
 	for _, network := range localNetworks {
 		if !slices.Contains(newSubnets, network) {
 			newSubnets = append(newSubnets, network)

--- a/test/qa/test_firewall.py
+++ b/test/qa/test_firewall.py
@@ -277,3 +277,22 @@ def test_firewall_lan_allowlist_interaction(tech, proto, obfuscated):
             rules = os.popen("sudo iptables -S POSTROUTING").read()
             for rule in firewall.POSTROUTING_LAN_DISCOVERY_RULES:
                 assert rule not in rules, f"{rule} postrouting rule not found in iptables"
+
+
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)
+def test_firewall_lan_allowlist_work_together(tech, proto, obfuscated):
+    """Manual TC: LVPN-10010"""
+
+    with lib.Defer(lambda: sh.nordvpn.set("lan-discovery", "off", _ok_code=(0, 1))):
+        with lib.Defer(sh.nordvpn.disconnect):
+            subnet = "1.1.1.1/32"
+            with lib.Defer(lambda: sh.nordvpn.allowlist.remove.subnet(subnet, _ok_code=(0, 1))):
+
+                lib.set_technology_and_protocol(tech, proto, obfuscated)
+                pre_allow_out = sh.ip.route.get("1.1.1.1")
+
+                sh.nordvpn.allowlist.add.subnet(subnet)
+                sh.nordvpn.set("lan-discovery", "on")
+                sh.nordvpn.connect()
+                assert pre_allow_out == sh.ip.route.get("1.1.1.1"), "Allowlisted subnet is not going through default interface"
+                assert pre_allow_out != sh.ip.route.get("1.0.0.1")


### PR DESCRIPTION
The issue was that the array that the existing were supposed to be copied into was not initialized, which meant if lan discovery was on, it would instead overwrite the allowlist instead of appending the lan networks to it