### PR TITLE
LVPN-10431: Don't add rules if meshnet sets are empty

### DIFF
--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -833,23 +833,20 @@ func (n *nft) addLanRangesSet(nftCtx *nftContext) error {
 }
 
 func (n *nft) addFilesharePeers(meshMap mesh.MachineMap, nftCtx *nftContext) error {
+	elems := convertPeersToSetElements(
+		meshMap.Peers,
+		func(peer mesh.MachinePeer) bool { return peer.DoIAllowFileshare },
+	)
+	if len(elems) == 0 {
+		return nil
+	}
+
 	nftCtx.fileshareAllowedPeers = &nftables.Set{
 		Table:    nftCtx.table,
 		Name:     fileshareAllowedPeersSet,
 		KeyType:  nftables.TypeIPAddr,
 		Interval: false,
 		Constant: true,
-	}
-
-	var elems []nftables.SetElement
-	for _, peer := range meshMap.Peers {
-		if !peer.Address.Is4() {
-			continue
-		}
-
-		if peer.DoIAllowFileshare {
-			elems = append(elems, nftables.SetElement{Key: peer.Address.AsSlice()})
-		}
 	}
 
 	if err := n.conn.AddSet(nftCtx.fileshareAllowedPeers, elems); err != nil {
@@ -860,24 +857,20 @@ func (n *nft) addFilesharePeers(meshMap mesh.MachineMap, nftCtx *nftContext) err
 }
 
 func (n *nft) addLanAllowedPeers(meshMap mesh.MachineMap, nftCtx *nftContext) error {
+	elems := convertPeersToSetElements(
+		meshMap.Peers,
+		func(peer mesh.MachinePeer) bool { return peer.DoIAllowRouting && peer.DoIAllowLocalNetwork },
+	)
+	if len(elems) == 0 {
+		return nil
+	}
+
 	nftCtx.meshLanAllowedPeers = &nftables.Set{
 		Table:    nftCtx.table,
 		Name:     lanAccessPeersSet,
 		KeyType:  nftables.TypeIPAddr,
 		Interval: false,
 		Constant: true,
-	}
-
-	var elems []nftables.SetElement
-	for _, peer := range meshMap.Peers {
-		if !peer.Address.IsValid() {
-			continue
-		}
-
-		lanAllowed := peer.DoIAllowRouting && peer.DoIAllowLocalNetwork
-		if lanAllowed {
-			elems = append(elems, nftables.SetElement{Key: peer.Address.AsSlice()})
-		}
 	}
 
 	if err := n.conn.AddSet(nftCtx.meshLanAllowedPeers, elems); err != nil {
@@ -888,25 +881,20 @@ func (n *nft) addLanAllowedPeers(meshMap mesh.MachineMap, nftCtx *nftContext) er
 }
 
 func (n *nft) addAllowedIncomingConnections(meshMap mesh.MachineMap, nftCtx *nftContext) error {
+	elems := convertPeersToSetElements(
+		meshMap.Peers,
+		func(peer mesh.MachinePeer) bool { return peer.DoIAllowInbound },
+	)
+	if len(elems) == 0 {
+		return nil
+	}
+
 	nftCtx.meshAllowedIncomingConnections = &nftables.Set{
 		Table:    nftCtx.table,
 		Name:     allowIncomingConnectionPeersSet,
 		KeyType:  nftables.TypeIPAddr,
 		Interval: false,
 		Constant: true,
-	}
-
-	var elems []nftables.SetElement
-	for _, peer := range meshMap.Peers {
-		if !peer.Address.IsValid() {
-			continue
-		}
-
-		if peer.DoIAllowInbound {
-			elems = append(elems,
-				nftables.SetElement{Key: peer.Address.AsSlice()},
-			)
-		}
 	}
 
 	if err := n.conn.AddSet(nftCtx.meshAllowedIncomingConnections, elems); err != nil {
@@ -917,25 +905,20 @@ func (n *nft) addAllowedIncomingConnections(meshMap mesh.MachineMap, nftCtx *nft
 }
 
 func (n *nft) addAllowedRoutingPeers(meshMap mesh.MachineMap, nftCtx *nftContext) error {
+	elems := convertPeersToSetElements(
+		meshMap.Peers,
+		func(peer mesh.MachinePeer) bool { return peer.DoIAllowRouting },
+	)
+	if len(elems) == 0 {
+		return nil
+	}
+
 	nftCtx.meshRoutingAllowed = &nftables.Set{
 		Table:    nftCtx.table,
 		Name:     allowTrafficRoutingPeersSet,
 		KeyType:  nftables.TypeIPAddr,
 		Interval: false,
 		Constant: true,
-	}
-
-	var elems []nftables.SetElement
-	for _, peer := range meshMap.Peers {
-		if !peer.Address.IsValid() {
-			continue
-		}
-
-		if peer.DoIAllowRouting {
-			elems = append(elems,
-				nftables.SetElement{Key: peer.Address.AsSlice()},
-			)
-		}
 	}
 
 	if err := n.conn.AddSet(nftCtx.meshRoutingAllowed, elems); err != nil {
@@ -981,4 +964,22 @@ func (n *nft) addMainTable() *nftables.Table {
 		Family: nftables.TableFamilyINet,
 		Name:   tableName,
 	})
+}
+
+func convertPeersToSetElements(
+	peers mesh.MachinePeers,
+	fn func(peer mesh.MachinePeer) bool,
+) []nftables.SetElement {
+
+	var elems []nftables.SetElement
+	for _, peer := range peers {
+		if !peer.Address.Is4() {
+			continue
+		}
+		if fn(peer) {
+			elems = append(elems, nftables.SetElement{Key: peer.Address.AsSlice()})
+		}
+	}
+
+	return elems
 }

--- a/daemon/firewall/nft/nft_snapshot_test.go
+++ b/daemon/firewall/nft/nft_snapshot_test.go
@@ -19,6 +19,8 @@ const (
 var selfMeshIP = netip.MustParseAddr("100.64.0.1")
 
 func TestVPNRuleset(t *testing.T) {
+	category.Set(t, category.Root)
+
 	tests := []struct {
 		name   string
 		config *helpers.FirewallConfigBuilder
@@ -64,6 +66,8 @@ func TestVPNRuleset(t *testing.T) {
 }
 
 func TestMeshnetRuleset(t *testing.T) {
+	category.Set(t, category.Root)
+
 	tests := []struct {
 		name   string
 		config *helpers.FirewallConfigBuilder

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_inbound_but_no_routing.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_inbound_but_no_routing.golden
@@ -6,21 +6,6 @@ table inet nordvpn {
 			     172.16.0.0/12, 192.168.0.0/16 }
 	}
 
-	set fileshare_allowed_peers {
-		type ipv4_addr
-		flags constant
-	}
-
-	set peer_local_network_access {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_peer_traffic_routing {
-		type ipv4_addr
-		flags constant
-	}
-
 	set allow_incoming_connections {
 		type ipv4_addr
 		flags constant
@@ -37,7 +22,6 @@ table inet nordvpn {
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
 		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
-		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"
 		drop
@@ -53,26 +37,5 @@ table inet nordvpn {
 
 	chain forward {
 		type filter hook forward priority filter; policy accept;
-		ip saddr 100.64.0.0/10 jump mesh_peer_to_internet comment "traffic from mesh peer"
-		ip daddr 100.64.0.0/10 jump internet_to_mesh_peer comment "traffic to mesh peer"
-	}
-
-	chain mesh_peer_to_internet {
-		ip saddr != @allow_peer_traffic_routing drop comment "traffic from not allowed peers"
-		ip daddr @lan_ranges ip saddr != @peer_local_network_access drop comment "mesh peer to LAN"
-		ip daddr != 100.64.0.0/10 accept comment "mesh peer to VPN"
-		drop
-	}
-
-	chain internet_to_mesh_peer {
-		ip daddr != @allow_peer_traffic_routing drop comment "traffic to allowed peers"
-		ip saddr @lan_ranges ip daddr != @peer_local_network_access drop comment "LAN to mesh peer"
-		oifname "nordlynx" ct state established,related accept comment "response to mesh peer"
-		drop
-	}
-
-	chain mesh_nat {
-		type nat hook postrouting priority srcnat; policy accept;
-		ip saddr @allow_peer_traffic_routing ip daddr != 100.64.0.0/10 masquerade
 	}
 }

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_routing.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/host_allows_routing.golden
@@ -6,25 +6,10 @@ table inet nordvpn {
 			     172.16.0.0/12, 192.168.0.0/16 }
 	}
 
-	set fileshare_allowed_peers {
-		type ipv4_addr
-		flags constant
-	}
-
-	set peer_local_network_access {
-		type ipv4_addr
-		flags constant
-	}
-
 	set allow_peer_traffic_routing {
 		type ipv4_addr
 		flags constant
 		elements = { 100.113.144.142 }
-	}
-
-	set allow_incoming_connections {
-		type ipv4_addr
-		flags constant
 	}
 
 	chain input {
@@ -37,9 +22,7 @@ table inet nordvpn {
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
 		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
-		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
-		ip saddr @allow_incoming_connections accept comment "meshnet to local"
 		drop
 	}
 
@@ -59,14 +42,12 @@ table inet nordvpn {
 
 	chain mesh_peer_to_internet {
 		ip saddr != @allow_peer_traffic_routing drop comment "traffic from not allowed peers"
-		ip daddr @lan_ranges ip saddr != @peer_local_network_access drop comment "mesh peer to LAN"
 		ip daddr != 100.64.0.0/10 accept comment "mesh peer to VPN"
 		drop
 	}
 
 	chain internet_to_mesh_peer {
 		ip daddr != @allow_peer_traffic_routing drop comment "traffic to allowed peers"
-		ip saddr @lan_ranges ip daddr != @peer_local_network_access drop comment "LAN to mesh peer"
 		oifname "nordlynx" ct state established,related accept comment "response to mesh peer"
 		drop
 	}

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/peer_with_lan_access.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/peer_with_lan_access.golden
@@ -6,21 +6,6 @@ table inet nordvpn {
 			     172.16.0.0/12, 192.168.0.0/16 }
 	}
 
-	set fileshare_allowed_peers {
-		type ipv4_addr
-		flags constant
-	}
-
-	set peer_local_network_access {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_peer_traffic_routing {
-		type ipv4_addr
-		flags constant
-	}
-
 	set allow_incoming_connections {
 		type ipv4_addr
 		flags constant
@@ -37,7 +22,6 @@ table inet nordvpn {
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
 		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
-		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
 		ip saddr @allow_incoming_connections accept comment "meshnet to local"
 		drop
@@ -53,26 +37,5 @@ table inet nordvpn {
 
 	chain forward {
 		type filter hook forward priority filter; policy accept;
-		ip saddr 100.64.0.0/10 jump mesh_peer_to_internet comment "traffic from mesh peer"
-		ip daddr 100.64.0.0/10 jump internet_to_mesh_peer comment "traffic to mesh peer"
-	}
-
-	chain mesh_peer_to_internet {
-		ip saddr != @allow_peer_traffic_routing drop comment "traffic from not allowed peers"
-		ip daddr @lan_ranges ip saddr != @peer_local_network_access drop comment "mesh peer to LAN"
-		ip daddr != 100.64.0.0/10 accept comment "mesh peer to VPN"
-		drop
-	}
-
-	chain internet_to_mesh_peer {
-		ip daddr != @allow_peer_traffic_routing drop comment "traffic to allowed peers"
-		ip saddr @lan_ranges ip daddr != @peer_local_network_access drop comment "LAN to mesh peer"
-		oifname "nordlynx" ct state established,related accept comment "response to mesh peer"
-		drop
-	}
-
-	chain mesh_nat {
-		type nat hook postrouting priority srcnat; policy accept;
-		ip saddr @allow_peer_traffic_routing ip daddr != 100.64.0.0/10 masquerade
 	}
 }

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_blocked_fileshare.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_blocked_fileshare.golden
@@ -6,21 +6,6 @@ table inet nordvpn {
 			     172.16.0.0/12, 192.168.0.0/16 }
 	}
 
-	set peer_local_network_access {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_peer_traffic_routing {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_incoming_connections {
-		type ipv4_addr
-		flags constant
-	}
-
 	chain input {
 		type filter hook input priority filter; policy accept;
 		iifname "lo" accept comment "local to local"
@@ -32,7 +17,6 @@ table inet nordvpn {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
 		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 drop comment "meshnet to fileshare"
-		ip saddr @allow_incoming_connections accept comment "meshnet to local"
 		drop
 	}
 
@@ -46,26 +30,5 @@ table inet nordvpn {
 
 	chain forward {
 		type filter hook forward priority filter; policy accept;
-		ip saddr 100.64.0.0/10 jump mesh_peer_to_internet comment "traffic from mesh peer"
-		ip daddr 100.64.0.0/10 jump internet_to_mesh_peer comment "traffic to mesh peer"
-	}
-
-	chain mesh_peer_to_internet {
-		ip saddr != @allow_peer_traffic_routing drop comment "traffic from not allowed peers"
-		ip daddr @lan_ranges ip saddr != @peer_local_network_access drop comment "mesh peer to LAN"
-		ip daddr != 100.64.0.0/10 accept comment "mesh peer to VPN"
-		drop
-	}
-
-	chain internet_to_mesh_peer {
-		ip daddr != @allow_peer_traffic_routing drop comment "traffic to allowed peers"
-		ip saddr @lan_ranges ip daddr != @peer_local_network_access drop comment "LAN to mesh peer"
-		oifname "nordlynx" ct state established,related accept comment "response to mesh peer"
-		drop
-	}
-
-	chain mesh_nat {
-		type nat hook postrouting priority srcnat; policy accept;
-		ip saddr @allow_peer_traffic_routing ip daddr != 100.64.0.0/10 masquerade
 	}
 }

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_fileshare.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/with_fileshare.golden
@@ -12,21 +12,6 @@ table inet nordvpn {
 		elements = { 100.113.144.142 }
 	}
 
-	set peer_local_network_access {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_peer_traffic_routing {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_incoming_connections {
-		type ipv4_addr
-		flags constant
-	}
-
 	chain input {
 		type filter hook input priority filter; policy accept;
 		iifname "lo" accept comment "local to local"
@@ -39,7 +24,6 @@ table inet nordvpn {
 		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
 		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
-		ip saddr @allow_incoming_connections accept comment "meshnet to local"
 		drop
 	}
 
@@ -53,26 +37,5 @@ table inet nordvpn {
 
 	chain forward {
 		type filter hook forward priority filter; policy accept;
-		ip saddr 100.64.0.0/10 jump mesh_peer_to_internet comment "traffic from mesh peer"
-		ip daddr 100.64.0.0/10 jump internet_to_mesh_peer comment "traffic to mesh peer"
-	}
-
-	chain mesh_peer_to_internet {
-		ip saddr != @allow_peer_traffic_routing drop comment "traffic from not allowed peers"
-		ip daddr @lan_ranges ip saddr != @peer_local_network_access drop comment "mesh peer to LAN"
-		ip daddr != 100.64.0.0/10 accept comment "mesh peer to VPN"
-		drop
-	}
-
-	chain internet_to_mesh_peer {
-		ip daddr != @allow_peer_traffic_routing drop comment "traffic to allowed peers"
-		ip saddr @lan_ranges ip daddr != @peer_local_network_access drop comment "LAN to mesh peer"
-		oifname "nordlynx" ct state established,related accept comment "response to mesh peer"
-		drop
-	}
-
-	chain mesh_nat {
-		type nat hook postrouting priority srcnat; policy accept;
-		ip saddr @allow_peer_traffic_routing ip daddr != 100.64.0.0/10 masquerade
 	}
 }

--- a/daemon/firewall/nft/testdata/TestMeshnetRuleset/without_peers.golden
+++ b/daemon/firewall/nft/testdata/TestMeshnetRuleset/without_peers.golden
@@ -6,26 +6,6 @@ table inet nordvpn {
 			     172.16.0.0/12, 192.168.0.0/16 }
 	}
 
-	set fileshare_allowed_peers {
-		type ipv4_addr
-		flags constant
-	}
-
-	set peer_local_network_access {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_peer_traffic_routing {
-		type ipv4_addr
-		flags constant
-	}
-
-	set allow_incoming_connections {
-		type ipv4_addr
-		flags constant
-	}
-
 	chain input {
 		type filter hook input priority filter; policy accept;
 		iifname "lo" accept comment "local to local"
@@ -36,9 +16,7 @@ table inet nordvpn {
 	chain mesh_input {
 		ip saddr 100.64.0.0/29 accept comment "meshnet private IP"
 		ct state established,related ct original ip saddr 100.64.0.1 accept comment "responses to my connections only"
-		tcp dport 49111 ip saddr @fileshare_allowed_peers accept comment "meshnet to fileshare"
 		tcp dport 49111 drop comment "meshnet to fileshare"
-		ip saddr @allow_incoming_connections accept comment "meshnet to local"
 		drop
 	}
 
@@ -52,26 +30,5 @@ table inet nordvpn {
 
 	chain forward {
 		type filter hook forward priority filter; policy accept;
-		ip saddr 100.64.0.0/10 jump mesh_peer_to_internet comment "traffic from mesh peer"
-		ip daddr 100.64.0.0/10 jump internet_to_mesh_peer comment "traffic to mesh peer"
-	}
-
-	chain mesh_peer_to_internet {
-		ip saddr != @allow_peer_traffic_routing drop comment "traffic from not allowed peers"
-		ip daddr @lan_ranges ip saddr != @peer_local_network_access drop comment "mesh peer to LAN"
-		ip daddr != 100.64.0.0/10 accept comment "mesh peer to VPN"
-		drop
-	}
-
-	chain internet_to_mesh_peer {
-		ip daddr != @allow_peer_traffic_routing drop comment "traffic to allowed peers"
-		ip saddr @lan_ranges ip daddr != @peer_local_network_access drop comment "LAN to mesh peer"
-		oifname "nordlynx" ct state established,related accept comment "response to mesh peer"
-		drop
-	}
-
-	chain mesh_nat {
-		type nat hook postrouting priority srcnat; policy accept;
-		ip saddr @allow_peer_traffic_routing ip daddr != 100.64.0.0/10 masquerade
 	}
 }


### PR DESCRIPTION
For meshnet if no peer is part of the sets then the sets are not added anymore.
Also if no peer is allow to route traffic thru current machine, meshnet NAT is not added.