### PR TITLE
LVPN-9811: Use EnableECH feature in NordWhisper

### DIFF
--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -18,4 +18,4 @@ jobs:
       project-id: ${{ secrets.PROJECT_ID }}
     with:
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v1.4.9
+      triggered-ref: v1.5.0

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -327,7 +327,8 @@ func main() {
 	buildTarget := config.BuildTarget{
 		Version:      Version,
 		Environment:  Environment,
-		Architecture: Arch}
+		Architecture: Arch,
+	}
 	if archVariant, err := machineIdGenerator.GetArchitectureVariantName(sysinfo.GetHostArchitecture()); err == nil {
 		buildTarget.Architecture = archVariant
 	}
@@ -373,17 +374,25 @@ func main() {
 	// try to load config from disk if it was previously downloaded
 	rcConfig.TryPreload()
 
-	vpnLibConfigGetter := vpnLibConfigGetterImplementation(fsystem, rcConfig)
+	vpnLibtelioConfigGetter := vpnLibtelioConfigGetterImplementation(fsystem, rcConfig)
+	vpnNordWhisperConfigGetter := vpnNordWhisperConfigGetterImplementation(fsystem, rcConfig)
 
 	internalVpnEvents := vpn.NewInternalVPNEvents()
 
 	// Networker
-	vpnFactory := getVpnFactory(eventsDbPath, cfg.FirewallMark,
-		internal.IsDevEnv(Environment), vpnLibConfigGetter, Version, internalVpnEvents)
+	vpnFactory := getVpnFactory(
+		eventsDbPath,
+		cfg.FirewallMark,
+		internal.IsDevEnv(Environment),
+		vpnLibtelioConfigGetter,
+		vpnNordWhisperConfigGetter,
+		Version,
+		internalVpnEvents,
+	)
 
 	vpn, err := vpnFactory(cfg.Technology)
 	if err != nil {
-		// if NordWhiser was disabled we'll fall back automatically to NordLynx if autoconnect is enabled or tell user
+		// if NordWhisper was disabled we'll fall back automatically to NordLynx if autoconnect is enabled or tell user
 		// to switch to a different tech
 		if !errors.Is(err, ErrNordWhisperDisabled) {
 			log.Fatalln(err)

--- a/cmd/daemon/vpn_factory.go
+++ b/cmd/daemon/vpn_factory.go
@@ -13,17 +13,23 @@ import (
 
 var ErrNordWhisperDisabled = errors.New("NordWhisper technology was disabled in compile time")
 
-func getVpnFactory(eventsDbPath string, fwmark uint32, envIsDev bool,
-	cfg vpn.LibConfigGetter, appVersion string, eventsPublisher *vpn.Events,
+func getVpnFactory(
+	eventsDbPath string,
+	fwmark uint32,
+	envIsDev bool,
+	libtelioCfg vpn.LibConfigGetter,
+	libquenchCfg vpn.NordWhisperConfigGetter,
+	appVersion string,
+	eventsPublisher *vpn.Events,
 ) daemon.FactoryFunc {
-	nordlynxVPN, nordLynxErr := getNordlynxVPN(envIsDev, eventsDbPath, fwmark, cfg, appVersion, eventsPublisher)
+	nordlynxVPN, nordLynxErr := getNordlynxVPN(envIsDev, eventsDbPath, fwmark, libtelioCfg, appVersion, eventsPublisher)
 	if nordLynxErr != nil {
 		// don't exit with `err` here in case the factory will be called with
 		// technology different than `config.Technology_NORDLYNX`
 		log.Println(internal.ErrorPrefix, "getting NordLynx vpn:", nordLynxErr)
 	}
 
-	nordWhisperVPN, nordWhisperErr := getNordWhisperVPN(fwmark, envIsDev, eventsPublisher)
+	nordWhisperVPN, nordWhisperErr := getNordWhisperVPN(fwmark, envIsDev, eventsPublisher, libquenchCfg)
 	if nordWhisperErr != nil {
 		log.Println(internal.ErrorPrefix, "getting NordWhisper vpn:", nordWhisperErr)
 	}

--- a/cmd/daemon/vpn_no_quench.go
+++ b/cmd/daemon/vpn_no_quench.go
@@ -9,7 +9,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/tunnel"
 )
 
-func getNordWhisperVPN(fwmark uint32, _ bool, _ *vpn.Events) (vpn.VPN, error) {
+func getNordWhisperVPN(fwmark uint32, _ bool, _ *vpn.Events, _ vpn.NordWhisperConfigGetter) (vpn.VPN, error) {
 	return noopNordWhisper{}, ErrNordWhisperDisabled
 }
 

--- a/cmd/daemon/vpn_quench.go
+++ b/cmd/daemon/vpn_quench.go
@@ -7,6 +7,11 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/vpn/quench"
 )
 
-func getNordWhisperVPN(fwmark uint32, envIsDev bool, events *vpn.Events) (*quench.Quench, error) {
-	return quench.New(fwmark, envIsDev, events), nil
+func getNordWhisperVPN(
+	fwmark uint32,
+	envIsDev bool,
+	events *vpn.Events,
+	cfg vpn.NordWhisperConfigGetter,
+) (*quench.Quench, error) {
+	return quench.New(fwmark, envIsDev, events, cfg), nil
 }

--- a/cmd/daemon/vpnconfig_no_telio.go
+++ b/cmd/daemon/vpnconfig_no_telio.go
@@ -16,6 +16,6 @@ func (noopConfigGetter) GetConfig() (string, error) {
 	return "", fmt.Errorf("config is not available")
 }
 
-func vpnLibConfigGetterImplementation(_ config.Manager, _ remote.ConfigGetter) vpn.LibConfigGetter {
+func vpnLibtelioConfigGetterImplementation(_ config.Manager, _ remote.ConfigGetter) vpn.LibConfigGetter {
 	return noopConfigGetter{}
 }

--- a/cmd/daemon/vpnconfig_no_whisper.go
+++ b/cmd/daemon/vpnconfig_no_whisper.go
@@ -1,0 +1,19 @@
+//go:build !quench
+
+package main
+
+import (
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
+)
+
+type noopNordWhisperConfigGetter struct{}
+
+func (noopNordWhisperConfigGetter) GetConfig() (vpn.NordWhisperFeatureConfig, error) {
+	return vpn.NewNordWhisperFeatureConfig(), nil
+}
+
+func vpnNordWhisperConfigGetterImplementation(_ config.Manager, _ remote.ConfigGetter) vpn.NordWhisperConfigGetter {
+	return noopNordWhisperConfigGetter{}
+}

--- a/cmd/daemon/vpnconfig_telio.go
+++ b/cmd/daemon/vpnconfig_telio.go
@@ -9,6 +9,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/vpn/nordlynx/libtelio"
 )
 
-func vpnLibConfigGetterImplementation(cm config.Manager, rcConfig remote.ConfigGetter) vpn.LibConfigGetter {
+func vpnLibtelioConfigGetterImplementation(cm config.Manager, rcConfig remote.ConfigGetter) vpn.LibConfigGetter {
 	return libtelio.NewTelioConfig(rcConfig.GetTelioConfig)
 }

--- a/cmd/daemon/vpnconfig_whisper.go
+++ b/cmd/daemon/vpnconfig_whisper.go
@@ -1,0 +1,14 @@
+//go:build quench
+
+package main
+
+import (
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
+	"github.com/NordSecurity/nordvpn-linux/daemon/vpn/quench"
+)
+
+func vpnNordWhisperConfigGetterImplementation(cm config.Manager, rcConfig remote.ConfigGetter) vpn.NordWhisperConfigGetter {
+	return quench.NewNordWhisperConfig(rcConfig)
+}

--- a/config/remote/constants.go
+++ b/config/remote/constants.go
@@ -58,9 +58,10 @@ func (e EventType) String() string {
 }
 
 const (
-	FeatureMain     = "nordvpn"
-	FeatureLibtelio = "libtelio"
-	FeatureMeshnet  = "meshnet"
+	FeatureMain        = "nordvpn"
+	FeatureLibtelio    = "libtelio"
+	FeatureMeshnet     = "meshnet"
+	FeatureNordWhisper = "nordwhisper"
 )
 
 const (

--- a/config/remote/remote.go
+++ b/config/remote/remote.go
@@ -147,6 +147,7 @@ func NewCdnRemoteConfig(buildTarget config.BuildTarget, remotePath, localPath st
 	rc.features.add(FeatureMain)
 	rc.features.add(FeatureLibtelio)
 	rc.features.add(FeatureMeshnet)
+	rc.features.add(FeatureNordWhisper)
 	return rc
 }
 

--- a/daemon/vpn/libconfig.go
+++ b/daemon/vpn/libconfig.go
@@ -4,3 +4,20 @@ package vpn
 type LibConfigGetter interface {
 	GetConfig() (string, error)
 }
+
+// NordWhisperFeatureConfig defines the features available for NordWhisper
+type NordWhisperFeatureConfig struct {
+	EnableECH bool
+}
+
+// NewNordWhisperFeatureConfig builds the default feature configuration for NordWhisper
+func NewNordWhisperFeatureConfig() NordWhisperFeatureConfig {
+	return NordWhisperFeatureConfig{
+		EnableECH: true,
+	}
+}
+
+// NordWhisperConfigGetter is interface to acquire config for NordWhisper vpn implementation
+type NordWhisperConfigGetter interface {
+	GetConfig() (NordWhisperFeatureConfig, error)
+}

--- a/daemon/vpn/quench/config.go
+++ b/daemon/vpn/quench/config.go
@@ -2,8 +2,16 @@
 
 package quench
 
+import (
+	"strconv"
+
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
+)
+
 type Spec struct {
 	TlsDomain string `json:"tls_domain"`
+	EnableECH bool   `json:"enable_ech"`
 }
 
 type Protocol struct {
@@ -13,4 +21,34 @@ type Protocol struct {
 
 type Config struct {
 	Protocol Protocol `json:"protocol"`
+}
+
+// NordWhisperConfig is responsible with fetching the remote configuration for NordWhisper
+type NordWhisperConfig struct {
+	remoteConfigGetter remote.ConfigGetter
+}
+
+// NewNordWhisperConfig builds a NordWhisperConfig struct
+func NewNordWhisperConfig(rc remote.ConfigGetter) *NordWhisperConfig {
+	return &NordWhisperConfig{
+		remoteConfigGetter: rc,
+	}
+}
+
+// GetConfig is the implementation of NordWhisperConfigGetter interface
+// It fetches the remote config for NordWhisper
+func (qc *NordWhisperConfig) GetConfig() (vpn.NordWhisperFeatureConfig, error) {
+	enableECHParam, err := qc.remoteConfigGetter.GetFeatureParam(remote.FeatureNordWhisper, "enable_ech")
+	if err != nil {
+		return vpn.NewNordWhisperFeatureConfig(), err
+	}
+
+	enableECH, err := strconv.ParseBool(enableECHParam)
+	if err != nil {
+		return vpn.NewNordWhisperFeatureConfig(), err
+	}
+
+	return vpn.NordWhisperFeatureConfig{
+		EnableECH: enableECH,
+	}, nil
 }


### PR DESCRIPTION
@dfetti update:
The feature setting is fetched from the remote config. If fetching fails, we default it to true.

I tried to keep as much as I could from the libtelio approach to make it easier to add features in the future. There are no tests yet. I just tested it manually.