### PR TITLE
LVPN-10537: Refine regional group deprecation.

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -181,6 +181,10 @@ func main() {
 		}
 	}
 
+	if err := daemon.MigrateDeprecatedRegionalAutoconnect(fsystem); err != nil {
+		log.Println(internal.WarningPrefix, "failed to migrate regional autoconnect group:", err)
+	}
+
 	// Events
 
 	daemonEvents := daemonevents.NewEventsEmpty()

--- a/daemon/jobs.go
+++ b/daemon/jobs.go
@@ -303,6 +303,9 @@ func (r *RPC) StartAutoConnect(timeoutFn network.CalculateRetryDelayForAttempt) 
 		}
 
 		if err := r.doAutoConnect(); err != nil {
+			if errors.Is(err, errAutoConnectDisabled) {
+				return nil
+			}
 			log.Println(internal.ErrorPrefix, "autoconnect failed:", err)
 		} else {
 			return nil
@@ -314,12 +317,20 @@ func (r *RPC) StartAutoConnect(timeoutFn network.CalculateRetryDelayForAttempt) 
 	}
 }
 
+// errAutoConnectDisabled is returned when autoconnect was turned off between retries
+var errAutoConnectDisabled = errors.New("autoconnect disabled")
+
 func (r *RPC) doAutoConnect() error {
 	var cfg config.Config
 	err := r.cm.Load(&cfg)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "auto-connect failed:", err)
 		return err
+	}
+
+	if !cfg.AutoConnect {
+		log.Println(internal.InfoPrefix, "skipping auto-connect: disabled in config")
+		return errAutoConnectDisabled
 	}
 
 	if cfg.Technology == config.Technology_NORDWHISPER && !features.NordWhisperEnabled {
@@ -335,18 +346,8 @@ func (r *RPC) doAutoConnect() error {
 
 	server := connectServer{}
 
-	serverTag := cfg.AutoConnectData.ServerTag
 	groupTag := ""
-	groupParam := cfg.AutoConnectData.Group
-
-	// runtime migration for deprecated regional groups.
-	if config.IsRegionalGroup(cfg.AutoConnectData.Group) {
-		groupParam = config.ServerGroup_UNDEFINED
-		if cfg.AutoConnectData.Country == "" && cfg.AutoConnectData.City == "" {
-			// the configured target was purely regional, so fall back to fastest server
-			serverTag = ""
-		}
-	} else if cfg.AutoConnectData.Group != config.ServerGroup_UNDEFINED &&
+	if cfg.AutoConnectData.Group != config.ServerGroup_UNDEFINED &&
 		cfg.AutoConnectData.ServerTag != strings.ToLower(cfg.AutoConnectData.Group.String()) &&
 		cfg.AutoConnectData.ServerTag != config.GroupTitleForId(cfg.AutoConnectData.Group) {
 		groupTag = cfg.AutoConnectData.Group.String()
@@ -354,7 +355,7 @@ func (r *RPC) doAutoConnect() error {
 
 	err = r.connectFromRequest(
 		&pb.ConnectRequest{
-			ServerTag:   serverTag,
+			ServerTag:   cfg.AutoConnectData.ServerTag,
 			ServerGroup: groupTag,
 		},
 		&server,
@@ -367,7 +368,7 @@ func (r *RPC) doAutoConnect() error {
 			ServerParameters{
 				Country: cfg.AutoConnectData.Country,
 				City:    cfg.AutoConnectData.City,
-				Group:   groupParam,
+				Group:   cfg.AutoConnectData.Group,
 			},
 		)
 		return nil

--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -43,6 +43,7 @@ func (failingLoginChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, 
 }
 
 func updateAutoconnectData(c *mockConfigManager, data config.AutoConnectData) {
+	c.c.AutoConnect = true
 	c.c.AutoConnectData.ServerTag = data.ServerTag
 	c.c.AutoConnectData.Country = data.Country
 	c.c.AutoConnectData.City = data.City
@@ -88,6 +89,18 @@ func TestStartAutoConnect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDoAutoConnect_BailsOutWhenAutoConnectDisabled(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	rpc := testRPC()
+	cm := newMockConfigManager()
+	cm.c.AutoConnect = false
+	rpc.cm = cm
+
+	err := rpc.doAutoConnect()
+	assert.ErrorIs(t, err, errAutoConnectDisabled)
 }
 
 func TestDoAutoconnectHandlesServerAvailabilityIssues(t *testing.T) {

--- a/daemon/migrations.go
+++ b/daemon/migrations.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+)
+
+// MigrateDeprecatedRegionalAutoconnect removes the deprecated regional group from autoconnect.
+// If it was the only target, ServerTag is cleared so autoconnect falls back to quick connect.
+// The migration is idempotent.
+func MigrateDeprecatedRegionalAutoconnect(cm config.Manager) error {
+	var cfg config.Config
+	if err := cm.Load(&cfg); err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	if !config.IsRegionalGroup(cfg.AutoConnectData.Group) {
+		return nil
+	}
+	return cm.SaveWith(func(c config.Config) config.Config {
+		c.AutoConnectData.Group = config.ServerGroup_UNDEFINED
+		if c.AutoConnectData.Country == "" && c.AutoConnectData.City == "" {
+			c.AutoConnectData.ServerTag = ""
+		}
+		return c
+	})
+}

--- a/daemon/migrations_test.go
+++ b/daemon/migrations_test.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	"gotest.tools/v3/assert"
+)
+
+// regionalGroupEurope is the deprecated EUROPE group ID.
+const regionalGroupEurope config.ServerGroup = 19
+
+func TestMigrateDeprecatedRegionalAutoconnect_PreservesCountryAndClearsGroup(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	cm := mock.NewMockConfigManager()
+	cm.Cfg.AutoConnect = true
+	cm.Cfg.AutoConnectData.ServerTag = "germany"
+	cm.Cfg.AutoConnectData.Country = "de"
+	cm.Cfg.AutoConnectData.City = ""
+	cm.Cfg.AutoConnectData.Group = regionalGroupEurope
+
+	assert.NilError(t, MigrateDeprecatedRegionalAutoconnect(cm))
+
+	assert.Equal(t, cm.SaveCallCount, 1)
+	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_UNDEFINED)
+	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "germany")
+	assert.Equal(t, cm.Cfg.AutoConnectData.Country, "de")
+	assert.Equal(t, cm.Cfg.AutoConnectData.City, "")
+}
+
+func TestMigrateDeprecatedRegionalAutoconnect_PreservesCityAndClearsGroup(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	cm := mock.NewMockConfigManager()
+	cm.Cfg.AutoConnect = true
+	cm.Cfg.AutoConnectData.ServerTag = "berlin"
+	cm.Cfg.AutoConnectData.Country = ""
+	cm.Cfg.AutoConnectData.City = "berlin"
+	cm.Cfg.AutoConnectData.Group = regionalGroupEurope
+
+	assert.NilError(t, MigrateDeprecatedRegionalAutoconnect(cm))
+
+	assert.Equal(t, cm.SaveCallCount, 1)
+	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_UNDEFINED)
+	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "berlin")
+	assert.Equal(t, cm.Cfg.AutoConnectData.Country, "")
+	assert.Equal(t, cm.Cfg.AutoConnectData.City, "berlin")
+}
+
+func TestMigrateDeprecatedRegionalAutoconnect_OnlyRegionalFallsBackToQuickConnect(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	cm := mock.NewMockConfigManager()
+	cm.Cfg.AutoConnect = true
+	cm.Cfg.AutoConnectData.ServerTag = "europe"
+	cm.Cfg.AutoConnectData.Country = ""
+	cm.Cfg.AutoConnectData.City = ""
+	cm.Cfg.AutoConnectData.Group = regionalGroupEurope
+
+	assert.NilError(t, MigrateDeprecatedRegionalAutoconnect(cm))
+
+	assert.Equal(t, cm.SaveCallCount, 1)
+	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_UNDEFINED)
+	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "")
+}
+
+func TestMigrateDeprecatedRegionalAutoconnect_NonRegionalGroup_NoSave(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	cm := mock.NewMockConfigManager()
+	cm.Cfg.AutoConnect = true
+	cm.Cfg.AutoConnectData.ServerTag = "us"
+	cm.Cfg.AutoConnectData.Country = "us"
+	cm.Cfg.AutoConnectData.City = ""
+	cm.Cfg.AutoConnectData.Group = config.ServerGroup_DOUBLE_VPN
+
+	assert.NilError(t, MigrateDeprecatedRegionalAutoconnect(cm))
+
+	assert.Equal(t, cm.SaveCallCount, 0)
+	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_DOUBLE_VPN)
+	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "us")
+	assert.Equal(t, cm.Cfg.AutoConnectData.Country, "us")
+}
+
+func TestMigrateDeprecatedRegionalAutoconnect_Idempotent(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	cm := mock.NewMockConfigManager()
+	cm.Cfg.AutoConnect = true
+	cm.Cfg.AutoConnectData.ServerTag = "europe"
+	cm.Cfg.AutoConnectData.Group = regionalGroupEurope
+
+	assert.NilError(t, MigrateDeprecatedRegionalAutoconnect(cm))
+	assert.Equal(t, cm.SaveCallCount, 1)
+
+	assert.NilError(t, MigrateDeprecatedRegionalAutoconnect(cm))
+	assert.Equal(t, cm.SaveCallCount, 1)
+}

--- a/daemon/rpc_get_recent_connections_test.go
+++ b/daemon/rpc_get_recent_connections_test.go
@@ -54,6 +54,34 @@ func TestGetRecentConnections_Filtering(t *testing.T) {
 	assert.False(t, resp.Connections[0].IsVirtual)
 }
 
+func TestGetRecentConnections_FiltersDeprecatedRegionalGroups(t *testing.T) {
+	category.Set(t, category.Unit)
+	r := testRPCLocal(t)
+
+	r.recentVPNConnStore.Add(recents.Model{
+		Country:            "France",
+		ConnectionType:     config.ServerSelectionRule_COUNTRY,
+		ServerTechnologies: []core.ServerTechnology{core.OpenVPNUDP},
+	})
+	r.recentVPNConnStore.Add(recents.Model{
+		Group:              regionalGroupEurope,
+		ConnectionType:     config.ServerSelectionRule_GROUP,
+		ServerTechnologies: []core.ServerTechnology{core.OpenVPNUDP},
+	})
+	r.recentVPNConnStore.Add(recents.Model{
+		Country:            "Germany",
+		ConnectionType:     config.ServerSelectionRule_COUNTRY,
+		ServerTechnologies: []core.ServerTechnology{core.OpenVPNUDP},
+	})
+
+	resp, err := r.GetRecentConnections(context.Background(), &pb.RecentConnectionsRequest{})
+	assert.NoError(t, err)
+	assert.Len(t, resp.Connections, 2)
+	for _, c := range resp.Connections {
+		assert.False(t, config.IsRegionalGroup(c.Group), "regional group leaked into response: %v", c)
+	}
+}
+
 func TestGetRecentConnections_Limit(t *testing.T) {
 	category.Set(t, category.Unit)
 	r := testRPCLocal(t)

--- a/daemon/rpc_settings.go
+++ b/daemon/rpc_settings.go
@@ -11,7 +11,6 @@ import (
 )
 
 var adjustAutoconnectCfgOnce sync.Once
-var migrateRegionalAutoconnectOnce sync.Once
 
 // Settings returns system daemon settings
 func (r *RPC) Settings(ctx context.Context, in *pb.Empty) (*pb.SettingsResponse, error) {
@@ -57,26 +56,6 @@ func (r *RPC) Settings(ctx context.Context, in *pb.Empty) (*pb.SettingsResponse,
 			if err != nil {
 				log.Println(internal.WarningPrefix, "failed to set autoconnect parameters during the settings RPC:", err)
 			}
-		}
-	})
-
-	migrateRegionalAutoconnectOnce.Do(func() {
-		if !config.IsRegionalGroup(cfg.AutoConnectData.Group) {
-			return
-		}
-		err := r.cm.SaveWith(func(c config.Config) config.Config {
-			c.AutoConnectData.Group = config.ServerGroup_UNDEFINED
-			// If a country or city was also configured alongside the group, keep that location
-			// and only drop the deprecated regional group.
-			// Otherwise the regional arg was the only parameter, so also clear ServerTag.
-			// Autoconnect will then pick the fastest server (quick connect).
-			if c.AutoConnectData.Country == "" && c.AutoConnectData.City == "" {
-				c.AutoConnectData.ServerTag = ""
-			}
-			return c
-		})
-		if err != nil {
-			log.Println(internal.WarningPrefix, "failed to migrate regional autoconnect group:", err)
 		}
 	})
 

--- a/daemon/rpc_settings_test.go
+++ b/daemon/rpc_settings_test.go
@@ -16,11 +16,7 @@ import (
 // resetSettingsMigrationOnces resets the package-level sync
 func resetSettingsMigrationOnces() {
 	adjustAutoconnectCfgOnce = sync.Once{}
-	migrateRegionalAutoconnectOnce = sync.Once{}
 }
-
-// regionalGroupEurope is the deprecated EUROPE group ID
-const regionalGroupEurope config.ServerGroup = 19
 
 func TestSettings_NoPeerContext(t *testing.T) {
 	category.Set(t, category.Unit)
@@ -60,97 +56,4 @@ func TestSettings_AutoconnectMigrationRunsOnlyOnce(t *testing.T) {
 
 	// migration was not executed again
 	assert.Equal(t, cm.SaveCallCount, 1)
-}
-
-func TestSettings_RegionalMigration_PreservesCountryAndClearsGroup(t *testing.T) {
-	category.Set(t, category.Unit)
-	resetSettingsMigrationOnces()
-
-	cm := mock.NewMockConfigManager()
-	cm.Cfg.AutoConnect = true
-	cm.Cfg.AutoConnectData.ServerTag = "germany"
-	cm.Cfg.AutoConnectData.Country = "de"
-	cm.Cfg.AutoConnectData.City = ""
-	cm.Cfg.AutoConnectData.Group = regionalGroupEurope
-
-	r := testRPC()
-	r.cm = cm
-
-	_, err := r.Settings(peerCtx(trayTestUID), &pb.Empty{})
-	assert.NilError(t, err)
-
-	assert.Equal(t, cm.SaveCallCount, 1)
-	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_UNDEFINED)
-	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "germany")
-	assert.Equal(t, cm.Cfg.AutoConnectData.Country, "de")
-	assert.Equal(t, cm.Cfg.AutoConnectData.City, "")
-}
-
-func TestSettings_RegionalMigration_PreservesCityAndClearsGroup(t *testing.T) {
-	category.Set(t, category.Unit)
-	resetSettingsMigrationOnces()
-
-	cm := mock.NewMockConfigManager()
-	cm.Cfg.AutoConnect = true
-	cm.Cfg.AutoConnectData.ServerTag = "berlin"
-	cm.Cfg.AutoConnectData.Country = ""
-	cm.Cfg.AutoConnectData.City = "berlin"
-	cm.Cfg.AutoConnectData.Group = regionalGroupEurope
-
-	r := testRPC()
-	r.cm = cm
-
-	_, err := r.Settings(peerCtx(trayTestUID), &pb.Empty{})
-	assert.NilError(t, err)
-
-	assert.Equal(t, cm.SaveCallCount, 1)
-	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_UNDEFINED)
-	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "berlin")
-	assert.Equal(t, cm.Cfg.AutoConnectData.Country, "")
-	assert.Equal(t, cm.Cfg.AutoConnectData.City, "berlin")
-}
-
-func TestSettings_RegionalMigration_OnlyRegionalFallsBackToQuickConnect(t *testing.T) {
-	category.Set(t, category.Unit)
-	resetSettingsMigrationOnces()
-
-	cm := mock.NewMockConfigManager()
-	cm.Cfg.AutoConnect = true
-	cm.Cfg.AutoConnectData.ServerTag = "europe"
-	cm.Cfg.AutoConnectData.Country = ""
-	cm.Cfg.AutoConnectData.City = ""
-	cm.Cfg.AutoConnectData.Group = regionalGroupEurope
-
-	r := testRPC()
-	r.cm = cm
-
-	_, err := r.Settings(peerCtx(trayTestUID), &pb.Empty{})
-	assert.NilError(t, err)
-
-	assert.Equal(t, cm.SaveCallCount, 1)
-	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_UNDEFINED)
-	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "")
-}
-
-func TestSettings_RegionalMigration_NonRegionalGroup_NoSave(t *testing.T) {
-	category.Set(t, category.Unit)
-	resetSettingsMigrationOnces()
-
-	cm := mock.NewMockConfigManager()
-	cm.Cfg.AutoConnect = true
-	cm.Cfg.AutoConnectData.ServerTag = "us"
-	cm.Cfg.AutoConnectData.Country = "us"
-	cm.Cfg.AutoConnectData.City = ""
-	cm.Cfg.AutoConnectData.Group = config.ServerGroup_DOUBLE_VPN
-
-	r := testRPC()
-	r.cm = cm
-
-	_, err := r.Settings(peerCtx(trayTestUID), &pb.Empty{})
-	assert.NilError(t, err)
-
-	assert.Equal(t, cm.SaveCallCount, 0)
-	assert.Equal(t, cm.Cfg.AutoConnectData.Group, config.ServerGroup_DOUBLE_VPN)
-	assert.Equal(t, cm.Cfg.AutoConnectData.ServerTag, "us")
-	assert.Equal(t, cm.Cfg.AutoConnectData.Country, "us")
 }


### PR DESCRIPTION
- Moving region-based migration to daemon start.
- Bailing out from the auto connect loop when turned off in the settings.