### PR TITLE
LVPN-3630: Log level watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,75 @@
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/NordSecurity/nordvpn-linux/badge)](https://scorecard.dev/viewer/?uri=github.com/NordSecurity/nordvpn-linux)
 
-The [NordVPN](https://nordvpn.com/features/) Linux application provides a simple and user-friendly command line interface for accessing all the different features of NordVPN.
-Users can choose from a list of server locations around the world, or let the application automatically select the best server for them.
-They can also customize their connection settings, such as choosing a specific protocol or enabling the kill switch feature.
+The [NordVPN](https://nordvpn.com/features/) Linux application provides a
+simple and user-friendly command line interface for accessing all the
+different features of NordVPN. Users can choose from a list of server
+locations around the world, or let the application automatically select
+the best server for them. They can also customize their connection
+settings, such as choosing a specific protocol or enabling the kill
+switch feature.
 
 The application manages:
-- network interfaces with the help of [tuntap](https://elixir.bootlin.com/linux/v6.0/source/Documentation/networking/tuntap.rst) kernel interface,
-- firewall with the help of [iptables](https://www.netfilter.org/projects/iptables/index.html),
-- routing with the help of [iproute2](https://wiki.linuxfoundation.org/networking/iproute2) and
-- DNS with the help of [systemd-resolved](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html).
+
+- network interfaces using
+  [WireGuard](https://www.wireguard.com/) (NordLynx) and tun (OpenVPN),
+- firewall with the help of
+  [iptables](https://www.netfilter.org/projects/iptables/index.html),
+- routing via the
+  [netlink](https://www.man7.org/linux/man-pages/man7/netlink.7.html)
+  kernel interface and
+- DNS using systemd-resolved, resolvconf, or NetworkManager depending
+  on what is available on the system.
 
 ---
 
-# Versioning
-The project follows https://semver.org/. Version tags and release branches must be named accordingly.
+## Versioning
 
-# Contributing
-We are happy to accept contributions for the project. Please check out [Contribute.md](./CONTRIBUTE.md) file for more details on how to do so.
+The project follows [semver](https://semver.org/). Version tags and
+release branches must be named accordingly.
 
-# Building
-You can find everything related to building, testing and environment setup in [BUILD.md](BUILD.md).
+## Contributing
 
-# Installing
-For installing an already released version please follow the instructions on our [official page](https://nordvpn.com/download/linux/#install-nordvpn).
+We are happy to accept contributions for the project. Please check out
+[CONTRIBUTE.md](./CONTRIBUTE.md) for more details on how to do so.
 
-## Supported distros
-https://nordvpn.com/download/linux/
+## Building
+
+You can find everything related to building, testing and environment
+setup in [BUILD.md](./BUILD.md).
+
+## Troubleshooting
+
+### Log level
+
+The log verbosity of the NordVPN daemons can be changed at runtime
+without restarting by writing to:
+
+- `/run/nordvpn/loglevel` for DEB and RPM
+- `/var/snap/nordvpn/common/run/nordvpn/loglevel` for SNAP
+
+Example:
+
+```sh
+echo "debug" | sudo tee /run/nordvpn/loglevel
+```
+
+Valid values are `debug`, `info`, `warn`, `error`, `fatal` and `off`.
+
+## Installing
+
+For installing an already released version please follow the
+instructions on our
+[official page](https://nordvpn.com/download/linux/#install-nordvpn).
+
+### Supported distros
+
+<https://nordvpn.com/download/linux/>
 
 Distributions are not supported after their end of life.
 
-This project is licensed under the terms of the [GNU General Public License v3.0](./LICENSE.md) only.
-The registered trademark Linux® is used pursuant to a sublicense from the Linux Foundation, the exclusive licensee of Linus Torvalds, owner of the mark on a world-wide basis.
+This project is licensed under the terms of the
+[GNU General Public License v3.0](./LICENSE.md) only.
+The registered trademark Linux® is used pursuant to a sublicense from
+the Linux Foundation, the exclusive licensee of Linus Torvalds, owner
+of the mark on a world-wide basis.

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -135,7 +135,7 @@ func main() {
 	stopLevelWatcher := log.SetupLogger(
 		os.Stdout,
 		internal.LogLevelFile,
-		log.DefaultLevel(internal.IsDevEnv(Environment)),
+		log.DefaultLevel(),
 	)
 	defer stopLevelWatcher()
 

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -132,6 +132,13 @@ func initializeStaticConfig(machineID uuid.UUID) config.StaticConfigManager {
 func main() {
 	appStartTime := time.Now()
 
+	stopLevelWatcher := log.SetupLogger(
+		os.Stdout,
+		internal.LogLevelFile,
+		log.DefaultLevel(internal.IsDevEnv(Environment)),
+	)
+	defer stopLevelWatcher()
+
 	// pprof
 	if internal.IsDevEnv(Environment) {
 		go func() {
@@ -142,9 +149,6 @@ func main() {
 		}()
 	}
 
-	// Logging
-
-	log.SetOutput(os.Stdout)
 	log.Println(internal.InfoPrefix, "Daemon has started")
 
 	if err := SetBufferSizeForHTTP3(); err != nil {

--- a/cmd/fileshare/log_cgo.go
+++ b/cmd/fileshare/log_cgo.go
@@ -22,8 +22,8 @@ void redirect_stdout_to_fd(int fd) {
 */
 import "C"
 
-// logSetup sets the stdout and stderr outside go runtime to a given file
-func logSetup(f *os.File) {
+// redirectNativeOutput sets the stdout and stderr outside go runtime to a given file
+func redirectNativeOutput(f *os.File) {
 	C.redirect_stdout_to_fd(C.int(f.Fd()))
 	// Ignore default printing of go stack trace in case of SIGABRT in prod builds which may be
 	// produced by Rust panics

--- a/cmd/fileshare/log_go.go
+++ b/cmd/fileshare/log_go.go
@@ -4,5 +4,5 @@ package main
 
 import "os"
 
-// logSetup is a placeholder function for non CGo builds
-func logSetup(f *os.File) {}
+// redirectNativeOutput is a placeholder function for non CGo builds
+func redirectNativeOutput(f *os.File) {}

--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -35,15 +35,6 @@ var (
 	daemonURL   = fmt.Sprintf("%s://%s", internal.Proto, internal.DaemonSocket)
 )
 
-func openLogFile(path string) (*os.File, error) {
-	// #nosec path is constant
-	logFile, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, internal.PermUserRW)
-	if err != nil {
-		return nil, err
-	}
-	return logFile, nil
-}
-
 func main() {
 	defer func() {
 		if r := recover(); r != nil {
@@ -59,14 +50,14 @@ func main() {
 		os.Exit(int(childprocess.CodeFailedToEnable))
 	}
 
-	cacheDirPath, err := internal.GetCacheDirPath(homeDir)
-	if err == nil {
-		if logFile, err := openLogFile(filepath.Join(cacheDirPath, internal.FileshareLogFileName)); err == nil {
-			log.SetOutput(logFile)
-			logSetup(logFile)
-			log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
-		}
-	}
+	logFile := internal.UserLogOutput(internal.FileshareLogFileName)
+	redirectNativeOutput(logFile)
+	stopLevelWatcher := log.SetupLogger(
+		logFile,
+		internal.LogLevelFile,
+		log.DefaultLevel(internal.IsDevEnv(Environment)),
+	)
+	defer stopLevelWatcher()
 
 	processStatus := fileshare_process.NewFileshareGRPCProcessManager().ProcessStatus()
 	switch processStatus {

--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -55,7 +55,7 @@ func main() {
 	stopLevelWatcher := log.SetupLogger(
 		logFile,
 		internal.LogLevelFile,
-		log.DefaultLevel(internal.IsDevEnv(Environment)),
+		log.DefaultLevel(),
 	)
 	defer stopLevelWatcher()
 

--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"syscall"
@@ -32,14 +31,8 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/uievent"
 )
 
-func openLogFile(path string) (*os.File, error) {
-	// #nosec path is constant
-	logFile, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
-	if err != nil {
-		return nil, err
-	}
-	return logFile, nil
-}
+// Value set when building the application
+var Environment = ""
 
 func addAutostart() (string, error) {
 	autostartDesktopFileContents := "[Desktop Entry]" +
@@ -145,24 +138,6 @@ func shouldEnableFileshare(uid uint32) (bool, error) {
 	return meshStatus.GetUid() == uid && meshStatus.GetValue(), nil
 }
 
-func setupLog() {
-	log.SetOutput(os.Stdout)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return
-	}
-
-	cacheDirPath, err := internal.GetCacheDirPath(homeDir)
-
-	if err == nil {
-		if logFile, err := openLogFile(filepath.Join(cacheDirPath, internal.NorduserdLogFileName)); err == nil {
-			log.SetOutput(logFile)
-			log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
-		}
-	}
-}
-
 func waitForShutdown(stopChan <-chan norduser.StopRequest,
 	fileshareManagementChan chan<- norduser.FileshareManagementMsg,
 	fileshareShutdownChan <-chan interface{},
@@ -227,7 +202,13 @@ func startFileshare(uid uint32) (chan<- norduser.FileshareManagementMsg, <-chan 
 }
 
 func startSnap() {
-	setupLog()
+	stopLevelWatcher := log.SetupLogger(
+		internal.UserLogOutput(internal.NorduserdLogFileName),
+		internal.LogLevelFile,
+		log.DefaultLevel(internal.IsDevEnv(Environment)),
+	)
+	defer stopLevelWatcher()
+
 	group, err := user.LookupGroup(internal.NordvpnGroup)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "Unable to retrieve nordvpn group:", err)
@@ -324,15 +305,18 @@ func startSnap() {
 }
 
 func start() {
-	listenerFunction := internal.SystemDListener
-
-	setupLog()
+	stopLevelWatcher := log.SetupLogger(
+		internal.UserLogOutput(internal.NorduserdLogFileName),
+		internal.LogLevelFile,
+		log.DefaultLevel(internal.IsDevEnv(Environment)),
+	)
+	defer stopLevelWatcher()
 
 	connURL := internal.GetNorduserSocketFork(os.Geteuid())
 	if err := os.Remove(connURL); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Println(internal.ErrorPrefix, "Failed to remove old socket file:", err)
 	}
-	listenerFunction = internal.ManualListener(connURL, internal.PermUserRWX)
+	listenerFunction := internal.ManualListener(connURL, internal.PermUserRWX)
 
 	listener, err := listenerFunction()
 	if err != nil {

--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -205,7 +205,7 @@ func startSnap() {
 	stopLevelWatcher := log.SetupLogger(
 		internal.UserLogOutput(internal.NorduserdLogFileName),
 		internal.LogLevelFile,
-		log.DefaultLevel(internal.IsDevEnv(Environment)),
+		log.DefaultLevel(),
 	)
 	defer stopLevelWatcher()
 
@@ -308,7 +308,7 @@ func start() {
 	stopLevelWatcher := log.SetupLogger(
 		internal.UserLogOutput(internal.NorduserdLogFileName),
 		internal.LogLevelFile,
-		log.DefaultLevel(internal.IsDevEnv(Environment)),
+		log.DefaultLevel(),
 	)
 	defer stopLevelWatcher()
 

--- a/contrib/manual/mantemplate
+++ b/contrib/manual/mantemplate
@@ -650,6 +650,19 @@ $ \fBnordvpn fileshare clear <time_period>\fR
 
 For example, \fInordvpn fileshare clear 1d 12h\fR clears entries older than 36 hours. Specify time periods using the systemd time span syntax: https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html
 
+.SH "FILES"
+.PP
+\fB/run/nordvpn/loglevel\fR
+.RS 4
+Controls the log verbosity of the NordVPN daemons at runtime\&.
+Write one of \fBdebug\fR, \fBinfo\fR, \fBwarn\fR, \fBerror\fR, \fBfatal\fR, or \fBoff\fR to this file
+to change the log level without restarting the service\&. For example:
+.sp
+.RS 4
+$ \fBecho "debug" | sudo tee /run/nordvpn/loglevel\fR
+.RE
+.RE
+
 .SH "BUGS"
 .sp
 Our QA team did their best to hunt for bugs before the release\&. But if it happens that we missed something, please report it to support@nordvpn.com\&.

--- a/daemon/dns/resolvconf_monitor.go
+++ b/daemon/dns/resolvconf_monitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/NordSecurity/nordvpn-linux/filewatch"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"github.com/fsnotify/fsnotify"
@@ -31,7 +32,7 @@ type resolvConfFileWatcherMonitor struct {
 func newResolvConfMonitor(analytics analytics) resolvConfFileWatcherMonitor {
 	return resolvConfFileWatcherMonitor{
 		analytics:      analytics,
-		getWatcherFunc: internal.GetFileWatcher,
+		getWatcherFunc: filewatch.GetFileWatcher,
 	}
 }
 

--- a/filewatch/filewatch.go
+++ b/filewatch/filewatch.go
@@ -21,7 +21,7 @@ func GetFileWatcher(pathsToMonitor ...string) (watcher *fsnotify.Watcher, err er
 
 	for _, file := range pathsToMonitor {
 		if err := watcher.Add(file); err != nil {
-			return nil, fmt.Errorf("adding group file to watcher: %w", err)
+			return nil, fmt.Errorf("adding file to watcher: %w", err)
 		}
 	}
 

--- a/filewatch/filewatch.go
+++ b/filewatch/filewatch.go
@@ -1,0 +1,29 @@
+package filewatch
+
+import (
+	"fmt"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// GetFileWatcher returns a fsnotify file watcher that is monitoring files provided in pathsToMonitor
+func GetFileWatcher(pathsToMonitor ...string) (watcher *fsnotify.Watcher, err error) {
+	watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("creating new watcher: %w", err)
+	}
+
+	defer func() {
+		if err != nil && watcher != nil {
+			_ = watcher.Close()
+		}
+	}()
+
+	for _, file := range pathsToMonitor {
+		if err := watcher.Add(file); err != nil {
+			return nil, fmt.Errorf("adding group file to watcher: %w", err)
+		}
+	}
+
+	return watcher, nil
+}

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -142,6 +142,9 @@ var (
 	// DaemonPid defines daemon PID file location
 	DaemonPid = filepath.Join(RunDir, "/nordvpnd.pid")
 
+	// LogLevelFile defines the path to the runtime log level control file
+	LogLevelFile = filepath.Join(RunDir, "loglevel")
+
 	FileshareBinaryPath = filepath.Join(AppDataPathStatic, Fileshare)
 
 	NorduserdBinaryPath = filepath.Join(AppDataPathStatic, Norduserd)

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -344,7 +344,7 @@ func FileExists(path string) bool {
 // FileWritable checks if the given file exists and is writable by its owner
 func FileWritable(path string) bool {
 	info, err := os.Stat(path)
-	if err == nil && info.Mode().Perm()&0200 == 0200 {
+	if err == nil && info.Mode().Perm()&0o200 == 0o200 {
 		return true
 	} else {
 		return false
@@ -639,4 +639,37 @@ func GetFileWatcher(pathsToMonitor ...string) (watcher *fsnotify.Watcher, err er
 	}
 
 	return watcher, nil
+}
+
+// UserLogOutput opens logFileName in the user's cache directory and returns it.
+// Falls back to os.Stdout if the file cannot be opened.
+func UserLogOutput(logFileName string) *os.File {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return os.Stdout
+	}
+	cacheDirPath, err := GetCacheDirPath(homeDir)
+	if err != nil {
+		return os.Stdout
+	}
+
+	root, err := os.OpenRoot(cacheDirPath)
+	if err != nil {
+		return os.Stdout
+	}
+	defer func() {
+		if err := root.Close(); err != nil {
+			log.Errorf("failed to close root '%s': %v", cacheDirPath, err)
+		}
+	}()
+
+	logFile, err := root.OpenFile(
+		logFileName,
+		os.O_WRONLY|os.O_APPEND|os.O_CREATE,
+		PermUserRW,
+	)
+	if err != nil {
+		return os.Stdout
+	}
+	return logFile
 }

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/NordSecurity/nordvpn-linux/log"
-	"github.com/fsnotify/fsnotify"
 	"golang.org/x/sys/unix"
 )
 
@@ -617,28 +616,6 @@ func isProcessRunning(executablePath string, readdir readdirFunc, readfile readf
 	}
 
 	return false, nil
-}
-
-// GetFileWatcher returns a fsnotify file watcher that is monitoring files provided in pathsToMonitor
-func GetFileWatcher(pathsToMonitor ...string) (watcher *fsnotify.Watcher, err error) {
-	watcher, err = fsnotify.NewWatcher()
-	if err != nil {
-		return nil, fmt.Errorf("creating new watcher: %w", err)
-	}
-
-	defer func() {
-		if err != nil && watcher != nil {
-			_ = watcher.Close()
-		}
-	}()
-
-	for _, file := range pathsToMonitor {
-		if err := watcher.Add(file); err != nil {
-			return nil, fmt.Errorf("adding group file to watcher: %w", err)
-		}
-	}
-
-	return watcher, nil
 }
 
 // UserLogOutput opens logFileName in the user's cache directory and returns it.

--- a/log/log_level_watcher.go
+++ b/log/log_level_watcher.go
@@ -1,0 +1,120 @@
+package log
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// WatchLevelFile starts a goroutine that watches path for writes and updates
+// the active log level whenever the file content changes. The file should
+// contain one of "debug", "info", or "error" (case-insensitive). The parent
+// directory is watched so that file creation is also detected. The goroutine
+// stops when the returned CancelFunc is called.
+func WatchLevelFile(path string) (CancelFunc, error) {
+	Info("setting log level watcher on path", path)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return nil, err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	applyLevelFile(path)
+
+	if err := watcher.Add(filepath.Dir(path)); err != nil {
+		if closeErr := watcher.Close(); closeErr != nil {
+			Warn("closing log level watcher:", closeErr)
+		}
+		return nil, err
+	}
+
+	go func() {
+		defer func() {
+			if err := watcher.Close(); err != nil {
+				Warn("closing log level watcher:", err)
+			}
+		}()
+		var debounce <-chan time.Time
+
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if event.Name != path {
+					continue
+				}
+				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+					debounce = time.After(50 * time.Millisecond)
+				}
+			case <-debounce:
+				Info("applying log level from file")
+				applyLevelFile(path)
+			case _, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+
+	return func() {
+		if err := watcher.Close(); err != nil {
+			Warn("closing log level watcher:", err)
+		}
+	}, nil
+}
+
+func applyLevelFile(path string) {
+	root, err := os.OpenRoot(filepath.Dir(path))
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err := root.Close(); err != nil {
+			Errorf("failed to close dir root '%s': %v", filepath.Dir(path), err)
+		}
+	}()
+
+	f, err := root.Open(filepath.Base(path))
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			Errorf("failed to close file '%s': %v", path, err)
+		}
+	}()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return
+	}
+
+	text := strings.TrimSpace(strings.ToLower(string(data)))
+	switch text {
+	case "debug":
+		SetLevel(levelDebug)
+	case "info":
+		SetLevel(levelInfo)
+	case "warn":
+		SetLevel(levelWarn)
+	case "error":
+		SetLevel(levelError)
+	case "fatal":
+		SetLevel(levelFatal)
+	case "off":
+		SetLevel(levelOff)
+	default:
+		Warn("unknown log level:", text)
+		return
+	}
+}

--- a/log/log_level_watcher.go
+++ b/log/log_level_watcher.go
@@ -12,12 +12,10 @@ import (
 )
 
 // WatchLevelFile starts a goroutine that watches path for writes and updates
-// the active log level whenever the file content changes. The file should
-// contain one of "debug", "info", or "error" (case-insensitive). The parent
-// directory is watched so that file creation is also detected. The goroutine
+// the active log level whenever the file content changes. The goroutine
 // stops when the returned CancelFunc is called.
 func WatchLevelFile(path string) (CancelFunc, error) {
-	Info("setting log level watcher on path", path)
+	Info("trying to set log level watcher on path", path)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return nil, err
 	}

--- a/log/log_level_watcher.go
+++ b/log/log_level_watcher.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/NordSecurity/nordvpn-linux/filewatch"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -21,19 +22,12 @@ func WatchLevelFile(path string) (CancelFunc, error) {
 		return nil, err
 	}
 
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := filewatch.GetFileWatcher(filepath.Dir(path))
 	if err != nil {
 		return nil, err
 	}
 
 	applyLevelFile(path)
-
-	if err := watcher.Add(filepath.Dir(path)); err != nil {
-		if closeErr := watcher.Close(); closeErr != nil {
-			Warn("closing log level watcher:", closeErr)
-		}
-		return nil, err
-	}
 
 	go func() {
 		defer func() {

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,15 +1,91 @@
+// Package log wraps the standard library logger with level-filtered functions
+// (Debug, Info, Warn, Error, Defer). The active level is stored atomically and
+// can be changed at runtime by writing to the file watched by SetupLogger.
 package log
 
 import (
+	"fmt"
 	"io"
 	"log"
+	"os"
+	"sync/atomic"
+)
+
+type logLevel uint32
+
+// showCallerAsSource instructs logger to skip frames and show `log.XYZ` function
+// caller file and line of code instead of file and line of `log.XYZ` function.
+const showCallerAsSource = 4
+
+const (
+	levelUnknown logLevel = iota
+	levelDebug
+	levelInfo
+	levelWarn
+	levelError
+	levelFatal
+	levelOff
 )
 
 const (
-	Lmicroseconds = log.Lmicroseconds
-	Lshortfile    = log.Lshortfile
-	LstdFlags     = log.Ldate | log.Ltime
+	debugPrefix   = "[Debug]"
+	infoPrefix    = "[Info]"
+	warningPrefix = "[Warning]"
+	deferPrefix   = "[Defer]"
+	errorPrefix   = "[Error]"
+	fatalPrefix   = "[Fatal]"
 )
+
+func (l logLevel) String() string {
+	switch l {
+	case levelDebug:
+		return "debug"
+	case levelInfo:
+		return "info"
+	case levelWarn:
+		return "warn"
+	case levelError:
+		return "error"
+	case levelFatal:
+		return "fatal"
+	case levelOff:
+		return "off"
+	case levelUnknown:
+		fallthrough
+	default:
+		return "unknown"
+	}
+}
+
+// CancelFunc stops a logger resource such as the level file watcher.
+type CancelFunc func()
+
+var level atomic.Uint32
+
+// DefaultLevel returns LevelDebug for dev environments and LevelInfo otherwise.
+func DefaultLevel(devEnv bool) logLevel {
+	return levelDebug
+}
+
+// SetupLogger configures the log output and initial level, then starts watching
+// levelFilePath for runtime level changes. The returned CancelFunc must be
+// called on shutdown to stop the watcher.
+func SetupLogger(out io.Writer, levelFilePath string, initialLevel logLevel) CancelFunc {
+	SetOutput(out)
+	SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
+	SetLevel(initialLevel)
+	cancel, err := WatchLevelFile(levelFilePath)
+	if err != nil {
+		Error("failed to start log level watcher:", err)
+		return func() {}
+	}
+	return cancel
+}
+
+func SetLevel(l logLevel) {
+	Info("setting log level to", l)
+	level.Store(uint32(l))
+}
 
 func SetOutput(w io.Writer) {
 	log.SetOutput(w)
@@ -17,6 +93,47 @@ func SetOutput(w io.Writer) {
 
 func SetFlags(flag int) {
 	log.SetFlags(flag)
+}
+
+func Debug(v ...any)                 { logAt(levelDebug, debugPrefix, v) }
+func Debugf(format string, v ...any) { logAtf(levelDebug, debugPrefix, format, v) }
+func Info(v ...any)                  { logAt(levelInfo, infoPrefix, v) }
+func Infof(format string, v ...any)  { logAtf(levelInfo, infoPrefix, format, v) }
+func Defer(v ...any)                 { logAt(levelInfo, deferPrefix, v) }
+func Deferf(format string, v ...any) { logAtf(levelInfo, deferPrefix, format, v) }
+func Warn(v ...any)                  { logAt(levelWarn, warningPrefix, v) }
+func Warnf(format string, v ...any)  { logAtf(levelWarn, warningPrefix, format, v) }
+func Error(v ...any)                 { logAt(levelError, errorPrefix, v) }
+func Errorf(format string, v ...any) { logAtf(levelError, errorPrefix, format, v) }
+
+func Fatal(v ...any) {
+	logAt(levelFatal, fatalPrefix, v)
+	os.Exit(1)
+}
+
+func Fatalf(format string, v ...any) {
+	logAtf(levelFatal, fatalPrefix, format, v)
+	os.Exit(1)
+}
+
+func logAt(l logLevel, prefix string, v []any) {
+	if level.Load() <= uint32(l) {
+		msg := fmt.Sprintln(v...)
+		// -1 to trim trailing \n
+		output(prefix + " " + msg[:len(msg)-1])
+	}
+}
+
+func output(msg string) {
+	if err := log.Output(showCallerAsSource, msg); err != nil {
+		fmt.Fprintf(os.Stderr, "log.Output: %v\n", err)
+	}
+}
+
+func logAtf(l logLevel, prefix, format string, v []any) {
+	if level.Load() <= uint32(l) {
+		output(fmt.Sprintf(prefix+" "+format, v...))
+	}
 }
 
 func Print(v ...any) {
@@ -31,14 +148,6 @@ func Printf(format string, v ...any) {
 	log.Printf(format, v...)
 }
 
-func Fatal(v ...any) {
-	log.Fatal(v...)
-}
-
 func Fatalln(v ...any) {
 	log.Fatalln(v...)
-}
-
-func Fatalf(format string, v ...any) {
-	log.Fatalf(format, v...)
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 	"sync/atomic"
 )
 
@@ -62,8 +63,7 @@ type CancelFunc func()
 
 var level atomic.Uint32
 
-// DefaultLevel returns LevelDebug for dev environments and LevelInfo otherwise.
-func DefaultLevel(devEnv bool) logLevel {
+func DefaultLevel() logLevel {
 	return levelDebug
 }
 
@@ -118,9 +118,8 @@ func Fatalf(format string, v ...any) {
 
 func logAt(l logLevel, prefix string, v []any) {
 	if level.Load() <= uint32(l) {
-		msg := fmt.Sprintln(v...)
-		// -1 to trim trailing \n
-		output(prefix + " " + msg[:len(msg)-1])
+		msg := strings.TrimRight(fmt.Sprintln(v...), "\n")
+		output(prefix + " " + msg)
 	}
 }
 

--- a/norduser/process_monitor.go
+++ b/norduser/process_monitor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
+	"github.com/NordSecurity/nordvpn-linux/filewatch"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"github.com/NordSecurity/nordvpn-linux/norduser/service"
@@ -180,7 +181,7 @@ func (n *NorduserProcessMonitor) handleUTMPFileUpdate(currentGroupMembers userSe
 
 // Start blocks the thread and starts monitoring for changes in the nordvpn group.
 func (n *NorduserProcessMonitor) Start() error {
-	watcher, err := internal.GetFileWatcher(etcPath, utmpFilePath)
+	watcher, err := filewatch.GetFileWatcher(etcPath, utmpFilePath)
 	if err != nil {
 		return fmt.Errorf("creating file watcher: %w", err)
 	}

--- a/norduser/process_monitor_snap.go
+++ b/norduser/process_monitor_snap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/NordSecurity/nordvpn-linux/filewatch"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"github.com/fsnotify/fsnotify"
@@ -37,7 +38,7 @@ func (n *NorduserProcessMonitor) stopForDeletedGroupMembers(currentGroupMembers 
 // WaitForLogout will send over logoutChan when user under the username logs out(i.e there are no remaining user
 // processes for that user).
 func WaitForLogout(username string, logoutChan chan<- interface{}) error {
-	watcher, err := internal.GetFileWatcher(utmpFilePath)
+	watcher, err := filewatch.GetFileWatcher(utmpFilePath)
 	if err != nil {
 		return fmt.Errorf("creating a fsnotify watcher for utmp file: %w", err)
 	}
@@ -79,7 +80,7 @@ func WaitForLogout(username string, logoutChan chan<- interface{}) error {
 // form the nordvpn group, no other actions will be taken. Because of snap, starting/restarting the process has to be
 // handled in the process itself.
 func (n *NorduserProcessMonitor) StartSnap() error {
-	watcher, err := internal.GetFileWatcher(etcPath, utmpFilePath)
+	watcher, err := filewatch.GetFileWatcher(etcPath, utmpFilePath)
 	if err != nil {
 		return fmt.Errorf("creating file watcher: %w", err)
 	}

--- a/test/qa/lib/selenium.py
+++ b/test/qa/lib/selenium.py
@@ -19,8 +19,8 @@ ENV_FF_TMP = "TMPDIR"
 SNAP_FF_TMP_DIR_PATH = os.path.expanduser("~") + "/ff_tmp"
 
 # XPath used in Selenium tests, to determine locations of elements on NordAccount
-NA_USERNAME_PAGE_TEXTBOX_XPATH = '//*[@data-testid="identifier-input"]'
-NA_USERNAME_PAGE_BUTTON_XPATH = '//*[@data-testid="identifier-submit"]'
+NA_USERNAME_PAGE_TEXTBOX_XPATH = '//*[@data-testid="email-input"]'
+NA_USERNAME_PAGE_BUTTON_XPATH = '//*[@data-testid="email-submit"]'
 
 NA_PASSWORD_PAGE_TEXTBOX_XPATH = '//*[@data-testid="signin-password-input"]'  # noqa: S105
 NA_PASSWORD_PAGE_BUTTON_XPATH = '//*[@data-testid="signin-button"]'  # noqa: S105


### PR DESCRIPTION
This PR adds runtime file in `/run/nordvpn/loglevel` (or `/var/snap/nordvpn/common/run/nordvpn/loglevel` for snap) that allows controlling log level in the application.

Example:
```bash
echo "debug" | sudo tee /run/nordvpn/loglevel
```
Valid values are `debug`, `info`, `warn`, `error`, `fatal` and `off`.

Changes:

- readme:
  - added `## Troubleshooting`
  - updated `The application manages:` as it was outdated
  - the rest is formatting

- man page to mention log level config

- `log.SetupLogger` function the configures watcher on runtime file and adjust log level on changes
- `log.DefaultLevel` to set default level to `info`, or `debug` (for dev builds)
- log funcs like `log.Info`, `log.Warn` - there is a separate PR with replacing current `log.PrintXYZ` with those new ones