### PR TITLE
LVPN-10276: Don't set fwmark for DNS requests when VPN is connected

### DIFF
--- a/ci/docker/builder/Dockerfile
+++ b/ci/docker/builder/Dockerfile
@@ -44,6 +44,7 @@ RUN dpkg --add-architecture i386 && \
         # Python and file for arch sanity check post build
         python3 \
         nftables \
+        conntrack \
         file && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -251,6 +251,7 @@ func main() {
 		validator,
 		cfg.FirewallMark,
 		network.ExponentialBackoff,
+		daemonEvents.Service,
 	)
 
 	httpClientWithRotator := request.NewStdHTTP()
@@ -706,7 +707,11 @@ func main() {
 	if cfg.AutoConnect {
 		go rpc.StartAutoConnect(network.ExponentialBackoff)
 	}
-	monitor, err := netstate.NewNetlinkMonitor([]string{openvpn.InterfaceName, nordlynx.InterfaceName})
+	monitor, err := netstate.NewNetlinkMonitor([]string{
+		openvpn.InterfaceName,
+		nordlynx.InterfaceName,
+		internal.NordWhisperInterfaceName,
+	})
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -837,12 +842,13 @@ func buildTpServersAndResolver(
 	validator response.Validator,
 	fwmark uint32,
 	timeoutFn dns.CalculateRetryDelayForAttempt,
-) (*dns.NameServers, *network.Resolver) {
+	serviceEvents *daemonevents.ServiceEvents,
+) (*dns.NameServers, network.DNSResolver) {
 	cdn := core.NewCDNAPI(userAgent, cdnUrl, httpClientSimple, validator)
 	tpServers := dns.NewNameServers()
 	// fetch async the TP servers, because FetchTPServers will retry until is successful
 	go tpServers.FetchTPServers(cdn.ThreatProtectionLite, timeoutFn)
 
-	resolver := network.NewResolver(tpServers, fwmark)
+	resolver := network.NewResolver(tpServers, fwmark, serviceEvents)
 	return tpServers, resolver
 }

--- a/cmd/daemon/main_test.go
+++ b/cmd/daemon/main_test.go
@@ -11,9 +11,12 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/core"
+	daemonevents "github.com/NordSecurity/nordvpn-linux/daemon/events"
 	"github.com/NordSecurity/nordvpn-linux/daemon/response"
+	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	mockevents "github.com/NordSecurity/nordvpn-linux/test/mock/events"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,6 +81,10 @@ func TestBuildTpServersAndResolver(t *testing.T) {
 		func(attempt int) time.Duration {
 			assert.Fail(t, "this must not be called in this case")
 			return time.Minute
+		},
+		&daemonevents.ServiceEvents{
+			Connect:    mockevents.NewMockPublisherSubscriber[events.DataConnect](),
+			Disconnect: mockevents.NewMockPublisherSubscriber[events.DataDisconnect](),
 		},
 	)
 

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -326,6 +326,7 @@ func NewAccountUpdateEvents() *AccountUpdateEvents {
 	}
 }
 
+// TODO: remove/replace with the mock
 type MockPublisherSubscriber[T any] struct {
 	Handler        events.Handler[T]
 	EventPublished bool

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -20,14 +20,14 @@ import (
 
 const (
 	registryPrefix         = "ghcr.io/nordsecurity/nordvpn-linux/"
-	imageBuilder           = registryPrefix + "builder:1.4.3"
+	imageBuilder           = registryPrefix + "builder:1.4.3_nft"
 	imageGUIFlutter        = registryPrefix + "flutter-3.38.1:1.0.2"
 	imagePackager          = registryPrefix + "packager:1.3.4"
 	imageDepender          = registryPrefix + "depender:1.3.3"
 	imageSnapPackager      = registryPrefix + "snaper:1.2.2"
 	imageProtobufGenerator = registryPrefix + "generator:1.4.2"
 	imageScanner           = registryPrefix + "scanner:1.1.0"
-	imageTester            = registryPrefix + "tester:1.6.3"
+	imageTester            = registryPrefix + "tester:1.6.3_nft"
 	imageQAPeer            = registryPrefix + "qa-peer:1.0.4"
 	imageRuster            = registryPrefix + "ruster:1.4.1"
 	imageCodeQL            = registryPrefix + "codeql:1.0.0"

--- a/network/connection_helper.go
+++ b/network/connection_helper.go
@@ -11,17 +11,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const NO_FW_MARK uint32 = 0
+const noFwMark uint32 = 0
 
-func LookupAddressNoFwmark(addr string, dns string, protocol string) ([]netip.Addr, error) {
-	return LookupAddress(addr, dns, protocol, NO_FW_MARK)
-}
-
-func LookupAddressWithFirewallMark(addr string, dns string, protocol string, fwmark uint32) ([]netip.Addr, error) {
-	return LookupAddress(addr, dns, protocol, fwmark)
-}
-
-func LookupAddress(addr string, dns string, protocol string, fwmark uint32) ([]netip.Addr, error) {
+func lookupAddress(addr string, dns string, protocol string, fwmark uint32) ([]netip.Addr, error) {
 	resolver := net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
@@ -30,7 +22,7 @@ func LookupAddress(addr string, dns string, protocol string, fwmark uint32) ([]n
 				Timeout: time.Second * 7,
 			}
 
-			if fwmark != NO_FW_MARK {
+			if fwmark != noFwMark {
 				fwmarkFn := func(fd uintptr) {
 					operr = syscall.SetsockoptInt(
 						int(fd),

--- a/network/connection_helper.go
+++ b/network/connection_helper.go
@@ -11,28 +11,40 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// LookupAddressWithCustomDNS looks up address in a specified DNS server
-func LookupAddressWithCustomDNS(addr string, dns string, protocol string, fwmark uint32) ([]netip.Addr, error) {
+const NO_FW_MARK uint32 = 0
+
+func LookupAddressNoFwmark(addr string, dns string, protocol string) ([]netip.Addr, error) {
+	return LookupAddress(addr, dns, protocol, NO_FW_MARK)
+}
+
+func LookupAddressWithFirewallMark(addr string, dns string, protocol string, fwmark uint32) ([]netip.Addr, error) {
+	return LookupAddress(addr, dns, protocol, fwmark)
+}
+
+func LookupAddress(addr string, dns string, protocol string, fwmark uint32) ([]netip.Addr, error) {
 	resolver := net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 			var operr error
-			fwmarkFn := func(fd uintptr) {
-				operr = syscall.SetsockoptInt(
-					int(fd),
-					unix.SOL_SOCKET,
-					unix.SO_MARK,
-					int(fwmark),
-				)
-			}
 			dialer := &net.Dialer{
-				Control: func(network, address string, conn syscall.RawConn) error {
+				Timeout: time.Second * 7,
+			}
+
+			if fwmark != NO_FW_MARK {
+				fwmarkFn := func(fd uintptr) {
+					operr = syscall.SetsockoptInt(
+						int(fd),
+						unix.SOL_SOCKET,
+						unix.SO_MARK,
+						int(fwmark),
+					)
+				}
+				dialer.Control = func(network, address string, conn syscall.RawConn) error {
 					if err := conn.Control(fwmarkFn); err != nil {
 						return err
 					}
 					return operr
-				},
-				Timeout: time.Second * 7,
+				}
 			}
 			// if the server address doesn't have port number then add port 53
 			hostAndPortAddress := dns

--- a/network/connection_helper_test.go
+++ b/network/connection_helper_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"log"
 	"net"
 	"net/netip"
 	"sync"
@@ -37,7 +38,7 @@ func startTestDNSServer(t *testing.T, domainName string, ip netip.Addr) (addr st
 		_ = w.WriteMsg(msg)
 	})
 
-	pc, err := net.ListenPacket("udp", "127.0.0.1:5000")
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen udp: %v", err)
 	}
@@ -49,8 +50,12 @@ func startTestDNSServer(t *testing.T, domainName string, ip netip.Addr) (addr st
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		_ = server.ActivateAndServe()
+		if err := server.ActivateAndServe(); err != nil {
+			t.Fatalf("activate server: %v", err)
+		}
 	})
+
+	log.Println("running DNS server on", pc.LocalAddr().String(), "for", domainName)
 
 	return pc.LocalAddr().String(), func() {
 		_ = server.Shutdown()
@@ -59,7 +64,7 @@ func startTestDNSServer(t *testing.T, domainName string, ip netip.Addr) (addr st
 }
 
 func TestResolveHostUsingLocalDnsServer(t *testing.T) {
-	category.Set(t, category.Root)
+	category.Set(t, category.Unit)
 
 	domainName := "nordvpn.com"
 	ipAddress := netip.MustParseAddr("1.2.3.4")
@@ -67,7 +72,7 @@ func TestResolveHostUsingLocalDnsServer(t *testing.T) {
 	dnsAddr, shutdown := startTestDNSServer(t, domainName, ipAddress)
 	defer shutdown()
 
-	result, err := LookupAddressWithCustomDNS(domainName, dnsAddr, "udp", 0xe1f1)
+	result, err := LookupAddressNoFwmark(domainName, dnsAddr, "udp")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
 	if len(result) > 0 {
@@ -76,9 +81,9 @@ func TestResolveHostUsingLocalDnsServer(t *testing.T) {
 }
 
 func TestResolveHost(t *testing.T) {
-	category.Set(t, category.Root)
+	category.Set(t, category.Unit)
 
-	result, err := LookupAddressWithCustomDNS("google.com", "1.1.1.1", "udp", 0x1234)
+	result, err := LookupAddressNoFwmark("google.com", "1.1.1.1", "udp")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result[0])
 	assert.NotEmpty(t, result[1])

--- a/network/connection_helper_test.go
+++ b/network/connection_helper_test.go
@@ -72,7 +72,7 @@ func TestResolveHostUsingLocalDnsServer(t *testing.T) {
 	dnsAddr, shutdown := startTestDNSServer(t, domainName, ipAddress)
 	defer shutdown()
 
-	result, err := LookupAddressNoFwmark(domainName, dnsAddr, "udp")
+	result, err := lookupAddress(domainName, dnsAddr, "udp", noFwMark)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
 	if len(result) > 0 {
@@ -83,7 +83,7 @@ func TestResolveHostUsingLocalDnsServer(t *testing.T) {
 func TestResolveHost(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	result, err := LookupAddressNoFwmark("google.com", "1.1.1.1", "udp")
+	result, err := lookupAddress("google.com", "1.1.1.1", "udp", noFwMark)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result[0])
 	assert.NotEmpty(t, result[1])

--- a/network/ip_helper.go
+++ b/network/ip_helper.go
@@ -16,6 +16,18 @@ func StringsToIPs(addresses []string) []netip.Addr {
 	return ips
 }
 
+func FilterInvalidIPs(addresses []string) []string {
+	result := []string{}
+	for _, address := range addresses {
+		_, err := netip.ParseAddr(address)
+		if err != nil {
+			continue
+		}
+		result = append(result, address)
+	}
+	return result
+}
+
 func ToRouteString(network netip.Prefix) string {
 	ip := network.Addr()
 	bits := network.Bits()

--- a/network/resolver.go
+++ b/network/resolver.go
@@ -64,12 +64,13 @@ func (r *Resolver) resolveWithNameservers(domain string, nameservers []string, p
 	var ipAddrs []netip.Addr
 	var err error
 	for _, nameserver := range nameservers {
-		if !r.isVpnConnected.Load() {
-			ipAddrs, err = LookupAddressWithFirewallMark(domain, nameserver, protocol, r.fwmark)
-		} else {
-			// While connected to VPN, send the DNS requests thru the tunnel
-			ipAddrs, err = LookupAddressNoFwmark(domain, nameserver, protocol)
+		var fwmark = r.fwmark
+		if r.isVpnConnected.Load() {
+			// While connected to VPN, send the DNS requests thru the tunnel so no fwmark
+			fwmark = noFwMark
 		}
+		ipAddrs, err = lookupAddress(domain, nameserver, protocol, fwmark)
+
 		if err == nil {
 			return ipAddrs, nil
 		}

--- a/network/resolver.go
+++ b/network/resolver.go
@@ -2,10 +2,15 @@ package network
 
 import (
 	"fmt"
+	"log"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/dns"
+	daemonevents "github.com/NordSecurity/nordvpn-linux/daemon/events"
+	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 )
 
 // Resolver is a DNSResolver implementation wrapping each DHCP request with
@@ -13,14 +18,33 @@ import (
 type Resolver struct {
 	servers dns.Getter
 	fwmark  uint32
+	// store if VPN is connected or not. Based on this is decided if the firewall mark is used or not
+	isVpnConnected atomic.Bool
 	sync.Mutex
 }
 
-func NewResolver(servers dns.Getter, fwmark uint32) *Resolver {
-	return &Resolver{
-		servers: servers,
-		fwmark:  fwmark,
+func NewResolver(
+	servers dns.Getter,
+	fwmark uint32,
+	daemonEvents *daemonevents.ServiceEvents,
+) DNSResolver {
+	resolver := &Resolver{
+		servers:        servers,
+		fwmark:         fwmark,
+		isVpnConnected: atomic.Bool{},
 	}
+
+	daemonEvents.Connect.Subscribe(func(dc events.DataConnect) error {
+		resolver.updateVpnStatus(dc.EventStatus == events.StatusSuccess)
+		return nil
+	})
+
+	daemonEvents.Disconnect.Subscribe(func(dd events.DataDisconnect) error {
+		resolver.updateVpnStatus(false)
+		return nil
+	})
+
+	return resolver
 }
 
 type DNSResolver interface {
@@ -29,10 +53,10 @@ type DNSResolver interface {
 
 func (r *Resolver) Resolve(domain string) ([]netip.Addr, error) {
 	nameservers := r.servers.Get(false)
-	return r.ResolveWithNameservers(domain, StringsToIPs(nameservers), "udp")
+	return r.resolveWithNameservers(domain, FilterInvalidIPs(nameservers), "udp")
 }
 
-func (r *Resolver) ResolveWithNameservers(domain string, nameservers []netip.Addr, protocol string) ([]netip.Addr, error) {
+func (r *Resolver) resolveWithNameservers(domain string, nameservers []string, protocol string) ([]netip.Addr, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -40,7 +64,12 @@ func (r *Resolver) ResolveWithNameservers(domain string, nameservers []netip.Add
 	var ipAddrs []netip.Addr
 	var err error
 	for _, nameserver := range nameservers {
-		ipAddrs, err = LookupAddressWithCustomDNS(domain, nameserver.String(), protocol, r.fwmark)
+		if !r.isVpnConnected.Load() {
+			ipAddrs, err = LookupAddressWithFirewallMark(domain, nameserver, protocol, r.fwmark)
+		} else {
+			// While connected to VPN, send the DNS requests thru the tunnel
+			ipAddrs, err = LookupAddressNoFwmark(domain, nameserver, protocol)
+		}
 		if err == nil {
 			return ipAddrs, nil
 		}
@@ -49,4 +78,9 @@ func (r *Resolver) ResolveWithNameservers(domain string, nameservers []netip.Add
 		return nil, fmt.Errorf("looking address up: %w", err)
 	}
 	return ipAddrs, nil
+}
+
+func (r *Resolver) updateVpnStatus(isConnected bool) {
+	log.Println(internal.InfoPrefix, "resolver set VPN connected to", isConnected)
+	r.isVpnConnected.Store(isConnected)
 }

--- a/network/resolver_test.go
+++ b/network/resolver_test.go
@@ -1,15 +1,141 @@
 package network
 
 import (
+	"fmt"
+	"log"
+	"net/netip"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/dns"
+	daemonevents "github.com/NordSecurity/nordvpn-linux/daemon/events"
+	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	mockevents "github.com/NordSecurity/nordvpn-linux/test/mock/events"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAllowlistIP(t *testing.T) {
+func TestResolverUpdatesVpnStatus(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	resolver := NewResolver(&dns.NameServers{}, 0x1234)
-	resolver.Resolve("nordvpn.com")
+	const fwmark uint32 = 0x1234
+
+	ev := &daemonevents.ServiceEvents{
+		Connect:    mockevents.NewMockPublisherSubscriber[events.DataConnect](),
+		Disconnect: mockevents.NewMockPublisherSubscriber[events.DataDisconnect](),
+	}
+	resolver := NewResolver(&dns.NameServers{}, fwmark, ev)
+
+	r, ok := resolver.(*Resolver)
+	assert.True(t, ok)
+
+	assert.Equal(t, fwmark, r.fwmark)
+	assert.False(t, r.isVpnConnected.Load())
+
+	ev.Connect.Publish(events.DataConnect{EventStatus: events.StatusAttempt})
+	assert.False(t, r.isVpnConnected.Load())
+
+	ev.Connect.Publish(events.DataConnect{EventStatus: events.StatusCanceled})
+	assert.False(t, r.isVpnConnected.Load())
+
+	ev.Connect.Publish(events.DataConnect{EventStatus: events.StatusFailure})
+	assert.False(t, r.isVpnConnected.Load())
+
+	ev.Connect.Publish(events.DataConnect{EventStatus: events.StatusSuccess})
+	assert.True(t, ok)
+
+	ev.Disconnect.Publish(events.DataDisconnect{})
+	assert.False(t, r.isVpnConnected.Load())
+}
+
+const nftBlockAll = `
+table inet nordvpn_test
+delete table inet nordvpn_test
+table inet nordvpn_test {
+  chain input {
+    type filter hook input priority 0; policy drop;
+  }
+
+  chain output {
+    type filter hook output priority 0; policy drop;
+  }
+}`
+
+const nftAllowFwMark = `
+table inet nordvpn_test
+delete table inet nordvpn_test
+table inet nordvpn_test {
+  chain input {
+    type filter hook input priority 0; policy drop;
+	ct mark 0xe1f1 accept
+  }
+
+  chain output {
+    type filter hook output priority 0; policy drop;
+	meta mark 0xe1f1 ct mark set meta mark accept
+	ct state established,related ct mark 0xe1f1 accept
+  }
+}`
+
+func TestResolver(t *testing.T) {
+	category.Set(t, category.Root)
+
+	domainName := "nordvpn.com"
+	ipAddress := netip.MustParseAddr("1.2.3.4")
+	dnsAddr, shutdown := startTestDNSServer(t, domainName, ipAddress)
+	assert.NotNil(t, dnsAddr)
+	defer shutdown()
+
+	const fwmark uint32 = 0xe1f1
+
+	ev := &daemonevents.ServiceEvents{
+		Connect:    mockevents.NewMockPublisherSubscriber[events.DataConnect](),
+		Disconnect: mockevents.NewMockPublisherSubscriber[events.DataDisconnect](),
+	}
+	r := NewResolver(&mock.DNSGetter{Names: []string{}}, fwmark, ev)
+	resolver, ok := r.(*Resolver)
+	assert.True(t, ok)
+
+	dnsRequestAreBlocked := func() {
+		_, err := resolver.resolveWithNameservers(domainName, []string{dnsAddr}, "udp")
+		assert.Error(t, err, "check that nft blocks all")
+	}
+
+	dnsRequestWork := func() {
+		ips, err := resolver.resolveWithNameservers(domainName, []string{dnsAddr}, "udp")
+		assert.NoError(t, err, "response received when fwmark is used")
+		assert.Equal(t, ipAddress, ips[0])
+	}
+
+	t.Cleanup(func() {
+		configureNft("delete table inet nordvpn_test")
+	})
+
+	assert.NoError(t, configureNft(nftBlockAll), "failed to block entire traffic")
+
+	dnsRequestAreBlocked()
+
+	assert.NoError(t, configureNft(nftAllowFwMark), "failed to allow only fwmark connections")
+	dnsRequestWork()
+
+	ev.Connect.Publish(events.DataConnect{EventStatus: events.StatusSuccess})
+	dnsRequestAreBlocked()
+
+	ev.Disconnect.Publish(events.DataDisconnect{})
+	dnsRequestWork()
+}
+
+func configureNft(cmd string) error {
+	c := exec.Command("nft", "-f", "-")
+	c.Stdin = strings.NewReader(cmd)
+
+	out, err := c.CombinedOutput()
+	if err != nil {
+		log.Println("failed to execute nft", cmd, err)
+
+		return fmt.Errorf("nft failed: %v\noutput:\n%s", err, string(out))
+	}
+	return nil
 }

--- a/test/helpers/network_namespace.go
+++ b/test/helpers/network_namespace.go
@@ -1,18 +1,33 @@
 package helpers
 
 import (
+	"log"
+	"os"
+	"os/exec"
 	"runtime"
 	"testing"
 
 	"github.com/vishvananda/netns"
 )
 
+// Works only for current goroutine
 func OpenNewNamespace(t *testing.T) netns.NsHandle {
+	if os.Geteuid() != 0 {
+		t.Fatal("requires root")
+	}
 	runtime.LockOSThread()
 	ns, err := netns.New()
 	if err != nil {
 		t.Fatalf("netns.New() failed: %v", err)
 	}
+
+	log.Println("namespace created:", ns.UniqueId())
+
+	cmd := exec.Command("ip", "link", "set", "lo", "up")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bring loopback up: %v, output=%s", err, out)
+	}
+
 	return ns
 }
 

--- a/test/mock/events/events.go
+++ b/test/mock/events/events.go
@@ -1,5 +1,7 @@
 package events
 
+import "github.com/NordSecurity/nordvpn-linux/events"
+
 type MockPublisher[T any] struct {
 	publishedEvents []T
 }
@@ -18,4 +20,26 @@ func (m *MockPublisher[T]) PopEvent() (T, int, bool) {
 
 func (m *MockPublisher[T]) Publish(message T) {
 	m.publishedEvents = append(m.publishedEvents, message)
+}
+
+func NewMockPublisherSubscriber[T any]() *MockPublisherSubscriber[T] {
+	return &MockPublisherSubscriber[T]{}
+}
+
+type MockPublisherSubscriber[T any] struct {
+	Handler        events.Handler[T]
+	EventPublished bool
+	Event          T
+}
+
+func (mp *MockPublisherSubscriber[T]) Publish(message T) {
+	mp.EventPublished = true
+	mp.Event = message
+	if mp.Handler != nil {
+		_ = mp.Handler(message)
+	}
+}
+
+func (mp *MockPublisherSubscriber[T]) Subscribe(handler events.Handler[T]) {
+	mp.Handler = handler
 }


### PR DESCRIPTION
To ensure that the DNS requests are not blocked, the socket is created to use the firewall mark.
When the application is connected to VPN, firewall mark is not set anymore on the socket to ensure that the requests will not bypass the VPN.