### PR TITLE
LVPN-10518: Fix lan discovery reset

### DIFF
--- a/daemon/job_servers_test.go
+++ b/daemon/job_servers_test.go
@@ -135,6 +135,7 @@ func (m *mockConfigManager) Load(c *config.Config) error {
 	c.MeshDevice = m.c.MeshDevice
 	c.MeshPrivateKey = m.c.MeshPrivateKey
 	c.VirtualLocation = m.c.VirtualLocation
+	c.LanDiscovery = m.c.LanDiscovery
 	return nil
 }
 

--- a/daemon/rpc_set_defaults.go
+++ b/daemon/rpc_set_defaults.go
@@ -68,7 +68,14 @@ func (r *RPC) SetDefaults(ctx context.Context, in *pb.SetDefaultsRequest) (*pb.P
 		}, nil
 	}
 	r.netw.SetVPN(v)
-	_ = r.netw.SetARPIgnore(cfg.ARPIgnore.Get())
+
+	if err = r.netw.SetARPIgnore(cfg.ARPIgnore.Get()); err != nil {
+		log.Warn("resetting arp ignore failed:", err)
+	}
+	r.netw.SetLanDiscovery(cfg.LanDiscovery)
+	if err := r.netw.SetAllowlist(cfg.AutoConnectData.Allowlist); err != nil {
+		log.Warn("resetting allowlist failed:", err)
+	}
 
 	r.events.Settings.Defaults.Publish(nil)
 	r.events.Settings.Publish(cfg)

--- a/daemon/rpc_set_defaults.go
+++ b/daemon/rpc_set_defaults.go
@@ -73,7 +73,7 @@ func (r *RPC) SetDefaults(ctx context.Context, in *pb.SetDefaultsRequest) (*pb.P
 		log.Warn("resetting arp ignore failed:", err)
 	}
 	r.netw.SetLanDiscovery(cfg.LanDiscovery)
-	if err := r.netw.SetAllowlist(cfg.AutoConnectData.Allowlist); err != nil {
+	if err = r.netw.SetAllowlist(cfg.AutoConnectData.Allowlist); err != nil {
 		log.Warn("resetting allowlist failed:", err)
 	}
 

--- a/daemon/rpc_set_defaults_test.go
+++ b/daemon/rpc_set_defaults_test.go
@@ -96,3 +96,26 @@ func TestResetToDefaults_PauseVariants(t *testing.T) {
 		})
 	}
 }
+
+func TestSetDefaults_ResetsNetworkerLanDiscoveryAndAllowlist(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	netw := &networker.Mock{
+		LanDiscovery: true,
+		Allowlist: config.Allowlist{
+			Ports: config.Ports{
+				TCP: config.PortSet{80: true},
+				UDP: config.PortSet{53: true},
+			},
+			Subnets: []string{"192.168.1.0/24"},
+		},
+	}
+
+	rpc := testRPC()
+	rpc.netw = netw
+
+	_, err := rpc.SetDefaults(context.Background(), &pb.SetDefaultsRequest{NoLogout: true})
+	assert.NoError(t, err)
+	assert.False(t, netw.LanDiscovery)
+	assert.Equal(t, config.Allowlist{}, netw.Allowlist)
+}


### PR DESCRIPTION
Context:
- when networker is initialized it gets config values passed in (or instances of classes that had config values pass to those)
- when `nordvpn set defaults` is called some of those values are not reset in networker which makes it use the stale values event though config has changed
- this PR fixes lan-discovery specifically

Changes:
- reset lan discovery value (and allowlist as it holds lan ranges)
- add logs
- add test for found issue