### PR TITLE
LVPN-10304: cancel active pause upon logout

### DIFF
--- a/daemon/rpc_logout.go
+++ b/daemon/rpc_logout.go
@@ -10,6 +10,9 @@ import (
 )
 
 func (r *RPC) Logout(ctx context.Context, in *pb.LogoutRequest) (*pb.Payload, error) {
+	if r.connectionInfo.IsPaused() {
+		r.CancelPause()
+	}
 	result := access.Logout(access.LogoutInput{
 		AuthChecker:                  r.ac,
 		CredentialsAPI:               r.credentialsAPI,

--- a/daemon/rpc_logout_test.go
+++ b/daemon/rpc_logout_test.go
@@ -119,7 +119,6 @@ func TestLogout_Pause(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			mockedDisconnectEvents := &daemonevents.MockPublisherSubscriber[events.DataDisconnect]{}
 			connectionInfo := state.NewConnectionInfo()
 
@@ -150,5 +149,4 @@ func TestLogout_Pause(t *testing.T) {
 			assert.Equal(t, test.isDataDisconnectExpected, mockedDisconnectEvents.EventPublished)
 		})
 	}
-
 }

--- a/daemon/rpc_logout_test.go
+++ b/daemon/rpc_logout_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -10,9 +11,11 @@ import (
 	daemonevents "github.com/NordSecurity/nordvpn-linux/daemon/events"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/daemon/recents"
+	"github.com/NordSecurity/nordvpn-linux/daemon/state"
 	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/events/subs"
 	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/mock"
 	testcore "github.com/NordSecurity/nordvpn-linux/test/mock/core"
 	"github.com/NordSecurity/nordvpn-linux/test/mock/fs"
@@ -22,6 +25,7 @@ import (
 )
 
 func TestLogout_Token(t *testing.T) {
+	category.Set(t, category.Integration)
 	cfgManagerMock := newMockConfigManager()
 	fs := fs.NewSystemFileHandleMock(t)
 
@@ -38,6 +42,8 @@ func TestLogout_Token(t *testing.T) {
 			Service: &daemonevents.ServiceEvents{Disconnect: &daemonevents.MockPublisherSubscriber[events.DataDisconnect]{}},
 		},
 		recentVPNConnStore: recents.NewRecentConnectionsStore("/test/path", &fs, nil),
+		pauseManager:       &mock.PauseSchedulerMock{},
+		connectionInfo:     state.NewConnectionInfo(),
 	}
 
 	tests := []struct {
@@ -89,4 +95,60 @@ func TestLogout_Token(t *testing.T) {
 			assert.Equal(t, "", cfgManagerMock.c.MeshPrivateKey, "Mesh private key not removed after logout.")
 		})
 	}
+}
+
+func TestLogout_Pause(t *testing.T) {
+	category.Set(t, category.Integration)
+	cfgManagerMock := newMockConfigManager()
+	fs := fs.NewSystemFileHandleMock(t)
+	pauseSchedulerMock := &mock.PauseSchedulerMock{}
+
+	tests := []struct {
+		name                     string
+		isDataDisconnectExpected bool
+	}{
+		{
+			name:                     "logout while pause active, disconect event shall be emitted",
+			isDataDisconnectExpected: true,
+		},
+		{
+			name:                     "logout while no pause active, disconnect event shall not be emitted",
+			isDataDisconnectExpected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			mockedDisconnectEvents := &daemonevents.MockPublisherSubscriber[events.DataDisconnect]{}
+			connectionInfo := state.NewConnectionInfo()
+
+			rpc := RPC{
+				ac:             &workingLoginChecker{},
+				cm:             cfgManagerMock,
+				norduser:       &testnorduser.MockNorduserCombinedService{},
+				netw:           &networker.Mock{},
+				ncClient:       &mock.NotificationClientMock{},
+				publisher:      &subs.Subject[string]{},
+				credentialsAPI: &testcore.CredentialsAPIMock{},
+				events: &daemonevents.Events{
+					User:    &daemonevents.LoginEvents{Logout: &daemonevents.MockPublisherSubscriber[events.DataAuthorization]{}},
+					Service: &daemonevents.ServiceEvents{Disconnect: mockedDisconnectEvents},
+				},
+				pauseManager:       pauseSchedulerMock,
+				connectionInfo:     connectionInfo,
+				recentVPNConnStore: recents.NewRecentConnectionsStore("/test/path", &fs, nil),
+			}
+
+			if test.isDataDisconnectExpected {
+				//simulate pause is activated
+				connectionInfo.Pause(time.Now(), time.Second*60*5)
+			}
+			// actual response code is not relevant for this test
+			_, err := rpc.Logout(context.Background(), &pb.LogoutRequest{PersistToken: false})
+			assert.NoError(t, err)
+			assert.Equal(t, test.isDataDisconnectExpected, mockedDisconnectEvents.EventPublished)
+		})
+	}
+
 }

--- a/daemon/rpc_pause.go
+++ b/daemon/rpc_pause.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
 )
@@ -43,4 +44,7 @@ func (r *RPC) PauseConnection(ctx context.Context, in *pb.PauseRequest) (*pb.Pay
 
 func (r *RPC) CancelPause() {
 	r.pauseManager.CancelReconnection()
+	//invariant: if the pause gets cancelled, the application state is then disconnected
+	//send out status update here, so the fontend can update its state accordingly
+	r.events.Service.Disconnect.Publish(events.DataDisconnect{})
 }

--- a/daemon/state/connection_info.go
+++ b/daemon/state/connection_info.go
@@ -284,3 +284,10 @@ func (cs *ConnectionInfo) SetServerSelectionData(serverSelectionRule config.Serv
 		serverFromAPI:       serverFromAPI,
 	}
 }
+
+// IsPaused return true if the connection is currently paused, false otherwise
+func (cs *ConnectionInfo) IsPaused() bool {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.pauseData != nil
+}

--- a/daemon/state/connection_info_test.go
+++ b/daemon/state/connection_info_test.go
@@ -464,6 +464,7 @@ func TestConnectionInfo_PauseHandling(t *testing.T) {
 	assert.Equal(t, pauseTime, status.PausedAt)
 	assert.Equal(t, status.State, pb.ConnectionState_PAUSED)
 	assert.Equal(t, status.PauseRemainingTimeSec, uint32(5))
+	assert.True(t, tf.sut.IsPaused())
 
 	go func() {
 		tf.notificationSubscriber.stateChangeHandler.ExpectEvents(1)

--- a/gui/lib/vpn/connection_card_server_info.dart
+++ b/gui/lib/vpn/connection_card_server_info.dart
@@ -36,7 +36,7 @@ final class ConnectionCardServerInfo extends ConsumerWidget {
   String _buildServerInfoLabel(
     RecommendedServerLocation? fastestServerLocation,
   ) {
-    if (vpnStatus.isDisconnected()) {
+    if (vpnStatus.isDisconnected() || vpnStatus.isPaused()) {
       return _buildDisconnectedServerInfo(fastestServerLocation);
     }
 


### PR DESCRIPTION
Changes under this PR:
- display recommended server in the connection cards also when pause is activated
- upon logout any active pause shall be cancelled
  - when this happens, additional `Disconnected` event is emitted, to allow any frontend to update its state accordingly
- tests