### PR TITLE
LVPN-10341: Move lan ranges rule to drop earlier

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -994,7 +994,8 @@ type LoaderInterceptor struct {
 }
 
 func (i *LoaderInterceptor) UnaryInterceptor(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn,
-	invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+) error {
 	if i.enabled {
 		loader := NewLoader()
 		loader.Start()
@@ -1006,7 +1007,8 @@ func (i *LoaderInterceptor) UnaryInterceptor(ctx context.Context, method string,
 }
 
 func (i *LoaderInterceptor) StreamInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string,
-	streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	streamer grpc.Streamer, opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
 	stream, err := streamer(ctx, desc, cc, method, opts...)
 	return loaderStream{ClientStream: stream, loaderEnabled: i.enabled}, err
 }
@@ -1079,7 +1081,9 @@ func (c *cmd) action(err error, f func(*cli.Context) error) func(*cli.Context) e
 			}
 			switch {
 			case errors.Is(err, ErrUpdateAvailable):
-				color.Yellow(UpdateAvailableMessage)
+				if term.IsTerminal(int(os.Stdout.Fd())) {
+					color.Yellow(UpdateAvailableMessage)
+				}
 			case errors.Is(err, ErrInternetConnection):
 				color.Red(ErrInternetConnection.Error())
 				os.Exit(1)

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -627,6 +627,20 @@ func (n *nft) addMeshPeerToInternet(config firewall.Config, nftCtx *nftContext) 
 		UserData: userdata.AppendString(nil, userdata.TypeComment, "traffic from not allowed peers"),
 	})
 
+	if nftCtx.meshLanAllowedPeers != nil {
+		// ip daddr @lan_ranges ip saddr != @peer_local_network_access drop
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: chain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictDrop},
+				checkIPIsInSet(nftCtx.lanRanges, matchDest),
+				checkIPIsNotInSet(nftCtx.meshLanAllowedPeers, matchSource),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "mesh peer to LAN"),
+		})
+	}
+
 	if nftCtx.allowlistSubnets != nil {
 		// ip daddr @allowed_subnets accept
 		n.conn.AddRule(&nftables.Rule{
@@ -666,19 +680,6 @@ func (n *nft) addMeshPeerToInternet(config firewall.Config, nftCtx *nftContext) 
 		})
 	}
 
-	if nftCtx.meshLanAllowedPeers != nil {
-		// ip daddr @lan_ranges ip saddr != @peer_local_network_access drop
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: chain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictDrop},
-				checkIPIsInSet(nftCtx.meshLanAllowedPeers, matchDest),
-				checkIPIsNotInSet(nftCtx.meshLanAllowedPeers, matchSource),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "mesh peer to LAN"),
-		})
-	}
 	// allow traffic thru VPN when connected
 	// or when no VPN connected and KS=0, everywhere
 	if len(config.TunnelInterface) > 0 || !config.KillSwitch {
@@ -722,6 +723,21 @@ func (n *nft) addInternetToMeshPeer(config firewall.Config, nftCtx *nftContext) 
 		UserData: userdata.AppendString(nil, userdata.TypeComment, "traffic to allowed peers"),
 	})
 
+
+	if nftCtx.meshLanAllowedPeers != nil {
+		// ip saddr @lan_ranges ip daddr != @peer_local_network_access drop
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: chain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictDrop},
+				checkIPIsInSet(nftCtx.lanRanges, matchSource),
+				checkIPIsNotInSet(nftCtx.meshLanAllowedPeers, matchDest),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "LAN to mesh peer"),
+		})
+	}
+
 	if nftCtx.allowlistSubnets != nil {
 		// ip saddr @allowed_subnets accept
 		n.conn.AddRule(&nftables.Rule{
@@ -761,19 +777,6 @@ func (n *nft) addInternetToMeshPeer(config firewall.Config, nftCtx *nftContext) 
 		})
 	}
 
-	if nftCtx.meshLanAllowedPeers != nil {
-		// ip saddr @lan_ranges ip daddr != @peer_local_network_access drop
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: chain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictDrop},
-				checkIPIsInSet(nftCtx.meshLanAllowedPeers, matchSource),
-				checkIPIsNotInSet(nftCtx.meshLanAllowedPeers, matchDest),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "LAN to mesh peer"),
-		})
-	}
 	if len(config.MeshnetInfo.MeshInterface) > 0 {
 		// oifname "nordlynx" ct state established,related accept
 		n.conn.AddRule(&nftables.Rule{

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -168,7 +168,7 @@ func (n *nft) addInputChain(config firewall.Config, nftCtx *nftContext) {
 	})
 
 	// meshnet
-	if nftCtx.fileshareAllowedPeers != nil || nftCtx.meshAllowedIncomingConnections != nil {
+	if config.MeshnetInfo != nil {
 		// Add chain for the meshnet and the jump rule to it
 		meshChain := n.addMeshnetInputChain(nftCtx)
 
@@ -464,7 +464,6 @@ func (n *nft) addExcludedInterfacesSet(config firewall.Config, nftCtx *nftContex
 }
 
 func (n *nft) addAllowlistInputChain(nftCtx *nftContext) *nftables.Chain {
-
 	chain := n.conn.AddChain(&nftables.Chain{
 		Name:  allowlistInputChainName,
 		Table: nftCtx.table,
@@ -722,7 +721,6 @@ func (n *nft) addInternetToMeshPeer(config firewall.Config, nftCtx *nftContext) 
 		),
 		UserData: userdata.AppendString(nil, userdata.TypeComment, "traffic to allowed peers"),
 	})
-
 
 	if nftCtx.meshLanAllowedPeers != nil {
 		// ip saddr @lan_ranges ip daddr != @peer_local_network_access drop

--- a/daemon/firewall/nft/nft_meshnet_test.go
+++ b/daemon/firewall/nft/nft_meshnet_test.go
@@ -62,3 +62,36 @@ func TestFileshareBlockAllow(t *testing.T) {
 		assert.Contains(t, out, "tcp dport 49111 drop")
 	})
 }
+
+func TestLANTrafficIsDroppedForPeerWithoutLANAccess(t *testing.T) {
+	category.Set(t, category.Root)
+	ns := helpers.OpenNewNamespace(t)
+	defer helpers.CleanNamespace(t, ns)
+
+	n := GetTestNft()
+	fwConfig := firewall.Config{
+		Allowlist: config.Allowlist{Subnets: internal.LocalNetworks},
+		MeshnetInfo: &firewall.MeshInfo{
+			MeshnetMap: mesh.MachineMap{
+				Peers: mesh.MachinePeers{
+					mesh.MachinePeer{
+						Address:         netip.MustParseAddr("100.77.197.112"),
+						DoIAllowRouting: true,
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, n.Configure(fwConfig))
+
+	dropPeerWithoutLANAccess := fmt.Sprintf(
+		"ip daddr @%s ip saddr != @%s drop",
+		lanPrivateIpsSetName, lanAccessPeersSet,
+	)
+	acceptAllowlistAccess := fmt.Sprintf("ip daddr @%s accept", allowlistSubnetsSetName)
+
+	helpers.WithNftCommandOutput(t, helpers.ListChain(meshPeerToInternet), func(out string) {
+		helpers.AssertRulesOrder(t, out, dropPeerWithoutLANAccess, acceptAllowlistAccess)
+	})
+}

--- a/daemon/firewall/nft/nft_meshnet_test.go
+++ b/daemon/firewall/nft/nft_meshnet_test.go
@@ -3,29 +3,17 @@ package nft
 import (
 	"fmt"
 	"net/netip"
-	"os/exec"
 	"testing"
 
+	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/core/mesh"
 	"github.com/NordSecurity/nordvpn-linux/daemon/firewall"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func runNftCommand(t *testing.T, args ...string) string {
-	t.Helper()
-	out, err := exec.Command("nft", args...).Output()
-
-	assert.NoError(t, err)
-	return string(out)
-}
-
-func withNftCommandOutput(t *testing.T, args []string, fn func(out string)) {
-	t.Helper()
-	out := runNftCommand(t, args...)
-	fn(out)
-}
 
 func TestFileshareBlockAllow(t *testing.T) {
 	category.Set(t, category.Root)
@@ -47,11 +35,11 @@ func TestFileshareBlockAllow(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, n.Configure(cfg))
+	require.NoError(t, n.Configure(cfg))
 
-	args := []string{"list", "chain", "inet", "nordvpn", "mesh_input"}
+	listMeshInput := helpers.ListChain(meshInputChainName)
 
-	withNftCommandOutput(t, args, func(out string) {
+	helpers.WithNftCommandOutput(t, listMeshInput, func(out string) {
 		assert.Contains(t, out, fmt.Sprintf("tcp dport 49111 ip saddr @%s accept", fileshareAllowedPeersSet))
 		assert.Contains(t, out, "tcp dport 49111 drop")
 	})
@@ -60,7 +48,7 @@ func TestFileshareBlockAllow(t *testing.T) {
 	cfg.BlockFileshare = true
 	assert.NoError(t, n.Configure(cfg))
 
-	withNftCommandOutput(t, args, func(out string) {
+	helpers.WithNftCommandOutput(t, listMeshInput, func(out string) {
 		assert.NotContains(t, out, fmt.Sprintf("tcp dport 49111 ip saddr @%s accept", fileshareAllowedPeersSet))
 		assert.Contains(t, out, "tcp dport 49111 drop")
 	})
@@ -69,7 +57,7 @@ func TestFileshareBlockAllow(t *testing.T) {
 	cfg.BlockFileshare = false
 	assert.NoError(t, n.Configure(cfg))
 
-	withNftCommandOutput(t, args, func(out string) {
+	helpers.WithNftCommandOutput(t, listMeshInput, func(out string) {
 		assert.Contains(t, out, fmt.Sprintf("tcp dport 49111 ip saddr @%s accept", fileshareAllowedPeersSet))
 		assert.Contains(t, out, "tcp dport 49111 drop")
 	})

--- a/daemon/firewall/nft/nft_test.go
+++ b/daemon/firewall/nft/nft_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/test/helpers"
 	"github.com/google/nftables"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func GetTestNft() *nft {
@@ -25,7 +26,7 @@ func TestConfigure(t *testing.T) {
 			name: "only vpn interface",
 			fwConfig: firewall.Config{
 				TunnelInterface: "dummynlx",
-				Allowlist:       config.Allowlist{config.Ports{}, []string{}},
+				Allowlist:       config.Allowlist{Ports: config.Ports{}, Subnets: []string{}},
 				KillSwitch:      false,
 				MeshnetInfo:     nil,
 			},
@@ -34,7 +35,7 @@ func TestConfigure(t *testing.T) {
 			name: "only killswitch",
 			fwConfig: firewall.Config{
 				TunnelInterface: "",
-				Allowlist:       config.Allowlist{config.Ports{}, []string{}},
+				Allowlist:       config.Allowlist{Ports: config.Ports{}, Subnets: []string{}},
 				KillSwitch:      true,
 				MeshnetInfo:     nil,
 			},
@@ -49,7 +50,7 @@ func TestConfigure(t *testing.T) {
 			ns := helpers.OpenNewNamespace(t)
 			defer helpers.CleanNamespace(t, ns)
 
-			n.Configure(tt.fwConfig)
+			require.NoError(t, n.Configure(tt.fwConfig))
 			// Currently just checking if the table was created
 			// When rules are finalized, we can start comparing hard coded expected strings to
 			// whatever output we get after calling Configure()

--- a/test/helpers/nft.go
+++ b/test/helpers/nft.go
@@ -1,0 +1,44 @@
+package helpers
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ListChain(chainName string) []string {
+	return []string{"list", "chain", "inet", "nordvpn", chainName}
+}
+
+func AssertRulesOrder(t *testing.T, content, firstSubstr, secondSubstr string) {
+	t.Helper()
+	i := strings.Index(content, firstSubstr)
+	j := strings.Index(content, secondSubstr)
+	if i == -1 {
+		t.Errorf("rule not found in output: %s", firstSubstr)
+		return
+	}
+	if j == -1 {
+		t.Errorf("rule not found in output: %s", secondSubstr)
+		return
+	}
+	if i >= j {
+		t.Errorf("expected rule:\n  %s\nto appear before:\n  %s", firstSubstr, secondSubstr)
+	}
+}
+
+func RunNftCommand(t *testing.T, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("nft", args...).Output()
+
+	assert.NoError(t, err)
+	return string(out)
+}
+
+func WithNftCommandOutput(t *testing.T, args []string, fn func(out string)) {
+	t.Helper()
+	out := RunNftCommand(t, args...)
+	fn(out)
+}


### PR DESCRIPTION
Context:
- when:
  - meshnet is enabled & 
  - you have connected peer &
  - that peer is allowed to route traffic through your host but it's not allowed to access lan &
  - you have lan-discovery enabled, 
  - then that peer could still access your lan

Changes:
- the rule that verifies that peer is allowed to access lan was moved before allowed subnet accepts the traffic
- it's for both - mesh to internet traffic and internet to mesh
- also the moved rule had wrong set used for verification `meshLanAllowedPeers` instead of `lanRanges`
- tests
- test helpers cleanup