### PR TITLE
LVPN-10379: handle user services updates in NC

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -84,7 +84,7 @@ type RenewingChecker struct {
 	mu                  sync.Mutex
 	accountUpdateEvents *daemonevents.AccountUpdateEvents
 	sessionStores       []session.SessionStore
-	servicesState       ServicesState
+	servicesState       *ServicesState
 }
 
 // NewRenewingChecker is a default constructor for RenewingChecker.
@@ -94,7 +94,7 @@ func NewRenewingChecker(cm config.Manager,
 	logoutPub events.Publisher[events.DataAuthorization],
 	errPub events.Publisher[error],
 	accountUpdateEvents *daemonevents.AccountUpdateEvents,
-	servicesState ServicesState,
+	servicesState *ServicesState,
 	sessionStores ...session.SessionStore,
 ) *RenewingChecker {
 	return &RenewingChecker{
@@ -193,9 +193,6 @@ func (r *RenewingChecker) IsVPNExpired() (bool, error) {
 }
 
 func (r *RenewingChecker) GetDedicatedIPServices() ([]DedicatedIPService, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	services, err := r.servicesState.fetchServices()
 	if err != nil {
 		return nil, fmt.Errorf("fetching available services: %w", err)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -68,6 +68,12 @@ func (systemTimeExpirationChecker) IsExpired(expiryTime string) bool {
 	return time.Now().After(expiry)
 }
 
+func hasDedicatedServerService(services core.ServicesResponse, expirationChecker core.ExpirationChecker) bool {
+	return slices.ContainsFunc(services, func(service core.ServiceData) bool {
+		return service.Service.ID == DedicatedServersServiceID && !expirationChecker.IsExpired(service.ExpiresAt)
+	})
+}
+
 // NewTokenExpirationChecker
 func NewTokenExpirationChecker() core.ExpirationChecker {
 	return &systemTimeExpirationChecker{}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -195,7 +195,7 @@ func (r *RenewingChecker) IsVPNExpired() (bool, error) {
 func (r *RenewingChecker) GetDedicatedIPServices() ([]DedicatedIPService, error) {
 	services, err := r.servicesState.fetchServices()
 	if err != nil {
-		return nil, fmt.Errorf("fetching available services: %w", err)
+		return nil, fmt.Errorf("fetching available dedicated IP services: %w", err)
 	}
 
 	dipServices := []DedicatedIPService{}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -84,6 +84,7 @@ type RenewingChecker struct {
 	mu                  sync.Mutex
 	accountUpdateEvents *daemonevents.AccountUpdateEvents
 	sessionStores       []session.SessionStore
+	servicesState       ServicesState
 }
 
 // NewRenewingChecker is a default constructor for RenewingChecker.
@@ -93,6 +94,7 @@ func NewRenewingChecker(cm config.Manager,
 	logoutPub events.Publisher[events.DataAuthorization],
 	errPub events.Publisher[error],
 	accountUpdateEvents *daemonevents.AccountUpdateEvents,
+	servicesState ServicesState,
 	sessionStores ...session.SessionStore,
 ) *RenewingChecker {
 	return &RenewingChecker{
@@ -104,6 +106,7 @@ func NewRenewingChecker(cm config.Manager,
 		errPub:              errPub,
 		accountUpdateEvents: accountUpdateEvents,
 		sessionStores:       sessionStores,
+		servicesState:       servicesState,
 	}
 }
 
@@ -193,7 +196,7 @@ func (r *RenewingChecker) GetDedicatedIPServices() ([]DedicatedIPService, error)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	services, err := r.fetchServices()
+	services, err := r.servicesState.fetchServices()
 	if err != nil {
 		return nil, fmt.Errorf("fetching available services: %w", err)
 	}
@@ -218,7 +221,7 @@ func (r *RenewingChecker) GetDedicatedServerService() (DedicatedServerService, e
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	services, err := r.fetchServices()
+	services, err := r.servicesState.fetchServices()
 	if err != nil {
 		return DedicatedServerService{}, fmt.Errorf("fetching services: %w", err)
 	}
@@ -273,14 +276,6 @@ func (r *RenewingChecker) fetchSaveServices(userID int64, data *config.TokenData
 	})
 
 	return nil
-}
-
-func (r *RenewingChecker) fetchServices() ([]core.ServiceData, error) {
-	services, err := r.creds.Services()
-	if err != nil {
-		return nil, err
-	}
-	return services, nil
 }
 
 func saveVpnExpirationDate(userID int64, data config.TokenData) config.SaveFunc {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -221,9 +221,6 @@ func (r *RenewingChecker) GetDedicatedIPServices() ([]DedicatedIPService, error)
 
 // GetDedicatedServerService returns dedicated server service status and expiration date
 func (r *RenewingChecker) GetDedicatedServerService() (DedicatedServerService, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	services, err := r.servicesState.fetchServices()
 	if err != nil {
 		return DedicatedServerService{}, fmt.Errorf("fetching services: %w", err)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -200,7 +200,7 @@ func TestIsMFAEnabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rc := NewRenewingChecker(test.cm, test.api, test.mfaPub, test.loutPub, test.errPub, daemonevents.NewAccountUpdateEvents(), &mocksession.MockSessionStore{})
+			rc := NewRenewingChecker(test.cm, test.api, test.mfaPub, test.loutPub, test.errPub, daemonevents.NewAccountUpdateEvents(), ServicesState{}, &mocksession.MockSessionStore{})
 			enabled, err := rc.isMFAEnabled()
 			assert.Equal(t, test.isEnabled, enabled)
 
@@ -284,6 +284,7 @@ func TestIsVPNExpired(t *testing.T) {
 				&mockAuthPublisher{},
 				&mockErrPublisher{},
 				&daemonevents.AccountUpdateEvents{SubscriptionUpdate: test.accPub},
+				ServicesState{},
 				&mocksession.MockSessionStore{},
 			)
 
@@ -312,6 +313,7 @@ func TestIsVPNExpired(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{SubscriptionUpdate: accPub},
+		ServicesState{},
 		nil,
 	)
 
@@ -504,9 +506,10 @@ func TestGetDedicatedIPServices(t *testing.T) {
 			}
 
 			rc := RenewingChecker{
-				cm:         &configMock,
-				creds:      &mockAPI,
-				expChecker: expirationChecker,
+				cm:            &configMock,
+				creds:         &mockAPI,
+				expChecker:    expirationChecker,
+				servicesState: ServicesState{credentialsAPI: &mockAPI},
 			}
 
 			dipServices, err := rc.GetDedicatedIPServices()
@@ -531,6 +534,7 @@ func TestIsLoggedIn_Success(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
+		ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()
@@ -550,6 +554,7 @@ func TestIsLoggedIn_InvalidToken(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
+		ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()
@@ -570,6 +575,7 @@ func TestIsLoggedIn_ConfigLoadFailed(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
+		ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()
@@ -591,6 +597,7 @@ func TestIsLoggedIn_CheckerRenewFailed(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
+		ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -202,7 +202,7 @@ func TestIsMFAEnabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rc := NewRenewingChecker(test.cm, test.api, test.mfaPub, test.loutPub, test.errPub, daemonevents.NewAccountUpdateEvents(), ServicesState{}, &mocksession.MockSessionStore{})
+			rc := NewRenewingChecker(test.cm, test.api, test.mfaPub, test.loutPub, test.errPub, daemonevents.NewAccountUpdateEvents(), &ServicesState{}, &mocksession.MockSessionStore{})
 			enabled, err := rc.isMFAEnabled()
 			assert.Equal(t, test.isEnabled, enabled)
 
@@ -286,7 +286,7 @@ func TestIsVPNExpired(t *testing.T) {
 				&mockAuthPublisher{},
 				&mockErrPublisher{},
 				&daemonevents.AccountUpdateEvents{SubscriptionUpdate: test.accPub},
-				ServicesState{},
+				&ServicesState{},
 				&mocksession.MockSessionStore{},
 			)
 
@@ -315,7 +315,7 @@ func TestIsVPNExpired(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{SubscriptionUpdate: accPub},
-		ServicesState{},
+		&ServicesState{},
 		nil,
 	)
 
@@ -513,7 +513,7 @@ func TestGetDedicatedIPServices(t *testing.T) {
 				cm:            &configMock,
 				creds:         &mockAuthAPI,
 				expChecker:    expirationChecker,
-				servicesState: ServicesState{cache: cache},
+				servicesState: &ServicesState{cache: cache},
 			}
 
 			dipServices, err := rc.GetDedicatedIPServices()
@@ -538,7 +538,7 @@ func TestIsLoggedIn_Success(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
-		ServicesState{},
+		&ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()
@@ -558,7 +558,7 @@ func TestIsLoggedIn_InvalidToken(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
-		ServicesState{},
+		&ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()
@@ -579,7 +579,7 @@ func TestIsLoggedIn_ConfigLoadFailed(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
-		ServicesState{},
+		&ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()
@@ -601,7 +601,7 @@ func TestIsLoggedIn_CheckerRenewFailed(t *testing.T) {
 		&mockAuthPublisher{},
 		&mockErrPublisher{},
 		&daemonevents.AccountUpdateEvents{},
-		ServicesState{},
+		&ServicesState{},
 		mockSS)
 
 	yes, err := checker.IsLoggedIn()

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/core"
@@ -12,6 +13,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/internal/caching"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	mocksession "github.com/NordSecurity/nordvpn-linux/test/mock/session"
 
@@ -496,7 +498,7 @@ func TestGetDedicatedIPServices(t *testing.T) {
 
 	for _, test := range test {
 		t.Run(test.name, func(t *testing.T) {
-			mockAPI := authAPI{
+			mockAuthAPI := authAPI{
 				resp: test.servicesResponse,
 				err:  test.servicesErr,
 			}
@@ -505,11 +507,13 @@ func TestGetDedicatedIPServices(t *testing.T) {
 				loadErr: test.configLoadErr,
 			}
 
+			cache := caching.NewCacheWithTTL(time.Hour*5, mockAuthAPI.Services)
+
 			rc := RenewingChecker{
 				cm:            &configMock,
-				creds:         &mockAPI,
+				creds:         &mockAuthAPI,
 				expChecker:    expirationChecker,
-				servicesState: ServicesState{credentialsAPI: &mockAPI},
+				servicesState: ServicesState{cache: cache},
 			}
 
 			dipServices, err := rc.GetDedicatedIPServices()

--- a/auth/services_state.go
+++ b/auth/services_state.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/NordSecurity/nordvpn-linux/core"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/log"
+)
+
+// ServicesState is responsible for fetching and storing user's available services.
+type ServicesState struct {
+	credentialsAPI core.CredentialsAPI
+
+	servicesFetched bool
+	services        core.ServicesResponse
+}
+
+func NewServicesState(credentialsAPI core.CredentialsAPI) ServicesState {
+	return ServicesState{
+		credentialsAPI: credentialsAPI,
+	}
+}
+
+// fetchServices fetches user's services from the API and saves them so that they will be returned on subsequent calls.
+func (s *ServicesState) fetchServices() (core.ServicesResponse, error) {
+	if s.servicesFetched {
+		return s.services, nil
+	}
+
+	services, err := s.credentialsAPI.Services()
+	if err != nil {
+		return core.ServicesResponse{}, fmt.Errorf("fetching services: %w", err)
+	}
+
+	s.services = services
+	s.servicesFetched = true
+
+	return services, nil
+}
+
+func (s *ServicesState) NotifyUserServicesChanged(any) error {
+	log.Println(internal.InfoPrefix, "received user services update, fetching new services")
+	services, err := s.credentialsAPI.Services()
+	if err != nil {
+		return fmt.Errorf("fetching services: %w", err)
+	}
+
+	s.services = services
+	s.servicesFetched = true
+	return nil
+}

--- a/auth/services_state.go
+++ b/auth/services_state.go
@@ -1,10 +1,10 @@
 package auth
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/core"
+	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/internal/caching"
 )
 
@@ -26,9 +26,11 @@ func (s *ServicesState) fetchServices() (core.ServicesResponse, error) {
 }
 
 func (s *ServicesState) NotifyUserServicesChanged(any) error {
-	_, err := s.cache.Fetch()
-	if err != nil {
-		return fmt.Errorf("fetching new services: %w", err)
-	}
+	s.cache.Invalidate()
+	return nil
+}
+
+func (s *ServicesState) NotifyLogout(events.DataAuthorization) error {
+	s.cache.Invalidate()
 	return nil
 }

--- a/auth/services_state.go
+++ b/auth/services_state.go
@@ -13,9 +13,9 @@ type ServicesState struct {
 	cache *caching.Cache[core.ServicesResponse]
 }
 
-func NewServicesState(credentialsAPI core.CredentialsAPI) ServicesState {
+func NewServicesState(credentialsAPI core.CredentialsAPI) *ServicesState {
 	cache := caching.NewCacheWithTTL(time.Hour*5, credentialsAPI.Services)
-	return ServicesState{
+	return &ServicesState{
 		cache: cache,
 	}
 }

--- a/auth/services_state.go
+++ b/auth/services_state.go
@@ -14,18 +14,18 @@ import (
 
 // ServicesState is responsible for fetching and storing user's available services.
 type ServicesState struct {
-	cache                    *caching.Cache[core.ServicesResponse]
-	dedicatdServerKeyManager devicekey.DedicatedServersKeyManager
-	expChecker               core.ExpirationChecker
+	cache                     *caching.Cache[core.ServicesResponse]
+	dedicatedServerKeyManager devicekey.DedicatedServersKeyManager
+	expChecker                core.ExpirationChecker
 }
 
 func NewServicesState(credentialsAPI core.CredentialsAPI,
 	dedicatdServerKeyManager devicekey.DedicatedServersKeyManager) *ServicesState {
 	cache := caching.NewCacheWithTTL(time.Hour*5, credentialsAPI.Services)
 	return &ServicesState{
-		cache:                    cache,
-		expChecker:               systemTimeExpirationChecker{},
-		dedicatdServerKeyManager: dedicatdServerKeyManager,
+		cache:                     cache,
+		expChecker:                systemTimeExpirationChecker{},
+		dedicatedServerKeyManager: dedicatdServerKeyManager,
 	}
 }
 
@@ -43,7 +43,7 @@ func (s *ServicesState) NotifyUserServicesChanged(any) error {
 	}
 
 	if hasDedicatedServerService(newServices, s.expChecker) {
-		s.dedicatdServerKeyManager.CheckAndRegisterDedicatedServers()
+		s.dedicatedServerKeyManager.CheckAndRegisterDedicatedServers()
 	}
 
 	return nil

--- a/auth/services_state.go
+++ b/auth/services_state.go
@@ -2,51 +2,33 @@ package auth
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/core"
-	"github.com/NordSecurity/nordvpn-linux/internal"
-	"github.com/NordSecurity/nordvpn-linux/log"
+	"github.com/NordSecurity/nordvpn-linux/internal/caching"
 )
 
 // ServicesState is responsible for fetching and storing user's available services.
 type ServicesState struct {
-	credentialsAPI core.CredentialsAPI
-
-	servicesFetched bool
-	services        core.ServicesResponse
+	cache *caching.Cache[core.ServicesResponse]
 }
 
 func NewServicesState(credentialsAPI core.CredentialsAPI) ServicesState {
+	cache := caching.NewCacheWithTTL(time.Hour*5, credentialsAPI.Services)
 	return ServicesState{
-		credentialsAPI: credentialsAPI,
+		cache: cache,
 	}
 }
 
 // fetchServices fetches user's services from the API and saves them so that they will be returned on subsequent calls.
 func (s *ServicesState) fetchServices() (core.ServicesResponse, error) {
-	if s.servicesFetched {
-		return s.services, nil
-	}
-
-	services, err := s.credentialsAPI.Services()
-	if err != nil {
-		return core.ServicesResponse{}, fmt.Errorf("fetching services: %w", err)
-	}
-
-	s.services = services
-	s.servicesFetched = true
-
-	return services, nil
+	return s.cache.Get()
 }
 
 func (s *ServicesState) NotifyUserServicesChanged(any) error {
-	log.Println(internal.InfoPrefix, "received user services update, fetching new services")
-	services, err := s.credentialsAPI.Services()
+	_, err := s.cache.Fetch()
 	if err != nil {
-		return fmt.Errorf("fetching services: %w", err)
+		return fmt.Errorf("fetching new services: %w", err)
 	}
-
-	s.services = services
-	s.servicesFetched = true
 	return nil
 }

--- a/auth/services_state.go
+++ b/auth/services_state.go
@@ -1,22 +1,31 @@
 package auth
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/core"
+	devicekey "github.com/NordSecurity/nordvpn-linux/device_key"
 	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/internal/caching"
+	"github.com/NordSecurity/nordvpn-linux/log"
 )
 
 // ServicesState is responsible for fetching and storing user's available services.
 type ServicesState struct {
-	cache *caching.Cache[core.ServicesResponse]
+	cache                    *caching.Cache[core.ServicesResponse]
+	dedicatdServerKeyManager devicekey.DedicatedServersKeyManager
+	expChecker               core.ExpirationChecker
 }
 
-func NewServicesState(credentialsAPI core.CredentialsAPI) *ServicesState {
+func NewServicesState(credentialsAPI core.CredentialsAPI,
+	dedicatdServerKeyManager devicekey.DedicatedServersKeyManager) *ServicesState {
 	cache := caching.NewCacheWithTTL(time.Hour*5, credentialsAPI.Services)
 	return &ServicesState{
-		cache: cache,
+		cache:                    cache,
+		expChecker:               systemTimeExpirationChecker{},
+		dedicatdServerKeyManager: dedicatdServerKeyManager,
 	}
 }
 
@@ -26,7 +35,17 @@ func (s *ServicesState) fetchServices() (core.ServicesResponse, error) {
 }
 
 func (s *ServicesState) NotifyUserServicesChanged(any) error {
-	s.cache.Invalidate()
+	log.Println(internal.DebugPrefix, "received user service change notification, invalidating service cache")
+
+	newServices, err := s.cache.Fetch()
+	if err != nil {
+		return fmt.Errorf("fetching new services: %w", err)
+	}
+
+	if hasDedicatedServerService(newServices, s.expChecker) {
+		s.dedicatdServerKeyManager.CheckAndRegisterDedicatedServers()
+	}
+
 	return nil
 }
 

--- a/auth/services_state_test.go
+++ b/auth/services_state_test.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/core"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	coremock "github.com/NordSecurity/nordvpn-linux/test/mock/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchServices(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	servicesResponseA := core.ServicesResponse{
+		core.ServiceData{ID: 1, ExpiresAt: "2026-07-14"},
+	}
+
+	servicesResponseB := core.ServicesResponse{
+		core.ServiceData{ID: 2, ExpiresAt: "2026-10-27"},
+	}
+
+	tests := []struct {
+		name                    string
+		hasFetchedServiceData   bool
+		storedServiceData       core.ServicesResponse
+		serviceResponse         core.ServicesResponse
+		fetchServiceErr         error
+		expectedServiceResponse core.ServicesResponse
+		expectedStatus          bool
+		shouldReturnError       bool
+	}{
+		{
+			name:                    "fetch new service",
+			serviceResponse:         servicesResponseA,
+			expectedServiceResponse: servicesResponseA,
+			expectedStatus:          true,
+		},
+		{
+			name:                    "services already stored",
+			hasFetchedServiceData:   true,
+			storedServiceData:       servicesResponseA,
+			serviceResponse:         servicesResponseB,
+			expectedServiceResponse: servicesResponseA,
+			expectedStatus:          true,
+		},
+		{
+			name:                    "service fetch fails",
+			serviceResponse:         servicesResponseA,
+			expectedServiceResponse: core.ServicesResponse{},
+			fetchServiceErr:         errors.New("failed to fetch the services data"),
+			expectedStatus:          false,
+			shouldReturnError:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			servicesState := ServicesState{
+				credentialsAPI: &coremock.CredentialsAPIMock{
+					ServicesResponse: test.serviceResponse,
+					ServicesErr:      test.fetchServiceErr,
+				},
+				services:        test.storedServiceData,
+				servicesFetched: test.hasFetchedServiceData,
+			}
+
+			services, err := servicesState.fetchServices()
+
+			if test.shouldReturnError {
+				assert.Error(t, err, "Expected error when fetching services.")
+			} else {
+				assert.NoError(t, err, "Unexpected error when fetching services.")
+			}
+			assert.Equal(t, test.expectedServiceResponse, services, "Unexpected services returned when fetching services.")
+			assert.Equal(t, test.expectedStatus, servicesState.servicesFetched,
+				"servicesFetched should be set to true after fetching services for the first time.")
+		})
+	}
+}
+
+func TestNotifyUserServicesChanged(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	servicesResponse := core.ServicesResponse{
+		core.ServiceData{ID: 1, ExpiresAt: "2026-07-14"},
+	}
+
+	servicesState := ServicesState{
+		credentialsAPI: &coremock.CredentialsAPIMock{
+			ServicesResponse: servicesResponse,
+		},
+		servicesFetched: true,
+	}
+
+	err := servicesState.NotifyUserServicesChanged(struct{}{})
+	assert.NoError(t, err, "Unexpected error returned by NotifyUserServicesChanged.")
+
+	services, _ := servicesState.fetchServices()
+	assert.Equal(t, servicesResponse, services, "Services should be updated after services change notification.")
+}
+
+func TestNotifyUserServicesChangedError(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	servicesResponse := core.ServicesResponse{
+		core.ServiceData{ID: 1, ExpiresAt: "2026-07-14"},
+	}
+	currentServiceData := core.ServicesResponse{
+		core.ServiceData{ID: 2, ExpiresAt: "2026-10-27"},
+	}
+
+	apiMock := coremock.CredentialsAPIMock{
+		ServicesResponse: servicesResponse,
+		ServicesErr:      errors.New("failed to fetch services"),
+	}
+	servicesState := ServicesState{
+		credentialsAPI:  &apiMock,
+		servicesFetched: true,
+		services:        currentServiceData,
+	}
+
+	err := servicesState.NotifyUserServicesChanged(struct{}{})
+	assert.Error(t, err, "Expected error when updating services.")
+
+	apiMock.ServicesErr = nil
+	services, _ := servicesState.fetchServices()
+
+	assert.Equal(t, currentServiceData, services,
+		"Old services should be kept in case of services change notification failure.")
+}

--- a/auth/services_state_test.go
+++ b/auth/services_state_test.go
@@ -5,9 +5,11 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/core"
+	devicekey "github.com/NordSecurity/nordvpn-linux/device_key"
 	"github.com/NordSecurity/nordvpn-linux/internal/caching"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	coremock "github.com/NordSecurity/nordvpn-linux/test/mock/core"
+	testdevicekey "github.com/NordSecurity/nordvpn-linux/test/mock/devicekey"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +31,9 @@ func TestNotifyUserServicesChanged(t *testing.T) {
 	cache.Set(oldServiceResponse)
 
 	servicesState := ServicesState{
-		cache: cache,
+		cache:                    cache,
+		expChecker:               newMockExpirationChecker(),
+		dedicatdServerKeyManager: &testdevicekey.MockDeviceKeyManager{},
 	}
 
 	err := servicesState.NotifyUserServicesChanged(struct{}{})
@@ -37,4 +41,53 @@ func TestNotifyUserServicesChanged(t *testing.T) {
 
 	services, _ := servicesState.fetchServices()
 	assert.Equal(t, newServiceResponse, services, "Services should be updated after services change notification.")
+}
+
+func TestNotifyUserServicesChanged_DedicatedServersHandling(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	dedicatedServersServiceResponse := core.ServicesResponse{
+		core.ServiceData{ID: 2, ExpiresAt: "2027-04-02", Service: core.Service{ID: DedicatedServersServiceID}},
+	}
+
+	mockApi := coremock.CredentialsAPIMock{}
+	mockApi.ServicesResponse = dedicatedServersServiceResponse
+
+	dedicatedServersKeyManagerMock := testdevicekey.MockDeviceKeyManager{
+		DedicatedServerRegistrationData: &devicekey.DedicatedServersConnectionData{},
+	}
+
+	cache := caching.NewCacheWithTTL(time.Hour*5, mockApi.Services)
+
+	expiredDate := "2027-05-02"
+	servicesState := ServicesState{
+		cache:                    cache,
+		expChecker:               newMockExpirationChecker(expiredDate),
+		dedicatdServerKeyManager: &dedicatedServersKeyManagerMock,
+	}
+
+	err := servicesState.NotifyUserServicesChanged(struct{}{})
+	assert.NoError(t, err, "Unexpected error returned by NotifyUserServicesChanged.")
+	assert.True(t, dedicatedServersKeyManagerMock.WasKeyRegistered,
+		"Key should be registered if dedicated servers service is present in the service response.")
+
+	dedicatedServersKeyManagerMock.WasKeyRegistered = false
+
+	noDedicatedServersServiceResponse := core.ServicesResponse{core.ServiceData{ID: 3, ExpiresAt: "2027-04-02"}}
+	mockApi.ServicesResponse = noDedicatedServersServiceResponse
+
+	err = servicesState.NotifyUserServicesChanged(struct{}{})
+	assert.NoError(t, err, "Unexpected error returned by NotifyUserServicesChanged.")
+	assert.False(t, dedicatedServersKeyManagerMock.WasKeyRegistered,
+		"Key should not be registered if dedicated servers service is not present in the service response.")
+
+	expiredDedicatedServersServiceResponse := core.ServicesResponse{
+		core.ServiceData{ID: 2, ExpiresAt: expiredDate, Service: core.Service{ID: DedicatedServersServiceID}},
+	}
+	mockApi.ServicesResponse = expiredDedicatedServersServiceResponse
+
+	err = servicesState.NotifyUserServicesChanged(struct{}{})
+	assert.NoError(t, err, "Unexpected error returned by NotifyUserServicesChanged.")
+	assert.False(t, dedicatedServersKeyManagerMock.WasKeyRegistered,
+		"Key should not be registered if dedicated servers service in the service response is expired.")
 }

--- a/auth/services_state_test.go
+++ b/auth/services_state_test.go
@@ -1,132 +1,40 @@
 package auth
 
 import (
-	"errors"
 	"testing"
+	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/core"
+	"github.com/NordSecurity/nordvpn-linux/internal/caching"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	coremock "github.com/NordSecurity/nordvpn-linux/test/mock/core"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFetchServices(t *testing.T) {
-	category.Set(t, category.Unit)
-
-	servicesResponseA := core.ServicesResponse{
-		core.ServiceData{ID: 1, ExpiresAt: "2026-07-14"},
-	}
-
-	servicesResponseB := core.ServicesResponse{
-		core.ServiceData{ID: 2, ExpiresAt: "2026-10-27"},
-	}
-
-	tests := []struct {
-		name                    string
-		hasFetchedServiceData   bool
-		storedServiceData       core.ServicesResponse
-		serviceResponse         core.ServicesResponse
-		fetchServiceErr         error
-		expectedServiceResponse core.ServicesResponse
-		expectedStatus          bool
-		shouldReturnError       bool
-	}{
-		{
-			name:                    "fetch new service",
-			serviceResponse:         servicesResponseA,
-			expectedServiceResponse: servicesResponseA,
-			expectedStatus:          true,
-		},
-		{
-			name:                    "services already stored",
-			hasFetchedServiceData:   true,
-			storedServiceData:       servicesResponseA,
-			serviceResponse:         servicesResponseB,
-			expectedServiceResponse: servicesResponseA,
-			expectedStatus:          true,
-		},
-		{
-			name:                    "service fetch fails",
-			serviceResponse:         servicesResponseA,
-			expectedServiceResponse: core.ServicesResponse{},
-			fetchServiceErr:         errors.New("failed to fetch the services data"),
-			expectedStatus:          false,
-			shouldReturnError:       true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			servicesState := ServicesState{
-				credentialsAPI: &coremock.CredentialsAPIMock{
-					ServicesResponse: test.serviceResponse,
-					ServicesErr:      test.fetchServiceErr,
-				},
-				services:        test.storedServiceData,
-				servicesFetched: test.hasFetchedServiceData,
-			}
-
-			services, err := servicesState.fetchServices()
-
-			if test.shouldReturnError {
-				assert.Error(t, err, "Expected error when fetching services.")
-			} else {
-				assert.NoError(t, err, "Unexpected error when fetching services.")
-			}
-			assert.Equal(t, test.expectedServiceResponse, services, "Unexpected services returned when fetching services.")
-			assert.Equal(t, test.expectedStatus, servicesState.servicesFetched,
-				"servicesFetched should be set to true after fetching services for the first time.")
-		})
-	}
-}
-
 func TestNotifyUserServicesChanged(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	servicesResponse := core.ServicesResponse{
+	oldServiceResponse := core.ServicesResponse{
 		core.ServiceData{ID: 1, ExpiresAt: "2026-07-14"},
 	}
 
+	newServiceResponse := core.ServicesResponse{
+		core.ServiceData{ID: 2, ExpiresAt: "2027-04-02"},
+	}
+
+	mockApi := coremock.CredentialsAPIMock{}
+	mockApi.ServicesResponse = newServiceResponse
+
+	cache := caching.NewCacheWithTTL(time.Hour*5, mockApi.Services)
+	cache.Set(oldServiceResponse)
+
 	servicesState := ServicesState{
-		credentialsAPI: &coremock.CredentialsAPIMock{
-			ServicesResponse: servicesResponse,
-		},
-		servicesFetched: true,
+		cache: cache,
 	}
 
 	err := servicesState.NotifyUserServicesChanged(struct{}{})
 	assert.NoError(t, err, "Unexpected error returned by NotifyUserServicesChanged.")
 
 	services, _ := servicesState.fetchServices()
-	assert.Equal(t, servicesResponse, services, "Services should be updated after services change notification.")
-}
-
-func TestNotifyUserServicesChangedError(t *testing.T) {
-	category.Set(t, category.Unit)
-
-	servicesResponse := core.ServicesResponse{
-		core.ServiceData{ID: 1, ExpiresAt: "2026-07-14"},
-	}
-	currentServiceData := core.ServicesResponse{
-		core.ServiceData{ID: 2, ExpiresAt: "2026-10-27"},
-	}
-
-	apiMock := coremock.CredentialsAPIMock{
-		ServicesResponse: servicesResponse,
-		ServicesErr:      errors.New("failed to fetch services"),
-	}
-	servicesState := ServicesState{
-		credentialsAPI:  &apiMock,
-		servicesFetched: true,
-		services:        currentServiceData,
-	}
-
-	err := servicesState.NotifyUserServicesChanged(struct{}{})
-	assert.Error(t, err, "Expected error when updating services.")
-
-	apiMock.ServicesErr = nil
-	services, _ := servicesState.fetchServices()
-
-	assert.Equal(t, currentServiceData, services,
-		"Old services should be kept in case of services change notification failure.")
+	assert.Equal(t, newServiceResponse, services, "Services should be updated after services change notification.")
 }

--- a/auth/services_state_test.go
+++ b/auth/services_state_test.go
@@ -31,9 +31,9 @@ func TestNotifyUserServicesChanged(t *testing.T) {
 	cache.Set(oldServiceResponse)
 
 	servicesState := ServicesState{
-		cache:                    cache,
-		expChecker:               newMockExpirationChecker(),
-		dedicatdServerKeyManager: &testdevicekey.MockDeviceKeyManager{},
+		cache:                     cache,
+		expChecker:                newMockExpirationChecker(),
+		dedicatedServerKeyManager: &testdevicekey.MockDeviceKeyManager{},
 	}
 
 	err := servicesState.NotifyUserServicesChanged(struct{}{})
@@ -61,9 +61,9 @@ func TestNotifyUserServicesChanged_DedicatedServersHandling(t *testing.T) {
 
 	expiredDate := "2027-05-02"
 	servicesState := ServicesState{
-		cache:                    cache,
-		expChecker:               newMockExpirationChecker(expiredDate),
-		dedicatdServerKeyManager: &dedicatedServersKeyManagerMock,
+		cache:                     cache,
+		expChecker:                newMockExpirationChecker(expiredDate),
+		dedicatedServerKeyManager: &dedicatedServersKeyManagerMock,
 	}
 
 	err := servicesState.NotifyUserServicesChanged(struct{}{})

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -508,6 +508,10 @@ func main() {
 	accountUpdateEvents := daemonevents.NewAccountUpdateEvents()
 	accountUpdateEvents.Subscribe(statePublisher)
 
+	servicesState := auth.NewServicesState(clientAPI)
+	userServicesEvents := daemonevents.NewUserServicesEvents()
+	userServicesEvents.Subscribe(&servicesState)
+
 	// Create auth checker with all session stores
 	authChecker := auth.NewRenewingChecker(
 		fsystem,
@@ -516,6 +520,7 @@ func main() {
 		daemonEvents.User.Logout,
 		errSubject,
 		accountUpdateEvents,
+		servicesState,
 		sessionBuilder.GetStores()...,
 	)
 
@@ -524,6 +529,7 @@ func main() {
 		infoSubject,
 		errSubject,
 		meshnetEvents.PeerUpdate,
+		userServicesEvents.ServicesUpdate,
 		nc.NewCredsFetcher(clientAPI, fsystem))
 
 	// on session unrecoverable error perform user log-out action

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -508,7 +508,7 @@ func main() {
 	accountUpdateEvents := daemonevents.NewAccountUpdateEvents()
 	accountUpdateEvents.Subscribe(statePublisher)
 
-	servicesState := auth.NewServicesState(clientAPI)
+	servicesState := auth.NewServicesState(clientAPI, deviceKeyManager)
 	userServicesEvents := daemonevents.NewUserServicesEvents()
 	userServicesEvents.Subscribe(servicesState)
 	daemonEvents.User.Logout.Subscribe(servicesState.NotifyLogout)

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -510,7 +510,7 @@ func main() {
 
 	servicesState := auth.NewServicesState(clientAPI)
 	userServicesEvents := daemonevents.NewUserServicesEvents()
-	userServicesEvents.Subscribe(&servicesState)
+	userServicesEvents.Subscribe(servicesState)
 
 	// Create auth checker with all session stores
 	authChecker := auth.NewRenewingChecker(

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -511,6 +511,7 @@ func main() {
 	servicesState := auth.NewServicesState(clientAPI)
 	userServicesEvents := daemonevents.NewUserServicesEvents()
 	userServicesEvents.Subscribe(servicesState)
+	daemonEvents.User.Logout.Subscribe(servicesState.NotifyLogout)
 
 	// Create auth checker with all session stores
 	authChecker := auth.NewRenewingChecker(

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -744,7 +744,7 @@ func main() {
 	if ok, _ := authChecker.IsLoggedIn(); ok {
 		go daemon.StartNC("[startup]", notificationClient)
 		if err := rpc.RegisterDedicatedServers(); err != nil {
-			log.Println(internal.ErrorPrefix, "failed to sync device: %s", err)
+			log.Println(internal.ErrorPrefix, "failed to sync device:", err)
 		}
 	}
 	if cfg.Mesh {

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -326,6 +326,24 @@ func NewAccountUpdateEvents() *AccountUpdateEvents {
 	}
 }
 
+type UserServicesPublisher interface {
+	NotifyUserServicesChanged(any) error
+}
+
+type UserServicesEvents struct {
+	ServicesUpdate events.PublishSubcriber[any]
+}
+
+func NewUserServicesEvents() *UserServicesEvents {
+	return &UserServicesEvents{
+		ServicesUpdate: &subs.Subject[any]{},
+	}
+}
+
+func (u *UserServicesEvents) Subscribe(to UserServicesPublisher) {
+	u.ServicesUpdate.Subscribe(to.NotifyUserServicesChanged)
+}
+
 // TODO: remove/replace with the mock
 type MockPublisherSubscriber[T any] struct {
 	Handler        events.Handler[T]

--- a/daemon/rpc_account.go
+++ b/daemon/rpc_account.go
@@ -53,6 +53,54 @@ func dipServicesToProtobuf(dipServices []auth.DedicatedIPService) []*pb.Dedidcat
 	return dipServicesProtobuf
 }
 
+// setDedicatedIPServerData sets Dedicated IP and Dedicated Server related fields in the accountInfo
+func (r *RPC) setDedicatedIPServerData(accountInfo *pb.AccountResponse) *pb.AccountResponse {
+	dipServices, err := r.ac.GetDedicatedIPServices()
+	if err != nil {
+		log.Println(internal.ErrorPrefix, "getting dedicated ip services:", err)
+		if errors.Is(err, core.ErrUnauthorized) {
+			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken}
+		} else {
+			return &pb.AccountResponse{Type: internal.CodeTokenRenewError}
+		}
+	}
+
+	accountInfo.DedicatedIpStatus = internal.CodeSuccess
+
+	if len(dipServices) < 1 {
+		accountInfo.DedicatedIpStatus = internal.CodeNoService
+	}
+
+	dedicatedIPExpirationDate := ""
+	if len(dipServices) != 0 {
+		accountInfo.DedicatedIpServices = dipServicesToProtobuf(dipServices)
+		dedicatedIPExpirationDate, err = findLatestDIPExpirationData(dipServices)
+		if err != nil {
+			log.Println(internal.ErrorPrefix, "getting latest dedicated ip expiration date:", err)
+			return &pb.AccountResponse{Type: internal.CodeTokenRenewError}
+		}
+	}
+
+	accountInfo.LastDedicatedIpExpiresAt = dedicatedIPExpirationDate
+
+	dedicatedServerService, err := r.ac.GetDedicatedServerService()
+	if err != nil {
+		log.Println(internal.ErrorPrefix, "getting dedicated server service:", err)
+		if errors.Is(err, core.ErrUnauthorized) {
+			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken}
+		}
+		return &pb.AccountResponse{Type: internal.CodeTokenRenewError}
+	}
+
+	accountInfo.DedicatedServerStatus = internal.CodeNoService
+	if dedicatedServerService.Active {
+		accountInfo.DedicatedServerStatus = internal.CodeSuccess
+		accountInfo.DedicatedServersServiceExpiresAt = dedicatedServerService.ExpiresAt
+	}
+
+	return accountInfo
+}
+
 // AccountInfo returns user account information.
 func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.AccountResponse, error) {
 	if ok, err := r.ac.IsLoggedIn(); !ok {
@@ -63,6 +111,12 @@ func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.Acco
 	}
 
 	if accountInfo, ok := r.dm.GetAccountData(req.Full); ok {
+		// because Dedicated IP and Dedicated Servers service data is using it's own caching that is updated with NC
+		// events, we can always try to fetch it to keep the returned information more accurate
+		dedicatedIPServerAccountInfo := r.setDedicatedIPServerData(accountInfo)
+		if dedicatedIPServerAccountInfo.Type == internal.CodeSuccess {
+			return dedicatedIPServerAccountInfo, nil
+		}
 		return accountInfo, nil
 	}
 
@@ -78,44 +132,9 @@ func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.Acco
 		accountInfo.Type = internal.CodeSuccess
 	}
 
-	accountInfo.DedicatedIpStatus = internal.CodeSuccess
-	dipServices, err := r.ac.GetDedicatedIPServices()
-	if err != nil {
-		log.Println(internal.ErrorPrefix, "getting dedicated ip services:", err)
-		if errors.Is(err, core.ErrUnauthorized) {
-			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken}, nil
-		} else {
-			return &pb.AccountResponse{Type: internal.CodeTokenRenewError}, nil
-		}
-	}
-
-	if len(dipServices) < 1 {
-		accountInfo.DedicatedIpStatus = internal.CodeNoService
-	}
-
-	dedicatedIPExpirationDate := ""
-	if len(dipServices) != 0 {
-		accountInfo.DedicatedIpServices = dipServicesToProtobuf(dipServices)
-		dedicatedIPExpirationDate, err = findLatestDIPExpirationData(dipServices)
-		if err != nil {
-			log.Println(internal.ErrorPrefix, "getting latest dedicated ip expiration date:", err)
-			return &pb.AccountResponse{Type: internal.CodeTokenRenewError}, nil
-		}
-	}
-
-	dedicatedServerService, err := r.ac.GetDedicatedServerService()
-	if err != nil {
-		log.Println(internal.ErrorPrefix, "getting dedicated server service:", err)
-		if errors.Is(err, core.ErrUnauthorized) {
-			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken}, nil
-		}
-		return &pb.AccountResponse{Type: internal.CodeTokenRenewError}, nil
-	}
-
-	accountInfo.DedicatedServerStatus = internal.CodeNoService
-	if dedicatedServerService.Active {
-		accountInfo.DedicatedServerStatus = internal.CodeSuccess
-		accountInfo.DedicatedServersServiceExpiresAt = dedicatedServerService.ExpiresAt
+	accountInfo = r.setDedicatedIPServerData(accountInfo)
+	if accountInfo.Type != internal.CodeSuccess {
+		return accountInfo, nil
 	}
 
 	// get user's current mfa status
@@ -136,7 +155,6 @@ func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.Acco
 
 	tokenData := cfg.TokensData[cfg.AutoConnectData.ID]
 	accountInfo.SubscriptionExpiresAt = tokenData.ServiceExpiry
-	accountInfo.LastDedicatedIpExpiresAt = dedicatedIPExpirationDate
 
 	currentUser, err := r.credentialsAPI.CurrentUser()
 	if err != nil {

--- a/nc/nc.go
+++ b/nc/nc.go
@@ -428,7 +428,7 @@ func (c *Client) handleMessage(client mqtt.Client, msg mqtt.Message, ctx context
 
 	switch payload.Message.Data.Event.Type {
 	case typeUserServiceUpdate:
-		c.subjectServicesUpdate.Publish(true)
+		c.subjectServicesUpdate.Publish(struct{}{})
 	case typeMeshnet:
 		c.subjectPeerUpdate.Publish(payload.Message.Data.Event.Attributes.AffectedMachines)
 	default:

--- a/nc/nc.go
+++ b/nc/nc.go
@@ -426,6 +426,8 @@ func (c *Client) handleMessage(client mqtt.Client, msg mqtt.Message, ctx context
 		)
 	}
 
+	log.Println(internal.InfoPrefix, logPrefix, "received", payload.Message.Data.Event.Type)
+
 	switch payload.Message.Data.Event.Type {
 	case typeUserServiceUpdate:
 		c.subjectServicesUpdate.Publish(struct{}{})

--- a/nc/nc.go
+++ b/nc/nc.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -44,8 +46,6 @@ var subscriptions = map[string]byte{
 	"meshnet":             byte(1),
 	"user_service_update": byte(1),
 }
-
-var unsubscriptions = []string{"content", "linux", "meshnet"}
 
 // RecPayload defines a payload sent by a NC
 type RecPayload struct {
@@ -323,7 +323,7 @@ func (c *Client) connectWithBackoff(client mqtt.Client,
 	token := client.SubscribeMultiple(subscriptions, nil)
 	if token.WaitTimeout(timeout) && token.Error() != nil {
 		c.subjectErr.Publish(
-			fmt.Errorf(logPrefix+" subscribing to %v topics: %s", unsubscriptions, token.Error()),
+			fmt.Errorf(logPrefix+" subscribing to topics: %s", token.Error()),
 		)
 	}
 
@@ -471,6 +471,7 @@ func (c *Client) ncClientManagementLoop(ctx context.Context) (<-chan any, error)
 			log.Println(logPrefix, "stopping management loop")
 			cancelConnectionFunc()
 			if client != nil {
+				unsubscriptions := slices.Collect(maps.Keys(subscriptions))
 				client.Unsubscribe(unsubscriptions...)
 				client.Disconnect(0)
 				client = nil

--- a/nc/nc.go
+++ b/nc/nc.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"github.com/NordSecurity/nordvpn-linux/network"
 
@@ -23,7 +24,8 @@ import (
 )
 
 const (
-	typeMeshnet = "meshnet_network_update"
+	typeMeshnet           = "meshnet_network_update"
+	typeUserServiceUpdate = "user_service_update"
 
 	topicDelivered    = "delivered"
 	topicAcknowledged = "ack"
@@ -37,9 +39,10 @@ const (
 )
 
 var subscriptions = map[string]byte{
-	"content": byte(1),
-	"linux":   byte(1),
-	"meshnet": byte(1),
+	"content":             byte(1),
+	"linux":               byte(1),
+	"meshnet":             byte(1),
+	"user_service_update": byte(1),
 }
 
 var unsubscriptions = []string{"content", "linux", "meshnet"}
@@ -124,11 +127,12 @@ type Client struct {
 	// MQTT Docs say that reusing client after doing Disconnect can lead to panics.
 	// Since we are doing connect manually with our exponential backoff, we are in risk of those panics.
 	// That's why this mutex must be locked every time client is used.
-	subjectInfo       events.Publisher[string]
-	subjectErr        events.Publisher[error]
-	subjectPeerUpdate events.Publisher[[]string]
-	credsFetcher      CredentialsGetter
-	retryDelayFunc    CalculateRetryDelayForAttempt
+	subjectInfo           events.Publisher[string]
+	subjectErr            events.Publisher[error]
+	subjectPeerUpdate     events.Publisher[[]string]
+	subjectServicesUpdate events.Publisher[any]
+	credsFetcher          CredentialsGetter
+	retryDelayFunc        CalculateRetryDelayForAttempt
 
 	startMu          sync.Mutex
 	started          bool
@@ -142,15 +146,17 @@ func NewClient(
 	subjectInfo events.Publisher[string],
 	subjectErr events.Publisher[error],
 	subjectPeerUpdate events.Publisher[[]string],
+	subjectServicesUpdate events.Publisher[any],
 	credsFetcher CredentialsGetter,
 ) *Client {
 	return &Client{
-		clientBuilder:     clientBuilder,
-		subjectInfo:       subjectInfo,
-		subjectErr:        subjectErr,
-		subjectPeerUpdate: subjectPeerUpdate,
-		credsFetcher:      credsFetcher,
-		retryDelayFunc:    network.ExponentialBackoff,
+		clientBuilder:         clientBuilder,
+		subjectInfo:           subjectInfo,
+		subjectErr:            subjectErr,
+		subjectPeerUpdate:     subjectPeerUpdate,
+		subjectServicesUpdate: subjectServicesUpdate,
+		credsFetcher:          credsFetcher,
+		retryDelayFunc:        network.ExponentialBackoff,
 	}
 }
 
@@ -420,8 +426,13 @@ func (c *Client) handleMessage(client mqtt.Client, msg mqtt.Message, ctx context
 		)
 	}
 
-	if payload.Message.Data.Event.Type == typeMeshnet {
+	switch payload.Message.Data.Event.Type {
+	case typeUserServiceUpdate:
+		c.subjectServicesUpdate.Publish(true)
+	case typeMeshnet:
 		c.subjectPeerUpdate.Publish(payload.Message.Data.Event.Attributes.AffectedMachines)
+	default:
+		log.Println(internal.WarningPrefix, logPrefix, "received unknown MQTT message type:", payload.Message.Data.Event.Type)
 	}
 }
 

--- a/nc/nc_test.go
+++ b/nc/nc_test.go
@@ -2,11 +2,13 @@ package nc
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/events/subs"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	cfgmock "github.com/NordSecurity/nordvpn-linux/test/mock"
@@ -18,12 +20,25 @@ import (
 	mqttp "github.com/eclipse/paho.mqtt.golang/packets"
 )
 
+type mockMqttMessage struct {
+	payload []byte
+}
+
+func (m *mockMqttMessage) Duplicate() bool   { return false }
+func (m *mockMqttMessage) Qos() byte         { return 0 }
+func (m *mockMqttMessage) Retained() bool    { return false }
+func (m *mockMqttMessage) Topic() string     { return "" }
+func (m *mockMqttMessage) MessageID() uint16 { return 0 }
+func (m *mockMqttMessage) Payload() []byte   { return m.payload }
+func (m *mockMqttMessage) Ack()              {}
+
 type mockMqttClient struct {
 	mqtt.Client
 	// connecting indicates if client is in connecting or disconnecting state
 	connecting     bool
 	connectToken   mockMqttToken
 	subscribeToken mockMqttToken
+	clientID       string
 }
 
 func (m *mockMqttClient) Connect() mqtt.Token {
@@ -41,6 +56,16 @@ func (m *mockMqttClient) SubscribeMultiple(filters map[string]byte, callback mqt
 	return &m.subscribeToken
 }
 
+func (m *mockMqttClient) OptionsReader() mqtt.ClientOptionsReader {
+	return mqtt.NewOptionsReader(&mqtt.ClientOptions{
+		ClientID: m.clientID,
+	})
+}
+
+func (m *mockMqttClient) Publish(topic string, qos byte, retained bool, payload interface{}) mqtt.Token {
+	return &mockMqttToken{}
+}
+
 type mockMqttToken struct {
 	mqtt.Token
 	timesOut bool
@@ -53,6 +78,12 @@ func (m *mockMqttToken) WaitTimeout(time.Duration) bool {
 
 func (m *mockMqttToken) Error() error {
 	return m.err
+}
+
+func (m *mockMqttToken) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }
 
 func connectionStateToString(t *testing.T, state connectionState) string {
@@ -170,6 +201,7 @@ func TestStartStopNotificationClient(t *testing.T) {
 			&subs.Subject[string]{},
 			&subs.Subject[error]{},
 			&subs.Subject[[]string]{},
+			&subs.Subject[any]{},
 			credsFetcher)
 
 		t.Run(test.name, func(t *testing.T) {
@@ -274,4 +306,66 @@ func TestConnectionCancellation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMessageHandling(t *testing.T) {
+	connectionToken := mockMqttToken{
+		timesOut: false,
+	}
+	mockMqttClient := mockMqttClient{
+		connectToken: connectionToken,
+		clientID:     "target-uuid",
+	}
+
+	peerUpdateCalled := false
+	peerUpdateHandler := events.Handler[[]string](func(s []string) error {
+		peerUpdateCalled = true
+		return nil
+	})
+
+	peerUpdateSubject := subs.Subject[[]string]{}
+	peerUpdateSubject.Subscribe(peerUpdateHandler)
+
+	serviceUpdateCalled := false
+	serviceUpdateHandler := events.Handler[any](func(s any) error {
+		serviceUpdateCalled = true
+		return nil
+	})
+
+	serviceUpdateSubject := subs.Subject[any]{}
+	serviceUpdateSubject.Subscribe(serviceUpdateHandler)
+
+	notificationClient := Client{
+		subjectPeerUpdate:     &peerUpdateSubject,
+		subjectServicesUpdate: &serviceUpdateSubject,
+	}
+
+	payload := RecPayload{
+		Message: MessagePayload{
+			Data: DataPayload{
+				Event: EventPayload{
+					Type: typeMeshnet,
+				},
+				Metadata: MetadataPayload{
+					TargetUID: "target-uuid",
+				},
+			},
+		},
+	}
+	serializedPayload, _ := json.Marshal(payload)
+	message := mockMqttMessage{
+		payload: serializedPayload,
+	}
+
+	notificationClient.handleMessage(&mockMqttClient, &message, context.Background())
+	assert.True(t, peerUpdateCalled, "Peer update should be triggered by meshnet network notification.")
+
+	payload.Message.Data.Event.Type = typeUserServiceUpdate
+	serializedPayload, _ = json.Marshal(payload)
+	message = mockMqttMessage{
+		payload: serializedPayload,
+	}
+
+	notificationClient.handleMessage(&mockMqttClient, &message, context.Background())
+	assert.True(t, serviceUpdateCalled, "Service update should be triggered by user service notification.")
 }

--- a/test/mock/core/core.go
+++ b/test/mock/core/core.go
@@ -16,6 +16,9 @@ type CredentialsAPIMock struct {
 	CurrentUserErr      error
 
 	ServiceCredentialsErr error
+
+	ServicesResponse core.ServicesResponse
+	ServicesErr      error
 }
 
 func (c *CredentialsAPIMock) NotificationCredentials(appUserID string) (core.NotificationCredentialsResponse, error) {
@@ -43,8 +46,8 @@ func (*CredentialsAPIMock) MultifactorAuthStatus() (*core.MultifactorAuthStatusR
 	return nil, nil
 }
 
-func (*CredentialsAPIMock) Services() (core.ServicesResponse, error) {
-	return core.ServicesResponse{}, nil
+func (c *CredentialsAPIMock) Services() (core.ServicesResponse, error) {
+	return c.ServicesResponse, c.ServicesErr
 }
 
 func (c *CredentialsAPIMock) CurrentUser() (*core.CurrentUserResponse, error) {


### PR DESCRIPTION
NC provides us with user service updates. We can fetch user's services upon receiving such notifications instead of fetching the services every time when needed. This will reduce the load on the backend and we will be able to use this for GUI in the future.

The user's services are only cached for Dedicated IP/Servers services. Regular VPN service is fetched based on the service's expiration date.