### PR TITLE
LVPN-9936: Reduce firewall reconfigure at network change

### DIFF
--- a/daemon/device/device.go
+++ b/daemon/device/device.go
@@ -178,9 +178,9 @@ func InterfacesAreEqual(a net.Interface, b net.Interface) bool {
 }
 
 // InterfacesWithDefaultRoute returns all the interfaces that have a default route, excluding the ones from ignoreSet
-func InterfacesWithDefaultRoute(ignoreSet mapset.Set[string]) map[string]net.Interface {
+func InterfacesWithDefaultRoute(ignoreSet mapset.Set[string]) mapset.Set[string] {
 	// get interface list from default routes
-	interfacesList := make(map[string]net.Interface)
+	interfacesList := mapset.NewSet[string]()
 
 	routeList, err := sysDepsImpl.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
@@ -194,7 +194,7 @@ func InterfacesWithDefaultRoute(ignoreSet mapset.Set[string]) map[string]net.Int
 
 		if iface, err := sysDepsImpl.InterfaceByIndex(r.LinkIndex); err == nil && iface != nil {
 			if ignoreSet == nil || !ignoreSet.Contains(iface.Name) {
-				interfacesList[iface.Name] = *iface
+				interfacesList.Add(iface.Name)
 			}
 		} else {
 			log.Println(internal.WarningPrefix, "default route, not found interface with index", r.LinkIndex, err)

--- a/daemon/device/device_test.go
+++ b/daemon/device/device_test.go
@@ -51,13 +51,9 @@ func TestInterfacesWithDefaultRoute(t *testing.T) {
 	category.Set(t, category.Unit)
 
 	setMockSysDeps(t)
-	expectedNames := []string{"en2", "virtual10"}
+	expectedNames := mapset.NewSet[string]("en2", "virtual10")
 	interfaces := InterfacesWithDefaultRoute(nil)
-	var names []string
-	for _, iface := range interfaces {
-		names = append(names, iface.Name)
-	}
-	assert.ElementsMatch(t, expectedNames, names)
+	assert.Equal(t, expectedNames, interfaces)
 }
 
 func TestListBlockedInterfaces(t *testing.T) {

--- a/daemon/firewall/firewall.go
+++ b/daemon/firewall/firewall.go
@@ -109,5 +109,9 @@ func (fw *Firewall) Flush() error {
 		return nil
 	}
 
+	if internal.IsDevEnv(fw.appEnvironment) {
+		log.Println(internal.DebugPrefix, logPrefix, "flush fw", internal.GetStack())
+	}
+
 	return fw.impl.Flush()
 }

--- a/daemon/vpn/quench/libquench.go
+++ b/daemon/vpn/quench/libquench.go
@@ -176,6 +176,7 @@ func (q *Quench) Start(ctx context.Context, creds vpn.Credentials, server vpn.Se
 
 	opts := quenchBindigns.NewVnicOptions()
 	opts.SetFwmark(q.fwmark)
+	// Set infinite timeout so the application can control the start/stop of the VPN connection
 	opts.SetConnectionTimeout(math.MaxUint64)
 
 	vnic, err := quenchBindigns.VnicFromName(q.vnicName, q.observer, &opts)

--- a/daemon/vpn/quench/libquench.go
+++ b/daemon/vpn/quench/libquench.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"net/netip"
 	"sync"
@@ -175,6 +176,7 @@ func (q *Quench) Start(ctx context.Context, creds vpn.Credentials, server vpn.Se
 
 	opts := quenchBindigns.NewVnicOptions()
 	opts.SetFwmark(q.fwmark)
+	opts.SetConnectionTimeout(math.MaxUint64)
 
 	vnic, err := quenchBindigns.VnicFromName(q.vnicName, q.observer, &opts)
 	if err != nil {

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -94,6 +94,14 @@ type Networker interface {
 	SetARPIgnore(bool) error
 }
 
+type killSwitchState int
+
+const (
+	enabledByUser killSwitchState = iota
+	disabledByUser
+	internallyEnabled
+)
+
 // Combined configures networking for VPN connections.
 //
 // It is implemented in such a way, that all public methods
@@ -136,7 +144,7 @@ type Combined struct {
 	ignoreARP       bool
 	arpIgnoreSetter kernel.SysctlSetter
 	allowlist       config.Allowlist
-	isKillSwitchSet bool
+	KillSwitchState killSwitchState
 	fwConfig        firewall.Config
 	ipForwardSetter kernel.SysctlSetter
 }
@@ -227,7 +235,7 @@ func failureRecover(netw *Combined) {
 		log.Println(internal.DeferPrefix, err)
 	}
 
-	if netw.isNetworkSet && !netw.isKillSwitchSet {
+	if netw.isNetworkSet && netw.KillSwitchState == disabledByUser {
 		if err := netw.unsetNetwork(); err != nil {
 			log.Println(internal.DeferPrefix, err)
 		}
@@ -515,7 +523,7 @@ func (netw *Combined) stop() error {
 		return err
 	}
 	netw.isVpnSet = false
-	if !netw.isKillSwitchSet {
+	if netw.KillSwitchState == disabledByUser {
 		if err = netw.unsetNetwork(); err != nil {
 			return fmt.Errorf("unsetting network: %w", err)
 		}
@@ -526,10 +534,8 @@ func (netw *Combined) stop() error {
 	}
 
 	// configure firewall
-	// remove tunnel interface and use the KS state, in case is set internally, e.g. at reconnect
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithTunnelInterface(""),
-		firewall.WithKillSwitch(netw.isKillSwitchSet),
 	)
 	if err := netw.configureFirewall(newCfg); err != nil {
 		return fmt.Errorf("configuring firewall at stop: %w", err)
@@ -620,7 +626,7 @@ func (netw *Combined) resetAllowlist() error {
 }
 
 // EnableFirewall activates the firewall and applies the rules
-// according to the user's settings. (killswitch, allowlist, meshnet)
+// according to the user's settings. (kill switch, allowlist, meshnet)
 func (netw *Combined) EnableFirewall() error {
 	netw.mu.Lock()
 	defer netw.mu.Unlock()
@@ -786,7 +792,7 @@ func (netw *Combined) UnsetFirewall() error {
 	netw.mu.Lock()
 	defer netw.mu.Unlock()
 
-	if netw.isKillSwitchSet {
+	if netw.KillSwitchState == enabledByUser {
 		return nil
 	}
 
@@ -825,7 +831,7 @@ func (netw *Combined) setKillSwitch() error {
 		return fmt.Errorf("enabling kill switch: %w", err)
 	}
 
-	netw.isKillSwitchSet = true
+	netw.KillSwitchState = enabledByUser
 	return nil
 }
 
@@ -851,7 +857,22 @@ func (netw *Combined) unsetKillSwitch() error {
 		return fmt.Errorf("disabling kill switch: %w", err)
 	}
 
-	netw.isKillSwitchSet = false
+	netw.KillSwitchState = disabledByUser
+	return nil
+}
+
+// This function is used to temporary enable KS when there is a VPN reconnect in background,
+// to prevent leaks
+func (netw *Combined) internallyEnabledKillSwitch() error {
+	newCfg := netw.fwConfig.CopyWith(
+		firewall.WithKillSwitch(true),
+	)
+
+	if err := netw.configureFirewall(newCfg); err != nil {
+		return fmt.Errorf("internally enabling kill switch failed: %w", err)
+	}
+
+	netw.KillSwitchState = internallyEnabled
 	return nil
 }
 

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -138,8 +138,7 @@ type Combined struct {
 	enableLocalTraffic bool
 	// list with the existing OS interfaces when VPN was connected.
 	// This is used at network changes to know when a new interface was inserted
-	interfaces mapset.Set[string]
-	// dnsDenied            bool
+	interfaces      mapset.Set[string]
 	ipv6Blocker     ipv6.Blocker
 	ignoreARP       bool
 	arpIgnoreSetter kernel.SysctlSetter

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -786,6 +786,10 @@ func (netw *Combined) UnsetFirewall() error {
 	netw.mu.Lock()
 	defer netw.mu.Unlock()
 
+	if netw.isKillSwitchSet {
+		return nil
+	}
+
 	if err := netw.unsetKillSwitch(); err != nil {
 		return fmt.Errorf("unset firewall: %w", err)
 	}

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -97,8 +97,8 @@ type Networker interface {
 type killSwitchState int
 
 const (
-	enabledByUser killSwitchState = iota
-	disabledByUser
+	disabledByUser killSwitchState = iota
+	enabledByUser
 	internallyEnabled
 )
 

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -786,10 +786,10 @@ func (netw *Combined) UnsetFirewall() error {
 	netw.mu.Lock()
 	defer netw.mu.Unlock()
 
-	// just refresh the firewall because the netw.fwConfig already contains the correct values
-	if err := netw.configureFirewall(netw.fwConfig); err != nil {
+	if err := netw.unsetKillSwitch(); err != nil {
 		return fmt.Errorf("unset firewall: %w", err)
 	}
+
 	return nil
 }
 

--- a/networker/vpn.go
+++ b/networker/vpn.go
@@ -120,8 +120,8 @@ func (netw *Combined) refreshVPN(ctx context.Context) (err error) {
 	defer func() { err = errors.Join(vpnErr, meshErr) }()
 
 	if isVPNStarted {
-		if !netw.isKillSwitchSet {
-			if err := netw.setKillSwitch(); err != nil {
+		if netw.KillSwitchState == disabledByUser {
+			if err := netw.internallyEnabledKillSwitch(); err != nil {
 				return fmt.Errorf("setting killswitch: %w", err)
 			}
 			defer func() {
@@ -129,8 +129,6 @@ func (netw *Combined) refreshVPN(ctx context.Context) (err error) {
 					vpnErr = netw.unsetKillSwitch()
 				} else {
 					log.Println(internal.InfoPrefix, "keeping killswitch, VPN failed to reconnect in background:", vpnErr)
-					// set the variable as false, but don't reconfigure the firewall
-					netw.isKillSwitchSet = false
 				}
 			}()
 		}

--- a/networker/vpn.go
+++ b/networker/vpn.go
@@ -129,6 +129,8 @@ func (netw *Combined) refreshVPN(ctx context.Context) (err error) {
 					vpnErr = netw.unsetKillSwitch()
 				} else {
 					log.Println(internal.InfoPrefix, "keeping killswitch, VPN failed to reconnect in background:", vpnErr)
+					// set the variable as false, but don't reconfigure the firewall
+					netw.isKillSwitchSet = false
 				}
 			}()
 		}

--- a/networker/vpn.go
+++ b/networker/vpn.go
@@ -92,12 +92,6 @@ func (netw *Combined) refreshVPN(ctx context.Context) (err error) {
 	isVPNStarted := netw.isVpnSet
 	isMeshStarted := netw.isMeshnetSet
 
-	if netw.isKillSwitchSet {
-		if err := netw.setKillSwitch(); err != nil {
-			return fmt.Errorf("setting killswitch: %w", err)
-		}
-	}
-
 	if !isVPNStarted && !isMeshStarted {
 		return nil
 	}
@@ -106,21 +100,17 @@ func (netw *Combined) refreshVPN(ctx context.Context) (err error) {
 	if netw.vpnet != nil && netw.vpnet.Tun() != nil {
 		tunnelName = netw.vpnet.Tun().Interface().Name
 	}
-	newInterfaces := device.OutsideCapableTrafficIfNames(mapset.NewSet(tunnelName))
+	newInterfaces := device.InterfacesWithDefaultRoute(mapset.NewSet(tunnelName))
 	newInterfaceDetected := !newInterfaces.IsSubset(netw.interfaces)
 	log.Println(internal.InfoPrefix,
 		"refresh VPN, new interface detected[]:",
 		newInterfaceDetected,
 		netw.interfaces, "->", newInterfaces)
 
-	if !newInterfaceDetected {
-		// if there is no new OS interface, just reconfigure the VPN internally if possible
-		errNetChanged := netw.handleNetworkChanged()
-		if errNetChanged == nil {
-			return nil
-		}
-
-		log.Println(internal.ErrorPrefix, "failed to handle network changes, reinit the tunnel", errNetChanged)
+	if err := netw.handleNetworkChanged(); err == nil {
+		return nil
+	} else {
+		log.Println(internal.ErrorPrefix, "failed to handle network changes, reinit the tunnel", err)
 	}
 
 	netw.interfaces = newInterfaces
@@ -135,11 +125,10 @@ func (netw *Combined) refreshVPN(ctx context.Context) (err error) {
 				return fmt.Errorf("setting killswitch: %w", err)
 			}
 			defer func() {
-				if vpnErr != nil {
-					// Keep iptables rules to not expose user after background connect failure
-					netw.isKillSwitchSet = false
-				} else {
+				if vpnErr == nil {
 					vpnErr = netw.unsetKillSwitch()
+				} else {
+					log.Println(internal.InfoPrefix, "keeping killswitch, VPN failed to reconnect in background:", vpnErr)
 				}
 			}()
 		}


### PR DESCRIPTION
* At network changes remove some of firewall reconfigure, because it is set to block all.
* Monitor only interfaces that have default route for VPN reconnect
* Make again `nordvpn d` cleanup the firewall, if is executed when not connected to VPN and killswitch is off.
* Change kill switch type from bool to enum to better understand its state from networker