### PR TITLE
Add RISC-V 64 bit target.

### DIFF
--- a/ci/archs.sh
+++ b/ci/archs.sh
@@ -7,6 +7,7 @@ if [[ ! "${ARCHS:-}" ]]; then
         armel
         armhf
         aarch64
+        riscv64
     )
 fi
 
@@ -23,6 +24,7 @@ declare -A ARCHS_REVERSE=(
     [armv7_eabihf]=armhf
     [arm64]=aarch64
     [aarch64]=aarch64
+    [riscv64]=riscv64
 )
 
 # Key is one of ARCHS
@@ -32,6 +34,7 @@ declare -A ARCHS_DEB=(
     [armel]=armel
     [armhf]=armhf
     [aarch64]=arm64
+    [riscv64]=riscv64
 )
 
 # Key is one of ARCHS
@@ -41,6 +44,7 @@ declare -A ARCHS_RPM=(
     [armel]=armv5l
     [armhf]=armhfp
     [aarch64]=aarch64
+    [riscv64]=riscv64
 )
 
 # Key is one of ARCHS
@@ -50,6 +54,7 @@ declare -A ARCHS_GO=(
     [armel]=arm
     [armhf]=arm
     [aarch64]=arm64
+    [riscv64]=riscv64
 )
 
 # for .so files comming from libtelio, libdrop and libmoose
@@ -63,6 +68,7 @@ declare -A ARCHS_SO_REVERSE=(
     [armv7hf]=armhf
     [armv7]=armhf
     [armv7_eabihf]=armhf
+    [riscv64]=riscv64
 )
 
 declare -A ARCHS_RUST=(
@@ -71,12 +77,14 @@ declare -A ARCHS_RUST=(
     [armel]=armel
     [armhf]=armhf
     [aarch64]=arm64
+    [riscv64]=riscv64
 )
 
 # Key is one of ARCHS
 declare -A ARCHS_FLUTTER=(
     [amd64]=x64
     [aarch64]=arm64
+    [riscv64]=riscv64
 )
 
 export ARCHS

--- a/ci/build_rust.sh
+++ b/ci/build_rust.sh
@@ -10,6 +10,7 @@ declare -A targets=(
   [arm64]=aarch64-unknown-linux-gnu
   [armhf]=armv7-unknown-linux-gnueabihf
   [armel]=arm-unknown-linux-gnueabi
+  [riscv64]=riscv64gc-unknown-linux-gnu
 )
 
 function clone_if_absent() {

--- a/ci/compile.sh
+++ b/ci/compile.sh
@@ -38,6 +38,7 @@ declare -A cross_compiler_map=(
     [armel]=arm-linux-gnueabi-gcc
     [armhf]=arm-linux-gnueabihf-gcc
     [aarch64]=aarch64-linux-gnu-gcc
+    [riscv64]=riscv64-linux-gnu-gcc
 )
 
 # Required by Go when cross-compiling

--- a/ci/openvpn/build.sh
+++ b/ci/openvpn/build.sh
@@ -64,6 +64,7 @@ declare -A cross_compiler_map=(
     [amd64]=x86_64-linux-gnu-gcc
     [armel]=arm-linux-gnueabi-gcc
     [armhf]=arm-linux-gnueabihf-gcc
+    [riscv64]=riscv64-linux-gnu-gcc
     [aarch64]=aarch64-linux-gnu-gcc
 )
 


### PR DESCRIPTION
Add riscv64 target. Tested on [deepcomputing framework laptop](https://deepcomputing.io/product/dc-roma-risc-v-ai-pc/).