### PR TITLE
LVPN-10524: Excluding third-party code from tests

### DIFF
--- a/.golangci-lint.yml
+++ b/.golangci-lint.yml
@@ -28,8 +28,8 @@ linters:
     paths:
       - third-party
     rules:
-      - linters: 
-        - staticcheck
+      - linters:
+          - staticcheck
         text: "ST1005:" # systematically, disable all the linter issues on errors strings capitalization, or ending with a punctuation mark
   settings:
     depguard:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -24,7 +24,7 @@ if [ "${1:-""}" = "full" ]; then
 	source "${WORKDIR}"/ci/add_private_bindings.sh moose/events "${LIBMOOSE_NORDVPNAPP_BINDINGS_PATH}"
 	source "${WORKDIR}"/ci/add_private_bindings.sh moose/worker "${LIBMOOSE_WORKER_BINDINGS_PATH}"
 
-	excluded_packages="thisshouldneverexist"
+	excluded_packages="third-party"
 	excluded_categories="notworking"
 	tags="internal,moose"
 	parallel="-p 1"


### PR DESCRIPTION
Excluding `/third-party` code testing.