### PR TITLE
LVPN-10168: Fix token renew race condition

### DIFF
--- a/core/smart_client_api.go
+++ b/core/smart_client_api.go
@@ -42,7 +42,9 @@ func callWithToken[T any](store session.TokenSessionStore, call func(token strin
 	}
 
 	if errors.Is(err, ErrUnauthorized) {
-		if err := store.Renew(); err != nil {
+		// Force renewal to avoid retrying with a server-invalidated token,
+		// which would cause an unnecessary logout.
+		if err := store.Renew(session.ForceRenewal()); err != nil {
 			var zero T
 			return zero, err
 		}

--- a/session/access_token_session_store.go
+++ b/session/access_token_session_store.go
@@ -3,6 +3,7 @@ package session
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -33,6 +34,7 @@ type AccessTokenSessionStore struct {
 	cfgManager         config.Manager
 	errHandlerRegistry *internal.ErrorHandlingRegistry[error]
 	renewAPICall       AccessTokenRenewalAPICall
+	renewMu            sync.Mutex
 }
 
 // NewAccessTokenSessionStore creates a new AccessTokenSessionStore instance
@@ -58,17 +60,39 @@ func (s *AccessTokenSessionStore) Renew(opts ...RenewalOption) error {
 		opt(&options)
 	}
 
+	// check if renewal is needed (without lock)
 	if !options.forceRenewal {
-		err := s.validate()
-		if err == nil {
+		if err := s.validate(); err == nil {
 			return nil
-		}
-
-		// [special case] without correct renewal token we cannot renew the access token
-		// we need to trigger error handlers directly without going through the normal flow
-		// to handle this case
-		if errors.Is(err, ErrInvalidRenewToken) {
+		} else if errors.Is(err, ErrInvalidRenewToken) {
 			return s.HandleError(err)
+		}
+	}
+
+	// manual tokens cannot be renewed
+	if s.isManualToken() {
+		return nil
+	}
+
+	s.renewMu.Lock()
+	defer s.renewMu.Unlock()
+
+	return s.doRenew(options)
+}
+
+// isManualToken returns true if the current token is a manually generated token.
+// Manual tokens cannot be renewed via API.
+func (s *AccessTokenSessionStore) isManualToken() bool {
+	cfg, err := s.getConfig()
+	return err == nil && cfg.ExpiresAt.Equal(ManualAccessTokenExpiryDate)
+}
+
+// doRenew performs the actual token renewal
+func (s *AccessTokenSessionStore) doRenew(options renewalOptions) error {
+	// re-check after acquiring lock - another goroutine may have renewed
+	if !options.forceRenewal {
+		if err := s.validate(); err == nil {
+			return nil
 		}
 	}
 
@@ -221,6 +245,7 @@ func (s *AccessTokenSessionStore) getConfig() (accessTokenConfig, error) {
 
 	expiryTime, err := time.Parse(internal.ServerDateFormat, data.TokenExpiry)
 	if err != nil {
+		log.Printf("[auth] %s Error parsing token expiry time [%s]: %v\n", internal.WarningPrefix, data.TokenExpiry, err)
 		expiryTime = time.Now().Add(-1 * time.Second)
 	}
 

--- a/session/access_token_session_store.go
+++ b/session/access_token_session_store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -35,6 +36,9 @@ type AccessTokenSessionStore struct {
 	errHandlerRegistry *internal.ErrorHandlingRegistry[error]
 	renewAPICall       AccessTokenRenewalAPICall
 	renewMu            sync.Mutex
+	// renewalCounter is incremented after every successful token renewal to detect
+	// whether a concurrent goroutine already completed a renewal.
+	renewalCounter atomic.Uint64
 }
 
 // NewAccessTokenSessionStore creates a new AccessTokenSessionStore instance
@@ -74,10 +78,15 @@ func (s *AccessTokenSessionStore) Renew(opts ...RenewalOption) error {
 		return nil
 	}
 
+	// Capture the current renewal counter before acquiring the lock.
+	// Used to detect whether a concurrent goroutine already completed
+	// a renewal while we were waiting.
+	renewalCounterSnapshot := s.renewalCounter.Load()
+
 	s.renewMu.Lock()
 	defer s.renewMu.Unlock()
 
-	return s.doRenew(options)
+	return s.doRenew(options, renewalCounterSnapshot)
 }
 
 // isManualToken returns true if the current token is a manually generated token.
@@ -87,13 +96,20 @@ func (s *AccessTokenSessionStore) isManualToken() bool {
 	return err == nil && cfg.ExpiresAt.Equal(ManualAccessTokenExpiryDate)
 }
 
-// doRenew performs the actual token renewal
-func (s *AccessTokenSessionStore) doRenew(options renewalOptions) error {
-	// re-check after acquiring lock - another goroutine may have renewed
+// doRenew performs the actual token renewal.
+func (s *AccessTokenSessionStore) doRenew(
+	options renewalOptions,
+	renewalCounterSnapshot uint64,
+) error {
+	// re-check after acquiring lock - another goroutine may have already renewed.
 	if !options.forceRenewal {
 		if err := s.validate(); err == nil {
 			return nil
 		}
+	} else if s.renewalCounter.Load() != renewalCounterSnapshot {
+		// The counter advanced while we waited, meaning a concurrent goroutine
+		// already completed the renewal. No need to call the API again.
+		return nil
 	}
 
 	var cfg config.Config
@@ -208,6 +224,7 @@ func (s *AccessTokenSessionStore) renewToken(
 		return fmt.Errorf("saving access token data: %w", err)
 	}
 
+	s.renewalCounter.Add(1)
 	return nil
 }
 

--- a/session/access_token_session_store_race_test.go
+++ b/session/access_token_session_store_race_test.go
@@ -2,6 +2,7 @@ package session_test
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -21,16 +22,23 @@ import (
 type raceConditionRenewalAPI struct {
 	mu                sync.Mutex
 	currentRenewToken string
-	requestDelay      time.Duration
-	callCount         atomic.Int32
-	successCount      atomic.Int32
-	failCount         atomic.Int32
+	// apiEnteredCh is sent when Renew is first entered.
+	// This let's to know that the first goroutine holds the renewal lock
+	// and is blocked inside the API call, giving remaining goroutines time to
+	// pile up at the mutex before the API call is released.
+	apiEnteredCh chan struct{}
+	// allowProceedCh is closed by the test to unblock the API call.
+	allowProceedCh chan struct{}
+	callCount      atomic.Int32
+	successCount   atomic.Int32
+	failCount      atomic.Int32
 }
 
 func newRaceConditionRenewalAPI(initialRenewToken string) *raceConditionRenewalAPI {
 	return &raceConditionRenewalAPI{
 		currentRenewToken: initialRenewToken,
-		requestDelay:      50 * time.Millisecond,
+		apiEnteredCh:      make(chan struct{}, 1),
+		allowProceedCh:    make(chan struct{}),
 	}
 }
 
@@ -38,7 +46,16 @@ var ErrRenewTokenNotFound = internal.NewCodedError(101202, "Renew token not foun
 
 func (api *raceConditionRenewalAPI) Renew(token string, idempotencyKey uuid.UUID) (*session.AccessTokenResponse, error) {
 	api.callCount.Add(1)
-	time.Sleep(api.requestDelay)
+
+	// Signal that the API has been entered (non-blocking; only the first call matters).
+	select {
+	case api.apiEnteredCh <- struct{}{}:
+	default:
+	}
+
+	// Block until the test releases. This ensures that goroutines blocked at
+	// the renewal mutex have a chance to pile up before the first renewal completes.
+	<-api.allowProceedCh
 
 	api.mu.Lock()
 	defer api.mu.Unlock()
@@ -100,15 +117,19 @@ func TestAccessTokenSessionStore_RaceCondition_MutexFix(t *testing.T) {
 	const numGoroutines = 5
 	var wg sync.WaitGroup
 	renewErrors := make([]error, numGoroutines)
+	startGate := make(chan struct{})
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			renewErrors[idx] = store.Renew()
-		}(i)
+	for i := range numGoroutines {
+		wg.Go(func() {
+			<-startGate
+			renewErrors[i] = store.Renew()
+		})
 	}
 
+	close(startGate)          // release all goroutines simultaneously
+	<-api.apiEnteredCh        // wait for G1 to enter the API call (holding the renewal mutex)
+	runtime.Gosched()         // yield so G2-5 can reach renewMu.Lock() while G1 is still blocked
+	close(api.allowProceedCh) // release the blocked API call
 	wg.Wait()
 
 	t.Logf("API call count: %d", api.callCount.Load())
@@ -211,15 +232,19 @@ func TestAccessTokenSessionStore_RaceCondition_WithExpiredToken(t *testing.T) {
 
 	const numGoroutines = 5
 	var wg sync.WaitGroup
+	startGate := make(chan struct{})
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(int) {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
+			<-startGate
 			_ = store.Renew()
-		}(i)
+		})
 	}
 
+	close(startGate)
+	<-api.apiEnteredCh
+	runtime.Gosched() // yield so G2-5 can reach renewMu.Lock() while G1 is still blocked
+	close(api.allowProceedCh)
 	wg.Wait()
 
 	t.Logf("API call count: %d", api.callCount.Load())

--- a/session/access_token_session_store_race_test.go
+++ b/session/access_token_session_store_race_test.go
@@ -1,0 +1,232 @@
+package session_test
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/core"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/session"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// raceConditionRenewalAPI simulates server behavior where using an old renewToken returns 404.
+type raceConditionRenewalAPI struct {
+	mu                sync.Mutex
+	currentRenewToken string
+	requestDelay      time.Duration
+	callCount         atomic.Int32
+	successCount      atomic.Int32
+	failCount         atomic.Int32
+}
+
+func newRaceConditionRenewalAPI(initialRenewToken string) *raceConditionRenewalAPI {
+	return &raceConditionRenewalAPI{
+		currentRenewToken: initialRenewToken,
+		requestDelay:      50 * time.Millisecond,
+	}
+}
+
+var ErrRenewTokenNotFound = internal.NewCodedError(101202, "Renew token not found", core.ErrNotFound)
+
+func (api *raceConditionRenewalAPI) Renew(token string, idempotencyKey uuid.UUID) (*session.AccessTokenResponse, error) {
+	api.callCount.Add(1)
+	time.Sleep(api.requestDelay)
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+
+	if token != api.currentRenewToken {
+		api.failCount.Add(1)
+		return nil, ErrRenewTokenNotFound
+	}
+
+	api.successCount.Add(1)
+	u := uuid.New()
+	newRenewToken := fmt.Sprintf("%x%x", u[:], u[:4])[:40]
+	api.currentRenewToken = newRenewToken
+
+	return &session.AccessTokenResponse{
+		Token:      "ab78bb36299d442fa0715fb53b5e3e57",
+		RenewToken: newRenewToken,
+		ExpiresAt:  time.Now().UTC().Add(24 * time.Hour).Format(internal.ServerDateFormat),
+	}, nil
+}
+
+// TestAccessTokenSessionStore_RaceCondition_MutexFix verifies mutex prevents
+// concurrent renewals from causing spurious logouts.
+func TestAccessTokenSessionStore_RaceCondition_MutexFix(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	initialRenewToken := "deadbeef1234567890abcdef1234567890abcdef"
+	api := newRaceConditionRenewalAPI(initialRenewToken)
+	idempotencyKey := uuid.New()
+	expiredDate := time.Now().UTC().Add(-1 * time.Hour)
+
+	cfg := &config.Config{
+		AutoConnectData: config.AutoConnectData{ID: 1},
+		TokensData: map[int64]config.TokenData{
+			1: {
+				Token:              "ab78bb36299d442fa0715fb53b5e3e57",
+				TokenExpiry:        expiredDate.Format(internal.ServerDateFormat),
+				RenewToken:         initialRenewToken,
+				IdempotencyKey:     &idempotencyKey,
+				NordLynxPrivateKey: "nordlynx-pkey",
+				OpenVPNUsername:    "openvpn-username",
+				OpenVPNPassword:    "openvpn-password",
+				IsOAuth:            true,
+			},
+		},
+	}
+
+	cfgManager := &mock.ConfigManager{Cfg: cfg}
+
+	errorHandlerCalls := atomic.Int32{}
+	errorRegistry := internal.NewErrorHandlingRegistry[error]()
+	errorRegistry.Add(func(err error) {
+		errorHandlerCalls.Add(1)
+		t.Logf("ERROR HANDLER CALLED (would trigger logout): %v", err)
+	}, core.ErrNotFound)
+
+	store := session.NewAccessTokenSessionStore(cfgManager, errorRegistry, api.Renew)
+
+	const numGoroutines = 5
+	var wg sync.WaitGroup
+	renewErrors := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			renewErrors[idx] = store.Renew()
+		}(i)
+	}
+
+	wg.Wait()
+
+	t.Logf("API call count: %d", api.callCount.Load())
+	t.Logf("Success count: %d", api.successCount.Load())
+	t.Logf("Fail count (404): %d", api.failCount.Load())
+	t.Logf("Error handler calls: %d", errorHandlerCalls.Load())
+
+	assert.Equal(t, int32(1), api.callCount.Load(), "Only one API call expected")
+	assert.Equal(t, int32(1), api.successCount.Load(), "Single API call should succeed")
+	assert.Equal(t, int32(0), api.failCount.Load(), "No 404 errors expected")
+	assert.Equal(t, int32(0), errorHandlerCalls.Load(), "No spurious logouts")
+
+	for i, err := range renewErrors {
+		assert.NoError(t, err, "Goroutine %d should succeed", i)
+	}
+}
+
+// TestAccessTokenSessionStore_IdempotencyKey_PreservedAfterRenewal verifies
+// idempotency key is preserved after renewal for retry scenarios.
+func TestAccessTokenSessionStore_IdempotencyKey_PreservedAfterRenewal(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	var usedKey uuid.UUID
+	renewAPI := func(token string, key uuid.UUID) (*session.AccessTokenResponse, error) {
+		usedKey = key
+		return &session.AccessTokenResponse{
+			Token:      "ab78bb36299d442fa0715fb53b5e3e57",
+			RenewToken: "deadbeef1234567890abcdef1234567890abcdef",
+			ExpiresAt:  time.Now().UTC().Add(24 * time.Hour).Format(internal.ServerDateFormat),
+		}, nil
+	}
+
+	initialKey := uuid.New()
+	expiredDate := time.Now().UTC().Add(-1 * time.Hour)
+
+	cfg := &config.Config{
+		AutoConnectData: config.AutoConnectData{ID: 1},
+		TokensData: map[int64]config.TokenData{
+			1: {
+				Token:              "ab78bb36299d442fa0715fb53b5e3e57",
+				TokenExpiry:        expiredDate.Format(internal.ServerDateFormat),
+				RenewToken:         "deadbeef1234567890abcdef1234567890abcdef",
+				IdempotencyKey:     &initialKey,
+				NordLynxPrivateKey: "nordlynx-pkey",
+				OpenVPNUsername:    "openvpn-username",
+				OpenVPNPassword:    "openvpn-password",
+				IsOAuth:            true,
+			},
+		},
+	}
+
+	cfgManager := &mock.ConfigManager{Cfg: cfg}
+	errorRegistry := internal.NewErrorHandlingRegistry[error]()
+	store := session.NewAccessTokenSessionStore(cfgManager, errorRegistry, renewAPI)
+
+	err := store.Renew(session.ForceRenewal())
+	assert.NoError(t, err, "Renewal should succeed")
+
+	assert.Equal(t, initialKey, usedKey, "Initial idempotency key should be used")
+	assert.NotNil(t, cfgManager.Cfg.TokensData[1].IdempotencyKey, "Key should be preserved")
+	assert.Equal(t, initialKey, *cfgManager.Cfg.TokensData[1].IdempotencyKey, "Same key preserved")
+}
+
+// TestAccessTokenSessionStore_RaceCondition_WithExpiredToken tests race condition
+// fix with expired token path (no ForceRenewal).
+func TestAccessTokenSessionStore_RaceCondition_WithExpiredToken(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	initialRenewToken := "deadbeef1234567890abcdef1234567890abcdef"
+	api := newRaceConditionRenewalAPI(initialRenewToken)
+	idempotencyKey := uuid.New()
+	expiredDate := time.Now().UTC().Add(-1 * time.Hour)
+
+	cfg := &config.Config{
+		AutoConnectData: config.AutoConnectData{ID: 1},
+		TokensData: map[int64]config.TokenData{
+			1: {
+				Token:              "ab78bb36299d442fa0715fb53b5e3e57",
+				TokenExpiry:        expiredDate.Format(internal.ServerDateFormat),
+				RenewToken:         initialRenewToken,
+				IdempotencyKey:     &idempotencyKey,
+				NordLynxPrivateKey: "nordlynx-pkey",
+				OpenVPNUsername:    "openvpn-username",
+				OpenVPNPassword:    "openvpn-password",
+				IsOAuth:            true,
+			},
+		},
+	}
+
+	cfgManager := &mock.ConfigManager{Cfg: cfg}
+
+	errorHandlerCalls := atomic.Int32{}
+	errorRegistry := internal.NewErrorHandlingRegistry[error]()
+	errorRegistry.Add(func(err error) {
+		errorHandlerCalls.Add(1)
+		t.Logf("ERROR HANDLER CALLED: %v", err)
+	}, core.ErrNotFound)
+
+	store := session.NewAccessTokenSessionStore(cfgManager, errorRegistry, api.Renew)
+
+	const numGoroutines = 5
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_ = store.Renew()
+		}(i)
+	}
+
+	wg.Wait()
+
+	t.Logf("API call count: %d", api.callCount.Load())
+	t.Logf("Success count: %d", api.successCount.Load())
+	t.Logf("Fail count (404): %d", api.failCount.Load())
+	t.Logf("Error handler calls: %d", errorHandlerCalls.Load())
+
+	assert.Equal(t, int32(1), api.callCount.Load(), "Only one API call expected")
+	assert.Equal(t, int32(0), errorHandlerCalls.Load(), "No spurious logouts")
+}

--- a/session/access_token_session_store_race_test.go
+++ b/session/access_token_session_store_race_test.go
@@ -214,7 +214,7 @@ func TestAccessTokenSessionStore_RaceCondition_WithExpiredToken(t *testing.T) {
 
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
-		go func(idx int) {
+		go func(int) {
 			defer wg.Done()
 			_ = store.Renew()
 		}(i)

--- a/session/access_token_session_store_test.go
+++ b/session/access_token_session_store_test.go
@@ -123,6 +123,7 @@ func TestAccessTokenSessionStore_Renew_SetIdempotencyKey(t *testing.T) {
 	pastTime := time.Now().UTC().Add(-24 * time.Hour)
 	futureTime := time.Now().UTC().Add(24 * time.Hour)
 
+	var usedKey uuid.UUID
 	cfg := &config.Config{
 		AutoConnectData: config.AutoConnectData{ID: uid},
 		TokensData: map[int64]config.TokenData{
@@ -139,6 +140,7 @@ func TestAccessTokenSessionStore_Renew_SetIdempotencyKey(t *testing.T) {
 	errorRegistry := internal.NewErrorHandlingRegistry[error]()
 
 	renewAPICall := func(token string, key uuid.UUID) (*session.AccessTokenResponse, error) {
+		usedKey = key
 		return &session.AccessTokenResponse{
 			Token:      "ab78bb36299d442fa0715fb53b5e3e58",
 			RenewToken: "ab78bb36299d442fa0715fb53b5e3e59",
@@ -150,7 +152,9 @@ func TestAccessTokenSessionStore_Renew_SetIdempotencyKey(t *testing.T) {
 	err := store.Renew()
 
 	assert.NoError(t, err)
-	assert.NotNil(t, cfgManager.Cfg.TokensData[uid].IdempotencyKey)
+	assert.NotEqual(t, uuid.Nil, usedKey, "An idempotency key should be generated for the API call")
+	assert.NotNil(t, cfgManager.Cfg.TokensData[uid].IdempotencyKey,
+		"Idempotency key should be preserved after renewal for retry scenarios")
 }
 
 func TestAccessTokenSessionStore_Renew_APIErrorWithHandler(t *testing.T) {


### PR DESCRIPTION
Changes:
- Guarding access token renewal process with mutex
- If there is a time de-sync between client and server a force token renewal is performed