### PR TITLE
LVPN-10360: Ignore meshnet changes that are not relevant to firewall

### DIFF
--- a/daemon/firewall/service.go
+++ b/daemon/firewall/service.go
@@ -71,22 +71,20 @@ func (m *MeshInfo) IsSimilar(meshInfo *MeshInfo) bool {
 				p1.DoIAllowRouting == p2.DoIAllowRouting &&
 				p1.DoIAllowLocalNetwork == p2.DoIAllowLocalNetwork &&
 				p1.DoIAllowFileshare == p2.DoIAllowFileshare
-
 		},
 	)
 
-	if !arePeersEqual {
-		return false
-	}
-
-	return true
+	return arePeersEqual
 }
 
 func NewMeshInfo(meshnetMap mesh.MachineMap, meshInterface string) *MeshInfo {
-	return &MeshInfo{
+	info := &MeshInfo{
 		MeshnetMap:    meshnetMap,
 		MeshInterface: meshInterface,
 	}
+	sortMeshnetMap(&info.MeshnetMap)
+
+	return info
 }
 
 func (c Config) CopyWith(opts ...Option) Config {

--- a/daemon/firewall/service.go
+++ b/daemon/firewall/service.go
@@ -1,6 +1,9 @@
 package firewall
 
 import (
+	"bytes"
+	"slices"
+
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/core/mesh"
 )
@@ -30,9 +33,53 @@ type Config struct {
 	MeshnetInfo    *MeshInfo
 }
 
+func NewConfig(opts ...Option) Config {
+	return Config{}.CopyWith(opts...)
+}
+
+// Only the firewall relevant parts are checked. It is not a fully IsEqual
+func (c *Config) HasSimilarMeshInfo(cfg *Config) bool {
+	return c.MeshnetInfo != nil &&
+		cfg.MeshnetInfo != nil &&
+		c.MeshnetInfo.IsSimilar(cfg.MeshnetInfo)
+}
+
 type MeshInfo struct {
 	MeshnetMap    mesh.MachineMap
 	MeshInterface string
+}
+
+// Only the firewall relevant parts are checked. It is not a fully IsEqual
+func (m *MeshInfo) IsSimilar(meshInfo *MeshInfo) bool {
+	if meshInfo == nil {
+		return false
+	}
+
+	if m.MeshInterface != meshInfo.MeshInterface {
+		return false
+	}
+
+	sortMeshnetMap(&meshInfo.MeshnetMap)
+
+	arePeersEqual := slices.EqualFunc(
+		m.MeshnetMap.Peers,
+		meshInfo.MeshnetMap.Peers,
+		func(p1, p2 mesh.MachinePeer) bool {
+			return p1.ID == p2.ID &&
+				p1.Address == p2.Address &&
+				p1.DoIAllowInbound == p2.DoIAllowInbound &&
+				p1.DoIAllowRouting == p2.DoIAllowRouting &&
+				p1.DoIAllowLocalNetwork == p2.DoIAllowLocalNetwork &&
+				p1.DoIAllowFileshare == p2.DoIAllowFileshare
+
+		},
+	)
+
+	if !arePeersEqual {
+		return false
+	}
+
+	return true
 }
 
 func NewMeshInfo(meshnetMap mesh.MachineMap, meshInterface string) *MeshInfo {
@@ -83,6 +130,9 @@ func WithTunnelInterface(tunnelInterface string) Option {
 func WithMeshnetInfo(meshInfo *MeshInfo) Option {
 	return func(c *Config) {
 		c.MeshnetInfo = meshInfo
+		if meshInfo != nil {
+			sortMeshnetMap(&c.MeshnetInfo.MeshnetMap)
+		}
 	}
 }
 
@@ -90,4 +140,11 @@ func WithBlockFileshare(block bool) Option {
 	return func(c *Config) {
 		c.BlockFileshare = block
 	}
+}
+
+func sortMeshnetMap(meshMap *mesh.MachineMap) {
+	// sort the peers to easier compare for equality
+	slices.SortFunc(meshMap.Peers, func(p1, p2 mesh.MachinePeer) int {
+		return bytes.Compare(p1.ID[:], p2.ID[:])
+	})
 }

--- a/daemon/firewall/service.go
+++ b/daemon/firewall/service.go
@@ -1,7 +1,6 @@
 package firewall
 
 import (
-	"bytes"
 	"slices"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -59,32 +58,32 @@ func (m *MeshInfo) IsSimilar(meshInfo *MeshInfo) bool {
 		return false
 	}
 
-	sortMeshnetMap(&meshInfo.MeshnetMap)
+	if len(meshInfo.MeshnetMap.Peers) != len(m.MeshnetMap.Peers) {
+		return false
+	}
 
-	arePeersEqual := slices.EqualFunc(
-		m.MeshnetMap.Peers,
-		meshInfo.MeshnetMap.Peers,
-		func(p1, p2 mesh.MachinePeer) bool {
-			return p1.ID == p2.ID &&
-				p1.Address == p2.Address &&
-				p1.DoIAllowInbound == p2.DoIAllowInbound &&
-				p1.DoIAllowRouting == p2.DoIAllowRouting &&
-				p1.DoIAllowLocalNetwork == p2.DoIAllowLocalNetwork &&
-				p1.DoIAllowFileshare == p2.DoIAllowFileshare
-		},
-	)
+	for _, peer := range m.MeshnetMap.Peers {
+		idx := slices.IndexFunc(meshInfo.MeshnetMap.Peers, func(p mesh.MachinePeer) bool {
+			return peer.ID == p.ID &&
+				peer.Address == p.Address &&
+				peer.DoIAllowInbound == p.DoIAllowInbound &&
+				peer.DoIAllowRouting == p.DoIAllowRouting &&
+				peer.DoIAllowLocalNetwork == p.DoIAllowLocalNetwork &&
+				peer.DoIAllowFileshare == p.DoIAllowFileshare
+		})
+		if idx == -1 {
+			return false
+		}
+	}
 
-	return arePeersEqual
+	return true
 }
 
 func NewMeshInfo(meshnetMap mesh.MachineMap, meshInterface string) *MeshInfo {
-	info := &MeshInfo{
+	return &MeshInfo{
 		MeshnetMap:    meshnetMap,
 		MeshInterface: meshInterface,
 	}
-	sortMeshnetMap(&info.MeshnetMap)
-
-	return info
 }
 
 func (c Config) CopyWith(opts ...Option) Config {
@@ -128,9 +127,6 @@ func WithTunnelInterface(tunnelInterface string) Option {
 func WithMeshnetInfo(meshInfo *MeshInfo) Option {
 	return func(c *Config) {
 		c.MeshnetInfo = meshInfo
-		if meshInfo != nil {
-			sortMeshnetMap(&c.MeshnetInfo.MeshnetMap)
-		}
 	}
 }
 
@@ -138,11 +134,4 @@ func WithBlockFileshare(block bool) Option {
 	return func(c *Config) {
 		c.BlockFileshare = block
 	}
-}
-
-func sortMeshnetMap(meshMap *mesh.MachineMap) {
-	// sort the peers to easier compare for equality
-	slices.SortFunc(meshMap.Peers, func(p1, p2 mesh.MachinePeer) int {
-		return bytes.Compare(p1.ID[:], p2.ID[:])
-	})
 }

--- a/daemon/firewall/service_test.go
+++ b/daemon/firewall/service_test.go
@@ -1,0 +1,198 @@
+package firewall
+
+import (
+	"math/rand"
+	"net/netip"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/core/mesh"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigOptions(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	allowlist := config.NewAllowlist([]int64{1}, []int64{101}, []string{"123.456.123.1"})
+	meshInfo := NewMeshInfo(mesh.MachineMap{}, "nordlynx")
+	fullConfig := Config{
+		TunnelInterface: "test",
+		KillSwitch:      true,
+		BlockFileshare:  true,
+		Allowlist:       allowlist,
+		MeshnetInfo:     meshInfo,
+	}
+
+	tests := []struct {
+		name     string
+		options  []Option
+		expected Config
+	}{
+		{
+			name:     "tunnel interface changes",
+			options:  []Option{WithTunnelInterface("test")},
+			expected: Config{TunnelInterface: "test"},
+		},
+		{
+			name:     "KillSwitch interface changes",
+			options:  []Option{WithKillSwitch(true)},
+			expected: Config{KillSwitch: true},
+		},
+		{
+			name:     "BlockFileshare interface changes",
+			options:  []Option{WithBlockFileshare(true)},
+			expected: Config{BlockFileshare: true},
+		},
+		{
+			name:     "Allowlist interface changes",
+			options:  []Option{WithAllowlist(allowlist)},
+			expected: Config{Allowlist: allowlist},
+		},
+		{
+			name:     "MeshnetInfo interface changes",
+			options:  []Option{WithMeshnetInfo(meshInfo)},
+			expected: Config{MeshnetInfo: meshInfo},
+		},
+		{
+			name: "combine all members works",
+			options: []Option{
+				WithTunnelInterface("test"),
+				WithKillSwitch(true),
+				WithBlockFileshare(true),
+				WithAllowlist(allowlist),
+				WithMeshnetInfo(meshInfo),
+			},
+			expected: fullConfig,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := NewConfig(test.options...)
+			assert.Equal(t, test.expected, c)
+		})
+	}
+}
+
+func TestMeshInfoIsSimilar(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	randomIP := func() netip.Addr {
+		return netip.AddrFrom4([4]byte{
+			byte(rand.Intn(256)),
+			byte(rand.Intn(256)),
+			byte(rand.Intn(256)),
+			byte(rand.Intn(256)),
+		})
+	}
+
+	createPeer := func() mesh.MachinePeer {
+		return mesh.MachinePeer{
+			ID:                   uuid.New(),
+			Address:              randomIP(),
+			DoIAllowInbound:      true,
+			DoIAllowRouting:      true,
+			DoIAllowLocalNetwork: true,
+			DoIAllowFileshare:    true,
+			AlwaysAcceptFiles:    true,
+		}
+	}
+
+	peer1 := createPeer()
+	peer2 := createPeer()
+	baseMeshInfo := NewMeshInfo(mesh.MachineMap{
+		Peers: mesh.MachinePeers{peer1, peer2}}, "nordlynx")
+
+	tests := []struct {
+		name     string
+		fn       func(*MeshInfo)
+		expected bool
+	}{
+		{
+			name:     "are equal for same data",
+			fn:       func(m *MeshInfo) {},
+			expected: true,
+		},
+		{
+			name: "not equal when mesh interface changes",
+			fn: func(m *MeshInfo) {
+				m.MeshInterface = "other"
+			},
+			expected: false,
+		},
+		{
+			name: "ID changes",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers[0].ID = uuid.New()
+			},
+			expected: false,
+		},
+		{
+			name: "address changes",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers[0].Address = randomIP()
+			},
+			expected: false,
+		},
+		{
+			name: "DoIAllowInbound changes",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers[0].DoIAllowInbound = false
+			},
+			expected: false,
+		},
+		{
+			name: "DoIAllowRouting changes",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers[0].DoIAllowRouting = false
+			},
+			expected: false,
+		},
+		{
+			name: "DoIAllowLocalNetwork changes",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers[0].DoIAllowLocalNetwork = false
+			},
+			expected: false,
+		},
+		{
+			name: "DoIAllowFileshare changes",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers[0].DoIAllowFileshare = false
+			},
+			expected: false,
+		},
+		{
+			name: "irrelevant changes have no effect",
+			fn: func(m *MeshInfo) {
+				peer := m.MeshnetMap.Peers[0]
+				peer.Hostname = "host1"
+				peer.OS = mesh.OperatingSystem{Name: "name"}
+				peer.PublicKey = "key"
+				peer.Endpoints = []netip.AddrPort{netip.AddrPortFrom(randomIP(), 1234)}
+				peer.Email = "email"
+				peer.IsLocal = true
+				peer.DoesPeerAllowRouting = true
+				peer.DoesPeerAllowInbound = true
+				peer.DoesPeerAllowLocalNetwork = true
+				peer.DoesPeerAllowFileshare = true
+				peer.DoesPeerSupportRouting = true
+				peer.AlwaysAcceptFiles = true
+				peer.Nickname = "nick"
+				m.MeshnetMap.Peers[0] = peer
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := NewMeshInfo(mesh.MachineMap{
+				Peers: mesh.MachinePeers{peer1, peer2}}, "nordlynx")
+			test.fn(m)
+			assert.Equal(t, test.expected, baseMeshInfo.IsSimilar(m))
+		})
+	}
+}

--- a/daemon/firewall/service_test.go
+++ b/daemon/firewall/service_test.go
@@ -102,8 +102,7 @@ func TestMeshInfoIsSimilar(t *testing.T) {
 
 	peer1 := createPeer()
 	peer2 := createPeer()
-	baseMeshInfo := NewMeshInfo(mesh.MachineMap{
-		Peers: mesh.MachinePeers{peer1, peer2}}, "nordlynx")
+	baseMeshInfo := NewMeshInfo(mesh.MachineMap{Peers: mesh.MachinePeers{peer1, peer2}}, "nordlynx")
 
 	tests := []struct {
 		name     string
@@ -189,8 +188,7 @@ func TestMeshInfoIsSimilar(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := NewMeshInfo(mesh.MachineMap{
-				Peers: mesh.MachinePeers{peer1, peer2}}, "nordlynx")
+			m := NewMeshInfo(mesh.MachineMap{Peers: mesh.MachinePeers{peer1, peer2}}, "nordlynx")
 			test.fn(m)
 			assert.Equal(t, test.expected, baseMeshInfo.IsSimilar(m))
 		})

--- a/daemon/firewall/service_test.go
+++ b/daemon/firewall/service_test.go
@@ -107,61 +107,75 @@ func TestMeshInfoIsSimilar(t *testing.T) {
 	tests := []struct {
 		name     string
 		fn       func(*MeshInfo)
-		expected bool
+		areEqual bool
 	}{
 		{
 			name:     "are equal for same data",
 			fn:       func(m *MeshInfo) {},
-			expected: true,
+			areEqual: true,
 		},
 		{
 			name: "not equal when mesh interface changes",
 			fn: func(m *MeshInfo) {
 				m.MeshInterface = "other"
 			},
-			expected: false,
+			areEqual: false,
 		},
 		{
 			name: "ID changes",
 			fn: func(m *MeshInfo) {
 				m.MeshnetMap.Peers[0].ID = uuid.New()
 			},
-			expected: false,
+			areEqual: false,
 		},
 		{
 			name: "address changes",
 			fn: func(m *MeshInfo) {
 				m.MeshnetMap.Peers[0].Address = randomIP()
 			},
-			expected: false,
+			areEqual: false,
 		},
 		{
 			name: "DoIAllowInbound changes",
 			fn: func(m *MeshInfo) {
 				m.MeshnetMap.Peers[0].DoIAllowInbound = false
 			},
-			expected: false,
+			areEqual: false,
 		},
 		{
 			name: "DoIAllowRouting changes",
 			fn: func(m *MeshInfo) {
 				m.MeshnetMap.Peers[0].DoIAllowRouting = false
 			},
-			expected: false,
+			areEqual: false,
 		},
 		{
 			name: "DoIAllowLocalNetwork changes",
 			fn: func(m *MeshInfo) {
 				m.MeshnetMap.Peers[0].DoIAllowLocalNetwork = false
 			},
-			expected: false,
+			areEqual: false,
 		},
 		{
 			name: "DoIAllowFileshare changes",
 			fn: func(m *MeshInfo) {
 				m.MeshnetMap.Peers[0].DoIAllowFileshare = false
 			},
-			expected: false,
+			areEqual: false,
+		},
+		{
+			name: "same peers in different order",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers = mesh.MachinePeers{peer2, peer1}
+			},
+			areEqual: true,
+		},
+		{
+			name: "different peers same number of elements",
+			fn: func(m *MeshInfo) {
+				m.MeshnetMap.Peers = mesh.MachinePeers{createPeer(), createPeer()}
+			},
+			areEqual: false,
 		},
 		{
 			name: "irrelevant changes have no effect",
@@ -182,7 +196,7 @@ func TestMeshInfoIsSimilar(t *testing.T) {
 				peer.Nickname = "nick"
 				m.MeshnetMap.Peers[0] = peer
 			},
-			expected: true,
+			areEqual: true,
 		},
 	}
 
@@ -190,7 +204,7 @@ func TestMeshInfoIsSimilar(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			m := NewMeshInfo(mesh.MachineMap{Peers: mesh.MachinePeers{peer1, peer2}}, "nordlynx")
 			test.fn(m)
-			assert.Equal(t, test.expected, baseMeshInfo.IsSimilar(m))
+			assert.Equal(t, test.areEqual, baseMeshInfo.IsSimilar(m))
 		})
 	}
 }

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -876,8 +876,11 @@ func (netw *Combined) Refresh(c mesh.MachineMap) error {
 		newCfg := netw.fwConfig.CopyWith(
 			firewall.WithMeshnetInfo(firewall.NewMeshInfo(netw.cfg, netw.mesh.Tun().Interface().Name)),
 		)
-		if err := netw.configureFirewall(newCfg); err != nil {
-			return fmt.Errorf("configure firewall for meshnet refresh: %w", err)
+
+		if !netw.fwConfig.HasSimilarMeshInfo(&newCfg) {
+			if err := netw.configureFirewall(newCfg); err != nil {
+				return fmt.Errorf("configure firewall for meshnet refresh: %w", err)
+			}
 		}
 		return nil
 	}
@@ -994,8 +997,10 @@ func (netw *Combined) setMesh(
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithMeshnetInfo(firewall.NewMeshInfo(netw.cfg, netw.mesh.Tun().Interface().Name)),
 	)
-	if err := netw.configureFirewall(newCfg); err != nil {
-		return fmt.Errorf("configure firewall for set meshnet: %w", err)
+	if !netw.fwConfig.HasSimilarMeshInfo(&newCfg) {
+		if err := netw.configureFirewall(newCfg); err != nil {
+			return fmt.Errorf("configure firewall for set meshnet: %w", err)
+		}
 	}
 
 	netw.isMeshnetSet = true


### PR DESCRIPTION
Not to reconfigure the firewall at every meshnet refresh, the meshnet map is compared with the last one that was used to configure the firewall. If the fields relevant for firewall didn't changed then the change is ignored.