### PR TITLE
LVPN-10278: Accept tunnel traffic before DNS drop

### DIFF
--- a/daemon/firewall/nft/match_expr.go
+++ b/daemon/firewall/nft/match_expr.go
@@ -194,25 +194,6 @@ const (
 	ifNameOutput ifDirection = 2
 )
 
-// iifname @set
-func interfaceNameInSet(interfaces *nftables.Set, direction ifDirection) []expr.Any {
-	dir := expr.MetaKeyIIFNAME
-	if direction == ifNameOutput {
-		dir = expr.MetaKeyOIFNAME
-	}
-	return []expr.Any{
-		&expr.Meta{
-			Key:      dir,
-			Register: 1,
-		},
-		&expr.Lookup{
-			SourceRegister: 1,
-			SetName:        interfaces.Name,
-			SetID:          interfaces.ID,
-		},
-	}
-}
-
 // iifname "nordlynx"
 func checkInterfaceName(ifName string, direction ifDirection, cmp expr.CmpOp) []expr.Any {
 	if len(ifName) == 0 {

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -361,7 +361,31 @@ func (n *nft) addForwardChain(config firewall.Config, nftCtx *nftContext) {
 			),
 			UserData: userdata.AppendString(nil, userdata.TypeComment, "traffic to mesh peer"),
 		})
+	}
 
+	if len(config.TunnelInterface) > 0 {
+		// oif "nordtun" accept
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: forwardChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictAccept},
+				checkInterfaceName(config.TunnelInterface, ifNameOutput, expr.CmpOpEq),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "internet to allowlist IPs"),
+		})
+
+		// iif "nordtun" ct state established,related accept
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: forwardChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictAccept},
+				checkInterfaceName(config.TunnelInterface, ifNameInput, expr.CmpOpEq),
+				checkCtState(expr.CtStateBitESTABLISHED|expr.CtStateBitRELATED),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "response to connections inside tunnel"),
+		})
 	}
 
 	n.addLanDNSDrop(config, nftCtx, forwardChain)
@@ -388,19 +412,6 @@ func (n *nft) addForwardChain(config firewall.Config, nftCtx *nftContext) {
 				checkCtState(expr.CtStateBitESTABLISHED|expr.CtStateBitRELATED),
 			),
 			UserData: userdata.AppendString(nil, userdata.TypeComment, "allow responses to allowlist IPs"),
-		})
-	}
-
-	if len(config.TunnelInterface) > 0 {
-		// oif "nordtun" accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: forwardChain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkInterfaceName(config.TunnelInterface, ifNameOutput, expr.CmpOpEq),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "internet to allowlist IPs"),
 		})
 	}
 }

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -8,7 +8,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/firewall"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/google/nftables"
-	"github.com/google/nftables/binaryutil"
 	"github.com/google/nftables/expr"
 	"github.com/google/nftables/userdata"
 	"golang.org/x/sys/unix"
@@ -16,7 +15,6 @@ import (
 
 const (
 	tableName                       = "nordvpn"
-	excludedInterfacesSetName       = "excluded_interfaces"
 	allowlistSubnetsSetName         = "allowlist_subnets"
 	tcpAllowlistSetName             = "tcp_allowlist"
 	udpAllowlistSetName             = "udp_allowlist"
@@ -35,11 +33,11 @@ const (
 	allowTrafficRoutingPeersSet     = "allow_peer_traffic_routing"
 	lanAccessPeersSet               = "peer_local_network_access"
 	defaultDNSPort                  = 53
+	loopbackInterface               = "lo"
 )
 
 type nftContext struct {
 	table                          *nftables.Table
-	excludedInterfaces             *nftables.Set
 	lanRanges                      *nftables.Set
 	allowlistSubnets               *nftables.Set
 	tcpPorts                       *nftables.Set
@@ -82,10 +80,6 @@ func (n *nft) configure(config firewall.Config) error {
 	nftCtx.table = n.addMainTable()
 	n.conn.DelTable(nftCtx.table)
 	nftCtx.table = n.addMainTable()
-
-	if err := n.addExcludedInterfacesSet(config, nftCtx); err != nil {
-		return err
-	}
 
 	if err := n.addLanRangesSet(nftCtx); err != nil {
 		return err
@@ -154,7 +148,7 @@ func (n *nft) addInputChain(config firewall.Config, nftCtx *nftContext) {
 		Chain: inputChain,
 		Exprs: buildRules(
 			&expr.Verdict{Kind: expr.VerdictAccept},
-			checkInterfaceName("lo", ifNameInput, expr.CmpOpEq),
+			checkInterfaceName(loopbackInterface, ifNameInput, expr.CmpOpEq),
 		),
 		UserData: userdata.AppendString(nil, userdata.TypeComment, "local to local"),
 	})
@@ -230,50 +224,16 @@ func (n *nft) addOutputChain(config firewall.Config, nftCtx *nftContext) {
 		Policy:   &chainPolicy,
 	})
 
-	// drop DNS if port 53 not whitelisted
-	n.addLanDNSDrop(config, nftCtx, outputChain)
-
-	if nftCtx.allowlistSubnets != nil {
-		// ip daddr @allowed_subnets accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: outputChain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkIPIsInSet(nftCtx.allowlistSubnets, matchDest),
-				setMetaMark(n.fwmark),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "local to allowlist IPs"),
-		})
-	}
-
-	if nftCtx.tcpPorts != nil {
-		// tcp sport @ports_tcp accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: outputChain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkPortIsInSet(nftCtx.tcpPorts, unix.IPPROTO_TCP, matchSource),
-				setMetaMark(n.fwmark),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "from allowlist TCP ports"),
-		})
-	}
-
-	if nftCtx.udpPorts != nil {
-		// udp sport @ports_udp accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: outputChain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkPortIsInSet(nftCtx.udpPorts, unix.IPPROTO_UDP, matchSource),
-				setMetaMark(n.fwmark),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "from allowlist UDP ports"),
-		})
-	}
+	// oifname "lo" accept
+	n.conn.AddRule(&nftables.Rule{
+		Table: nftCtx.table,
+		Chain: outputChain,
+		Exprs: buildRules(
+			&expr.Verdict{Kind: expr.VerdictAccept},
+			checkInterfaceName(loopbackInterface, ifNameOutput, expr.CmpOpEq),
+		),
+		UserData: userdata.AppendString(nil, userdata.TypeComment, "local to loopback"),
+	})
 
 	// ct mark 0xe1f1 accept
 	n.conn.AddRule(&nftables.Rule{
@@ -296,16 +256,49 @@ func (n *nft) addOutputChain(config firewall.Config, nftCtx *nftContext) {
 		UserData: userdata.AppendString(nil, userdata.TypeComment, "mark connection for socket with SO_MARK"),
 	})
 
-	// oifname @excluded_interfaces accept
-	n.conn.AddRule(&nftables.Rule{
-		Table: nftCtx.table,
-		Chain: outputChain,
-		Exprs: buildRules(
-			&expr.Verdict{Kind: expr.VerdictAccept},
-			interfaceNameInSet(nftCtx.excludedInterfaces, ifNameOutput),
-		),
-		UserData: userdata.AppendString(nil, userdata.TypeComment, "local to local and local to VPN"),
-	})
+	n.addLanDNSDrop(config, nftCtx, outputChain)
+
+	if nftCtx.allowlistSubnets != nil {
+		// ip daddr @allowed_subnets accept
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: outputChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictAccept},
+				checkIPIsInSet(nftCtx.allowlistSubnets, matchDest),
+				setMetaMark(n.fwmark),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "local to allowlist IPs"),
+		})
+	}
+
+	if nftCtx.tcpPorts != nil {
+		// tcp sport @tcp_allowlist meta mark set 0x0000e1f1 accept
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: outputChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictAccept},
+				checkPortIsInSet(nftCtx.tcpPorts, unix.IPPROTO_TCP, matchSource),
+				setMetaMark(n.fwmark),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "from allowlist TCP ports"),
+		})
+	}
+
+	if nftCtx.udpPorts != nil {
+		// udp sport @ports_udp meta mark set 0x0000e1f1 accept
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: outputChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictAccept},
+				checkPortIsInSet(nftCtx.udpPorts, unix.IPPROTO_UDP, matchSource),
+				setMetaMark(n.fwmark),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "from allowlist UDP ports"),
+		})
+	}
 
 	if config.MeshnetInfo != nil {
 		// oifname "nordlynx" ip daddr 100.64.0.0/10 accept
@@ -318,6 +311,19 @@ func (n *nft) addOutputChain(config firewall.Config, nftCtx *nftContext) {
 				checkIPIsPartOfSubnet(internal.MeshSubnet, matchDest, expr.CmpOpEq),
 			),
 			UserData: userdata.AppendString(nil, userdata.TypeComment, "local to meshnet"),
+		})
+	}
+
+	if len(config.TunnelInterface) > 0 {
+		// oif "nordtun" accept
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: outputChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictAccept},
+				checkInterfaceName(config.TunnelInterface, ifNameOutput, expr.CmpOpEq),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "local to VPN"),
 		})
 	}
 }
@@ -443,33 +449,6 @@ func (n *nft) addAllowlistPorts(config firewall.Config, nftCtx *nftContext) erro
 		if err := n.conn.AddSet(nftCtx.udpPorts, elements); err != nil {
 			return fmt.Errorf("add UDP ports set: %w", err)
 		}
-	}
-	return nil
-}
-
-func (n *nft) addExcludedInterfacesSet(config firewall.Config, nftCtx *nftContext) error {
-	elems := []nftables.SetElement{
-		{Key: ifname("lo")},
-	}
-	// add excluded interfaces set, lo and tunnel interface
-	nftCtx.excludedInterfaces = &nftables.Set{
-		Table:        nftCtx.table,
-		Name:         excludedInterfacesSetName,
-		KeyType:      nftables.TypeIFName,
-		KeyByteOrder: binaryutil.NativeEndian,
-		// Constant:     true, // disable for strings https://github.com/google/nftables/issues/177
-	}
-
-	tunInterfaceLen := len(config.TunnelInterface)
-	if tunInterfaceLen > 0 {
-		if tunInterfaceLen > unix.IFNAMSIZ {
-			return fmt.Errorf("interface name is too long: %s", config.TunnelInterface)
-		}
-		elems = append(elems, nftables.SetElement{Key: ifname(config.TunnelInterface)})
-	}
-
-	if err := n.conn.AddSet(nftCtx.excludedInterfaces, elems); err != nil {
-		return fmt.Errorf("add excluded interfaces set %w", err)
 	}
 	return nil
 }

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -378,7 +378,7 @@ func (n *nft) addForwardChain(config firewall.Config, nftCtx *nftContext) {
 				&expr.Verdict{Kind: expr.VerdictAccept},
 				checkInterfaceName(config.TunnelInterface, ifNameOutput, expr.CmpOpEq),
 			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "internet to allowlist IPs"),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "traffic to VPN"),
 		})
 
 		// iif "nordtun" ct state established,related accept

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -664,32 +664,6 @@ func (n *nft) addMeshPeerToInternet(config firewall.Config, nftCtx *nftContext) 
 		})
 	}
 
-	if nftCtx.tcpPorts != nil {
-		// tcp dport @ports_tcp accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: chain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkPortIsInSet(nftCtx.tcpPorts, unix.IPPROTO_TCP, matchDest),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "mesh peer to allowlist TCP"),
-		})
-	}
-
-	if nftCtx.udpPorts != nil {
-		// udp dport @ports_udp accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: chain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkPortIsInSet(nftCtx.udpPorts, unix.IPPROTO_UDP, matchDest),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "mesh peer to allowlist UDP"),
-		})
-	}
-
 	// allow traffic thru VPN when connected
 	// or when no VPN connected and KS=0, everywhere
 	if len(config.TunnelInterface) > 0 || !config.KillSwitch {
@@ -757,32 +731,6 @@ func (n *nft) addInternetToMeshPeer(config firewall.Config, nftCtx *nftContext) 
 				checkIPIsInSet(nftCtx.allowlistSubnets, matchSource),
 			),
 			UserData: userdata.AppendString(nil, userdata.TypeComment, "allowlist IPs to mesh peer"),
-		})
-	}
-
-	if nftCtx.tcpPorts != nil {
-		// tcp sport @ports_tcp accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: chain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkPortIsInSet(nftCtx.tcpPorts, unix.IPPROTO_TCP, matchSource),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "allowlist TCP to mesh peer"),
-		})
-	}
-
-	if nftCtx.udpPorts != nil {
-		// udp sport @ports_udp accept
-		n.conn.AddRule(&nftables.Rule{
-			Table: nftCtx.table,
-			Chain: chain,
-			Exprs: buildRules(
-				&expr.Verdict{Kind: expr.VerdictAccept},
-				checkPortIsInSet(nftCtx.udpPorts, unix.IPPROTO_UDP, matchSource),
-			),
-			UserData: userdata.AppendString(nil, userdata.TypeComment, "allowlist UDP to mesh peer"),
 		})
 	}
 

--- a/daemon/firewall/nft/nft_test.go
+++ b/daemon/firewall/nft/nft_test.go
@@ -1,10 +1,13 @@
 package nft
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/core/mesh"
 	"github.com/NordSecurity/nordvpn-linux/daemon/firewall"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/helpers"
 	"github.com/google/nftables"
@@ -64,4 +67,69 @@ func TestConfigure(t *testing.T) {
 			assert.NotNil(t, table)
 		})
 	}
+}
+
+func TestAllowlistPortsMarkedBeforeAcceptedByOtherRule(t *testing.T) {
+	category.Set(t, category.Root)
+	ns := helpers.OpenNewNamespace(t)
+	defer helpers.CleanNamespace(t, ns)
+
+	tunnelIface := "nordlynx"
+	n := GetTestNft()
+	require.NoError(t, n.Configure(firewall.Config{
+		TunnelInterface: tunnelIface,
+		KillSwitch:      true,
+		Allowlist: config.Allowlist{
+			Ports: config.Ports{
+				TCP: config.PortSet{55: true},
+				UDP: config.PortSet{55: true},
+			},
+		},
+		MeshnetInfo: &firewall.MeshInfo{
+			MeshInterface: tunnelIface,
+			MeshnetMap:    mesh.MachineMap{},
+		},
+	}))
+
+	tcpPortRule := fmt.Sprintf("tcp sport @%s meta mark set 0x%08x accept", tcpAllowlistSetName, n.fwmark)
+	udpPortRule := fmt.Sprintf("udp sport @%s meta mark set 0x%08x accept", udpAllowlistSetName, n.fwmark)
+	vpnAccept := fmt.Sprintf(`oifname "%s" accept`, tunnelIface)
+	meshAccept := fmt.Sprintf(`oifname "%s" ip daddr %s accept`, tunnelIface, internal.MeshSubnet)
+
+	helpers.WithNftCommandOutput(t, helpers.ListChain(outputChainName), func(out string) {
+		for _, portRule := range []string{tcpPortRule, udpPortRule} {
+			helpers.AssertRulesOrder(t, out, portRule, vpnAccept)
+			helpers.AssertRulesOrder(t, out, portRule, meshAccept)
+		}
+	})
+}
+
+func TestLanDNSDropBeforeAllowlistPorts(t *testing.T) {
+	category.Set(t, category.Root)
+	ns := helpers.OpenNewNamespace(t)
+	defer helpers.CleanNamespace(t, ns)
+
+	n := GetTestNft()
+	require.NoError(t, n.Configure(firewall.Config{
+		TunnelInterface: "nordlynx",
+		KillSwitch:      true,
+		Allowlist: config.Allowlist{
+			Ports: config.Ports{
+				TCP: config.PortSet{55: true},
+				UDP: config.PortSet{55: true},
+			},
+		},
+	}))
+
+	tcpDNSDrop := fmt.Sprintf("ip daddr @%s tcp dport %d drop", lanPrivateIpsSetName, defaultDNSPort)
+	udpDNSDrop := fmt.Sprintf("ip daddr @%s udp dport %d drop", lanPrivateIpsSetName, defaultDNSPort)
+	tcpPortRule := fmt.Sprintf("tcp sport @%s meta mark set 0x%08x accept", tcpAllowlistSetName, n.fwmark)
+	udpPortRule := fmt.Sprintf("udp sport @%s meta mark set 0x%08x accept", udpAllowlistSetName, n.fwmark)
+
+	helpers.WithNftCommandOutput(t, helpers.ListChain(outputChainName), func(out string) {
+		helpers.AssertRulesOrder(t, out, tcpDNSDrop, tcpPortRule)
+		helpers.AssertRulesOrder(t, out, tcpDNSDrop, udpPortRule)
+		helpers.AssertRulesOrder(t, out, udpDNSDrop, tcpPortRule)
+		helpers.AssertRulesOrder(t, out, udpDNSDrop, udpPortRule)
+	})
 }


### PR DESCRIPTION
## Context
- for main changes:
  - when container is started first, then VPN is connected, container does not have DNS updated so it uses local resolver I - this causes DNS traffic to be dropped in forward chain, so DNS wasn't working in containers
  - also there was no rule that would accept forwarded response so even correct order didn't work

## Changes

There are three changes in this PR

[Main changes](https://github.com/NordSecurity/nordvpn-linux/pull/1456/changes/a0eeaf19338fdc97424d5f4525767e23810fa0a0):
- tunnel traffic is accepted quicker, before DNS is dropped, so as long as DNS goes through the tunnel, it's ok
- also established traffic is accepted on forward, so responses come back so now container vs VPN doesn't matter

Additional changes:
- [reordered](https://github.com/NordSecurity/nordvpn-linux/pull/1456/changes/f4c1d9da1f63498ad515ee16f30586eb1710f276) output chain to optimize local and VPN traffic
- [removed](https://github.com/NordSecurity/nordvpn-linux/pull/1456/changes/c80ff4c335fc1c3461416936a18cfbb97f5420a6) TCP/UDP allowlist rules from forward chain