### PR TITLE
LVPN-9970: Fix calculateRulePriority logic (#1348)

### DIFF
--- a/daemon/routes/iprule/iprule.go
+++ b/daemon/routes/iprule/iprule.go
@@ -226,7 +226,7 @@ func (r *Router) TableID() uint {
 	return r.tableID
 }
 
-// calculateRulePriority find out what priority id to use for Fwmark rule
+// calculateRulePriority find out what priority id to use for a new rule
 //
 // On some environments already existing IP rules can exist with very high priority
 // (close to 0) and our rules do not fit into ip rules table. E. g.
@@ -238,7 +238,7 @@ func (r *Router) TableID() uint {
 //
 // If NordVPN tries to create 3 new rules, by default `ip rule` behaviour they will
 // appear with `1`, `0`, and `0` priorities. This creates conflicts between highest
-// priorities rules and traffic may become unpredictable. Therefore, NordVPN would
+// priorities rules and traffic may become unpredictable. Therefore, NordVPN should
 // shift rule with priority `2` to as many levels as we need. E. g. `ip rule` output
 // with VPN connected would result in such ip rule table:
 //
@@ -249,6 +249,8 @@ func (r *Router) TableID() uint {
 // 4:      from 1.1.1.1 lookup main # problematic rule
 // 32766:  from all lookup main
 // 32767:  from all lookup default
+// For now we don't do that. We will return the highest prio (lowest value) closer to
+// main rule (from all lookup main). In the above case 32765. We need to rethink this mechanism.
 func calculateRulePriority() (uint, error) {
 	// # get rule priority:
 	// CDM "ip rule show" PARSE OUTPUT, LOOKUP "from all lookup main":
@@ -258,25 +260,27 @@ func calculateRulePriority() (uint, error) {
 	// 32767:	from all lookup default
 	// # EXPECTED RESULT: 32766 - 1 = 32765 (check if priority/id is not in use)
 
-	var prioID uint
-
 	rules, err := netlink.RuleList(netlink.FAMILY_V4)
 	if err != nil {
 		return 0, fmt.Errorf("listing ip rules: %w", err)
 	}
+	return findRulePriorityCandidate(rules)
+}
+
+func findRulePriorityCandidate(rules []netlink.Rule) (uint, error) {
+	prioID := uint(0)
+
 	allID := make(map[uint]bool, len(rules))
 
 	for _, rule := range rules {
-		mainRule := netlink.NewRule()
-		mainRule.Table = unix.RT_TABLE_MAIN
 		allID[uint(rule.Priority)] = true // #nosec G115
-		if isRuleSame(rule, *mainRule) {
-			continue
+		prioID = uint(rule.Priority)      // #nosec G115
+		if isFromAllLookupMainRule(rule) {
+			break
 		}
-		prioID = uint(rule.Priority) // #nosec G115
 	}
 
-	if prioID == 0 {
+	if prioID == 0 || prioID > math.MaxInt {
 		return 0, fmt.Errorf("unable to calculate ip rule priority id")
 	}
 
@@ -290,6 +294,8 @@ func calculateRulePriority() (uint, error) {
 			break
 		}
 	}
+
+	log.Println(internal.InfoPrefix, "Selected candidate for new rule priority: ", prioID)
 	return prioID, nil
 }
 
@@ -479,6 +485,19 @@ func isRuleSame(rule netlink.Rule, target netlink.Rule) bool {
 		rule.Table == target.Table &&
 		(rule.SuppressIfgroup == target.SuppressIfgroup ||
 			rule.SuppressPrefixlen == target.SuppressPrefixlen)
+}
+
+// isFromAllLookupMainRule checks if the rule is the "from all lookup main"
+func isFromAllLookupMainRule(rule netlink.Rule) bool {
+	return rule.Table == unix.RT_TABLE_MAIN &&
+		rule.Src == nil && // from all
+		rule.Dst == nil &&
+		rule.Mark == -1 &&
+		rule.IifName == "" &&
+		rule.OifName == "" &&
+		rule.SuppressIfgroup == -1 &&
+		rule.SuppressPrefixlen == -1 &&
+		!rule.Invert
 }
 
 func allowSubnetRule(prioID int, subnet *net.IPNet) *netlink.Rule {

--- a/daemon/routes/iprule/iprule_test.go
+++ b/daemon/routes/iprule/iprule_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -246,5 +247,200 @@ func TestAddAllowlistRules(t *testing.T) {
 	for ruleIndex, rule := range rulesBeforeAdd {
 		assert.Equal(t, rule, rulesAfterRemove[ruleIndex],
 			"IP rules were not restored to the previous state after removal.")
+	}
+}
+
+func rule(opts ...func(*netlink.Rule)) netlink.Rule {
+	r := netlink.NewRule()
+	for _, opt := range opts {
+		opt(r)
+	}
+	return *r
+}
+
+func withPriority(p int) func(*netlink.Rule) {
+	return func(r *netlink.Rule) {
+		r.Priority = p
+	}
+}
+
+func withTable(t int) func(*netlink.Rule) {
+	return func(r *netlink.Rule) {
+		r.Table = t
+	}
+}
+
+func withMark(m int) func(*netlink.Rule) {
+	return func(r *netlink.Rule) {
+		r.Mark = m
+	}
+}
+
+func withCloudflareSource() func(*netlink.Rule) {
+	ipNet := &net.IPNet{
+		IP:   net.ParseIP("1.1.1.1"),
+		Mask: net.CIDRMask(32, 32),
+	}
+	return func(r *netlink.Rule) {
+		r.Src = ipNet
+	}
+}
+
+func TestFindRulePriorityCandidate(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name        string
+		rules       []netlink.Rule
+		expectError bool
+		expectedID  uint
+	}{
+		{
+			name: "misconfig only local rule",
+			rules: []netlink.Rule{
+				// The version of netlink used by us returns -1 instead of 0 for local rule
+				rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+			},
+			expectError: true,
+		},
+		{
+			name: "misconfig main rule with too high priority",
+			rules: []netlink.Rule{
+				rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+				rule(withPriority(1), withTable(unix.RT_TABLE_MAIN)),
+			},
+			expectError: true,
+		},
+		{
+			name: "local and main rules",
+			rules: []netlink.Rule{
+				rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+				rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN)),
+			},
+			expectError: false,
+			expectedID:  32765,
+		},
+		{
+			name: "local main and default rules",
+			rules: []netlink.Rule{
+				rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+				rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN)),
+				rule(withPriority(32767), withTable(unix.RT_TABLE_DEFAULT)),
+			},
+			expectError: false,
+			expectedID:  32765,
+		},
+		{
+			name: "different configs 1",
+			rules: []netlink.Rule{
+				rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+				rule(withPriority(2), withTable(unix.RT_TABLE_MAIN), withCloudflareSource()),
+				rule(withPriority(3), withTable(200), withCloudflareSource()),
+				rule(withPriority(4), withTable(unix.RT_TABLE_MAIN), withMark(0xAA)),
+
+				rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN)),
+				rule(withPriority(32767), withTable(unix.RT_TABLE_DEFAULT)),
+			},
+			expectError: false,
+			expectedID:  32765,
+		},
+		{
+			name: "different configs 2",
+			rules: []netlink.Rule{
+				rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+				rule(withPriority(2), withTable(unix.RT_TABLE_MAIN), withCloudflareSource()),
+				rule(withPriority(3), withTable(200), withCloudflareSource()),
+				rule(withPriority(4), withTable(unix.RT_TABLE_MAIN), withMark(0xAA)),
+
+				rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN)),
+				rule(withPriority(32767), withTable(unix.RT_TABLE_DEFAULT)),
+
+				rule(withPriority(32770), withTable(unix.RT_TABLE_MAIN), withMark(0xBB)),
+			},
+			expectError: false,
+			expectedID:  32765,
+		},
+		{
+			name: "different configs 3",
+			rules: []netlink.Rule{
+				rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+				rule(withPriority(2), withTable(unix.RT_TABLE_MAIN), withCloudflareSource()),
+				rule(withPriority(3), withTable(200), withCloudflareSource()),
+				rule(withPriority(4), withTable(unix.RT_TABLE_MAIN), withMark(0xAA)),
+
+				rule(withPriority(32764), withTable(unix.RT_TABLE_MAIN), withMark(0xAB)),
+				rule(withPriority(32765), withTable(unix.RT_TABLE_MAIN), withMark(0xAC)),
+				rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN)),
+				rule(withPriority(32767), withTable(unix.RT_TABLE_DEFAULT)),
+
+				rule(withPriority(32770), withTable(unix.RT_TABLE_MAIN), withMark(0xBB)),
+			},
+			expectError: false,
+			expectedID:  32763,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := findRulePriorityCandidate(tt.rules)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedID, id)
+			}
+		})
+	}
+}
+
+func TestIsFromAllLookupMainRule(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name     string
+		testRule netlink.Rule
+		expected bool
+	}{
+		{
+			name:     "main rule",
+			testRule: rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN)),
+			expected: true,
+		},
+		{
+			name:     "main rule with different priority",
+			testRule: rule(withPriority(100), withTable(unix.RT_TABLE_MAIN)),
+			expected: true,
+		},
+		{
+			name:     "different rule 1",
+			testRule: rule(withPriority(-1), withTable(unix.RT_TABLE_LOCAL)),
+			expected: false,
+		},
+		{
+			name:     "different rule 2",
+			testRule: rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN), withCloudflareSource()),
+			expected: false,
+		},
+		{
+			name:     "different rule 3",
+			testRule: rule(withPriority(32766), withTable(unix.RT_TABLE_MAIN), withMark(0xAA)),
+			expected: false,
+		},
+		{
+			name:     "different rule 4",
+			testRule: rule(withPriority(100), withTable(unix.RT_TABLE_MAIN), withCloudflareSource()),
+			expected: false,
+		},
+		{
+			name:     "different rule 5",
+			testRule: rule(withPriority(32766), withTable(unix.RT_TABLE_DEFAULT), withCloudflareSource()),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isFromAllLookupMainRule(tt.testRule))
+		})
 	}
 }


### PR DESCRIPTION
Cherry-pick the changes from the release branch. They were reviewed and tested in this [PR](https://github.com/NordSecurity/nordvpn-linux/pull/1348)