### PR TITLE
LVPN-10513: Allow responses from peer without incoming access

### DIFF
--- a/daemon/firewall/nft/match_expr.go
+++ b/daemon/firewall/nft/match_expr.go
@@ -272,6 +272,25 @@ func checkMetaMarkAndSetCtMark(fwmark uint32) []expr.Any {
 	}
 }
 
+// ct original saddr <ip>
+func checkCtOriginalSrcIP(ip netip.Addr) []expr.Any {
+	addr := ip.As4()
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
+		&expr.Cmp{
+			Register: 1,
+			Op:       expr.CmpOpEq,
+			Data:     []byte{unix.NFPROTO_IPV4},
+		},
+		&expr.Ct{Register: 1, Key: expr.CtKeySRC, Direction: 0},
+		&expr.Cmp{
+			Register: 1,
+			Op:       expr.CmpOpEq,
+			Data:     addr[:],
+		},
+	}
+}
+
 // ip saddr 100.64.0.0/10
 func checkIPIsPartOfSubnet(pfx netip.Prefix, match matchType, op expr.CmpOp) []expr.Any {
 	var offset uint32 = 12

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -165,7 +165,7 @@ func (n *nft) addInputChain(config firewall.Config, nftCtx *nftContext) {
 	// meshnet
 	if config.MeshnetInfo != nil {
 		// Add chain for the meshnet and the jump rule to it
-		meshChain := n.addMeshnetInputChain(nftCtx, config.MeshnetInfo.MeshnetMap.Machine.Address)
+		meshChain := n.addMeshnetInputChain(nftCtx, config.MeshnetInfo.MeshnetMap.Address)
 
 		// iifname "nordlynx" ip saddr 100.64.0.0/10 jump mesh_input
 		n.conn.AddRule(&nftables.Rule{

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -2,6 +2,7 @@ package nft
 
 import (
 	"fmt"
+	"net/netip"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/core/mesh"
@@ -164,7 +165,7 @@ func (n *nft) addInputChain(config firewall.Config, nftCtx *nftContext) {
 	// meshnet
 	if config.MeshnetInfo != nil {
 		// Add chain for the meshnet and the jump rule to it
-		meshChain := n.addMeshnetInputChain(nftCtx)
+		meshChain := n.addMeshnetInputChain(nftCtx, config.MeshnetInfo.MeshnetMap.Machine.Address)
 
 		// iifname "nordlynx" ip saddr 100.64.0.0/10 jump mesh_input
 		n.conn.AddRule(&nftables.Rule{
@@ -501,7 +502,7 @@ func (n *nft) addAllowlistInputChain(nftCtx *nftContext) *nftables.Chain {
 	return chain
 }
 
-func (n *nft) addMeshnetInputChain(nftCtx *nftContext) *nftables.Chain {
+func (n *nft) addMeshnetInputChain(nftCtx *nftContext, selfMeshIP netip.Addr) *nftables.Chain {
 	// the chain is not hooked to anything, it is called from input chain
 	meshChain := n.conn.AddChain(&nftables.Chain{
 		Name:  meshInputChainName,
@@ -518,6 +519,20 @@ func (n *nft) addMeshnetInputChain(nftCtx *nftContext) *nftables.Chain {
 		),
 		UserData: userdata.AppendString(nil, userdata.TypeComment, "meshnet private IP"),
 	})
+
+	// ct state established,related ct original saddr <selfMeshIP> accept
+	if selfMeshIP.IsValid() {
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: meshChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictAccept},
+				checkCtState(expr.CtStateBitESTABLISHED|expr.CtStateBitRELATED),
+				checkCtOriginalSrcIP(selfMeshIP),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "responses to my connections only"),
+		})
+	}
 
 	if nftCtx.fileshareAllowedPeers != nil {
 		// tcp dport 49111 ip saddr @fileshare_allowed_peers accept

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -521,7 +521,7 @@ func (n *nft) addMeshnetInputChain(nftCtx *nftContext, selfMeshIP netip.Addr) *n
 	})
 
 	// ct state established,related ct original saddr <selfMeshIP> accept
-	if selfMeshIP.IsValid() {
+	if selfMeshIP.Is4() {
 		n.conn.AddRule(&nftables.Rule{
 			Table: nftCtx.table,
 			Chain: meshChain,

--- a/daemon/firewall/nft/nft_snapshot_test.go
+++ b/daemon/firewall/nft/nft_snapshot_test.go
@@ -16,6 +16,8 @@ const (
 	ifName = "nordlynx"
 )
 
+var selfMeshIP = netip.MustParseAddr("100.64.0.1")
+
 func TestVPNRuleset(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -68,12 +70,12 @@ func TestMeshnetRuleset(t *testing.T) {
 	}{
 		{
 			name:   "without peers",
-			config: helpers.NewFWConfig().Meshnet(ifName),
+			config: helpers.NewFWConfig().Meshnet(ifName, selfMeshIP),
 		},
 		{
 			name: "peer with lan_access",
 			config: helpers.NewFWConfig().
-				Meshnet(ifName).
+				Meshnet(ifName, selfMeshIP).
 				MeshPeer(mesh.MachinePeer{
 					Address:              netip.MustParseAddr(peerIP),
 					DoIAllowLocalNetwork: true,
@@ -83,7 +85,7 @@ func TestMeshnetRuleset(t *testing.T) {
 		{
 			name: "host allows routing",
 			config: helpers.NewFWConfig().
-				Meshnet(ifName).
+				Meshnet(ifName, selfMeshIP).
 				MeshPeer(mesh.MachinePeer{
 					Address:         netip.MustParseAddr(peerIP),
 					DoIAllowRouting: true,
@@ -92,7 +94,7 @@ func TestMeshnetRuleset(t *testing.T) {
 		{
 			name: "host allows inbound but_no_routing",
 			config: helpers.NewFWConfig().
-				Meshnet(ifName).
+				Meshnet(ifName, selfMeshIP).
 				MeshPeer(mesh.MachinePeer{
 					Address:         netip.MustParseAddr(peerIP),
 					DoIAllowInbound: true,
@@ -102,7 +104,7 @@ func TestMeshnetRuleset(t *testing.T) {
 		{
 			name: "with fileshare",
 			config: helpers.NewFWConfig().
-				Meshnet(ifName).
+				Meshnet(ifName, selfMeshIP).
 				MeshPeer(mesh.MachinePeer{
 					Address:           netip.MustParseAddr(peerIP),
 					DoIAllowFileshare: true,
@@ -111,7 +113,7 @@ func TestMeshnetRuleset(t *testing.T) {
 		{
 			name: "with blocked fileshare",
 			config: helpers.NewFWConfig().
-				Meshnet(ifName).
+				Meshnet(ifName, selfMeshIP).
 				BlockFileshare().
 				MeshPeer(mesh.MachinePeer{
 					Address:           netip.MustParseAddr(peerIP),
@@ -121,7 +123,7 @@ func TestMeshnetRuleset(t *testing.T) {
 		{
 			name: "peer with full permissions",
 			config: helpers.NewFWConfig().
-				Meshnet(ifName).
+				Meshnet(ifName, selfMeshIP).
 				MeshPeer(mesh.MachinePeer{
 					Address:              netip.MustParseAddr(peerIP),
 					DoIAllowFileshare:    true,

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_inbound_but_no_routing.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_inbound_but_no_routing.golden
@@ -36,6 +36,7 @@ table inet nordvpn {
 
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
+		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_routing.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_routing.golden
@@ -36,6 +36,7 @@ table inet nordvpn {
 
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
+		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/peer_with_full_permissions.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/peer_with_full_permissions.golden
@@ -39,6 +39,7 @@ table inet nordvpn {
 
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
+		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/peer_with_lan_access.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/peer_with_lan_access.golden
@@ -36,6 +36,7 @@ table inet nordvpn {
 
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
+		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_blocked_fileshare.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_blocked_fileshare.golden
@@ -30,6 +30,7 @@ table inet nordvpn {
 
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
+		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"
 		drop

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_fileshare.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_fileshare.golden
@@ -36,6 +36,7 @@ table inet nordvpn {
 
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
+		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/without_peers.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/without_peers.golden
@@ -35,6 +35,7 @@ table inet nordvpn {
 
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
+		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"

--- a/test/helpers/fw_config_builder.go
+++ b/test/helpers/fw_config_builder.go
@@ -8,8 +8,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/firewall"
 )
 
-const DefaultMachineAddr = "100.64.0.1"
-
 type FirewallConfigBuilder struct {
 	cfg firewall.Config
 }
@@ -54,9 +52,9 @@ func (b *FirewallConfigBuilder) BlockFileshare() *FirewallConfigBuilder {
 	return b
 }
 
-func (b *FirewallConfigBuilder) Meshnet(iface string) *FirewallConfigBuilder {
+func (b *FirewallConfigBuilder) Meshnet(iface string, selfMeshIP netip.Addr) *FirewallConfigBuilder {
 	b.cfg.MeshnetInfo = &firewall.MeshInfo{MeshInterface: iface}
-	b.cfg.MeshnetInfo.MeshnetMap.Machine.Address = netip.MustParseAddr(DefaultMachineAddr)
+	b.cfg.MeshnetInfo.MeshnetMap.Address = selfMeshIP
 	return b
 }
 

--- a/test/helpers/fw_config_builder.go
+++ b/test/helpers/fw_config_builder.go
@@ -1,10 +1,14 @@
 package helpers
 
 import (
+	"net/netip"
+
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/core/mesh"
 	"github.com/NordSecurity/nordvpn-linux/daemon/firewall"
 )
+
+const DefaultMachineAddr = "100.64.0.1"
 
 type FirewallConfigBuilder struct {
 	cfg firewall.Config
@@ -52,6 +56,7 @@ func (b *FirewallConfigBuilder) BlockFileshare() *FirewallConfigBuilder {
 
 func (b *FirewallConfigBuilder) Meshnet(iface string) *FirewallConfigBuilder {
 	b.cfg.MeshnetInfo = &firewall.MeshInfo{MeshInterface: iface}
+	b.cfg.MeshnetInfo.MeshnetMap.Machine.Address = netip.MustParseAddr(DefaultMachineAddr)
 	return b
 }
 


### PR DESCRIPTION
Details:
- when host denies incoming connections for peer, it should still be able to communicate with peer and receive responses
- this PR modifies `meshnet_input` chain to allow that:
```nft
chain mesh_input {
  ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
  ct state established,related ct original ip saddr <host_mesh_ip> accept comment "responses to my connections only"   <---- new
  tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
  tcp dport 49111 drop comment "meshnet to fileshare"
  ip saddr @allow_incoming_connections accept comment "meshnet to local"
  drop
}
```