### PR TITLE
LVPN-10541: Fix DIP server filter for E2E tests

### DIFF
--- a/test/qa/lib/server.py
+++ b/test/qa/lib/server.py
@@ -65,15 +65,56 @@ class ServerInfo:
         self.country = server_info["locations"][0]["country"]["name"]
 
 
-def get_hostname_by(technology="", protocol="", obfuscated="", group_name=""):
-    """Returns server name and hostname from core API."""
+def _server_is_dedicated_ip(server: dict) -> bool:
+    """
+    True if the server belongs to the Dedicated_IP group.
+
+    Example:
+        _server_is_dedicated_ip({"groups": [{"id": GROUP_DEDICATED_IP}]})  # -> True
+        _server_is_dedicated_ip({"groups": [{"id": GROUP_EUROPE}]})        # -> False
+    """
+    groups: list[dict] = server.get("groups", [])
+    for group in groups:  # noqa: SIM110
+        if group.get("id") == GROUP_DEDICATED_IP:
+            return True
+    return False
+
+
+def _exclude_dedicated_ip_servers(servers: list[dict]) -> list[dict]:
+    """
+    Returns the input list with any Dedicated_IP servers removed.
+
+    The API also returns DIP servers when querying by a region group
+    (e.g. Europe), since one server may belong to several groups.
+
+    Example:
+        _exclude_dedicated_ip_servers([dip_server, eu_server])  # -> [eu_server]
+    """
+    non_dip_servers: list[dict] = []
+    for server in servers:
+        if not _server_is_dedicated_ip(server):
+            non_dip_servers.append(server)
+    return non_dip_servers
+
+
+def get_hostname_by(technology="", protocol="", obfuscated="", group_name="", exclude_dip=False):
+    """
+    Returns server name and hostname from core API.
+
+    If exclude_dip is True, skips Dedicated_IP servers.
+    """
 
     (tech_id, group_id) = get_request_parameters(technology, protocol, obfuscated, group_name)
 
     # api limits
     time.sleep(2)
 
-    url = f"https://api.nordvpn.com/v1/servers?limit=10&filters[servers.status]=online&filters[servers_technologies][id]={tech_id}&filters[servers_groups][id]={group_id}"
+    # fetch extra when post-filtering DIP
+    # a queried group can include DIP servers and dropping them on client could
+    # leave us with an empty list
+    limit = 20 if exclude_dip else 10
+
+    url = f"https://api.nordvpn.com/v1/servers?limit={limit}&filters[servers.status]=online&filters[servers_technologies][id]={tech_id}&filters[servers_groups][id]={group_id}"
     logging.debug(url)
 
     response = requests.get(url, timeout=5)
@@ -92,6 +133,12 @@ def get_hostname_by(technology="", protocol="", obfuscated="", group_name=""):
 
     assert len(response) > 0, "Core API returned an empty servers list"
     logging.debug("Core API response (truncated): %s", str(response)[:300])
+
+    if exclude_dip:
+        response = _exclude_dedicated_ip_servers(response)
+        if not response:
+            return None
+
     server = response[0]
     validate_server(server_json=str(server), tech_id=tech_id, group_id=group_id)
     return ServerInfo(server_info=server)

--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -1,4 +1,5 @@
 import random
+import warnings
 
 import pytest
 import sh
@@ -242,19 +243,16 @@ def test_prevent_obfuscate_disable_with_autoconnect_enabled_to_obfuscated_server
 
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    available_groups = str(sh.nordvpn.groups(_tty_out=False)).strip().split()
+    server_name = server.get_hostname_by(group_name="Obfuscated_Servers").hostname.split(".")[0]
+    sh.nordvpn.set.autoconnect.on(server_name)
 
-    for group in available_groups:
-        server_name = server.get_hostname_by(tech, proto, obfuscated, group).hostname.split(".")[0]
-        sh.nordvpn.set.autoconnect.on(server_name)
-
-        with pytest.raises(sh.ErrorReturnCode_1) as ex:
-             sh.nordvpn.set.obfuscate.off()
-        print(ex.value)
-        error_message = "We couldn’t turn off obfuscation because your current auto-connect server is obfuscated by default. " \
-            + "Set a different server for auto-connect, then turn off obfuscation."
-        assert error_message in ex.value.stdout.decode("utf-8"), "Should show correct error message"
-        assert "Obfuscate: enabled" in sh.nordvpn.settings(), "Obfuscate should be enabled"
+    with pytest.raises(sh.ErrorReturnCode_1) as ex:
+        sh.nordvpn.set.obfuscate.off()
+    print(ex.value)
+    error_message = "We couldn’t turn off obfuscation because your current auto-connect server is obfuscated by default. " \
+        + "Set a different server for auto-connect, then turn off obfuscation."
+    assert error_message in ex.value.stdout.decode("utf-8"), "Should show correct error message"
+    assert "Obfuscate: enabled" in sh.nordvpn.settings(), "Obfuscate should be enabled"
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
@@ -287,7 +285,11 @@ def test_prevent_obfuscate_enable_with_autoconnect_set_to_nonobfuscated(tech, pr
         if group == "Dedicated_IP":
             server_name = server.get_dedicated_ip().hostname.split(".")[0]
         else:
-            server_name = server.get_hostname_by(tech, proto, obfuscated, group).hostname.split(".")[0]
+            server_info = server.get_hostname_by(tech, proto, obfuscated, group, exclude_dip=True)
+            if server_info is None:
+                warnings.warn(f"no non-DIP servers available for group {group}", stacklevel=2)
+                continue
+            server_name = server_info.hostname.split(".")[0]
 
         sh.nordvpn.set.autoconnect.on(server_name)
 

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -1,6 +1,7 @@
 import random
 import socket
 import time
+import warnings
 
 import pytest
 import sh
@@ -128,7 +129,10 @@ def test_connect_to_group_random_server_by_name_standard(tech, proto, obfuscated
 
     lib.set_technology_and_protocol(tech, proto, obfuscated)
 
-    server_info = server.get_hostname_by(tech, proto, obfuscated, group)
+    server_info = server.get_hostname_by(tech, proto, obfuscated, group, exclude_dip=True)
+    if server_info is None:
+        warnings.warn(f"no non-DIP servers available for group {group}", stacklevel=2)
+        pytest.skip(f"no non-DIP servers available for group {group}")
     connect_base_test((tech, proto, obfuscated), server_info.hostname.split(".")[0], server_info.name, server_info.hostname)
 
     disconnect_base_test()


### PR DESCRIPTION
Adding a new argument `exclude_dip`. This will optionally parse the response from `/servers` to exclude any DIP servers.
Updating some tests flow.