### PR TITLE
LVPN-10556: harden the way how libsqlite symlink is created

### DIFF
--- a/contrib/scriptlets/deb/postinst
+++ b/contrib/scriptlets/deb/postinst
@@ -49,10 +49,18 @@ for path in $(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[
     fi
 done
 
+# if no symlink found, try to assign anything (probably a direct .so file)
+if [ -z "$sqlite" ]; then
+    sqlite=$(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p' | head -n1)
+    echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; using $sqlite for nordvpnd, which may fail to start after lib update" >&2
+fi
+
 if [ -n "$sqlite" ]; then
     ln -sf "$sqlite" "${LIBS_DIR}/libsqlite3.so"
 else
-    echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd may fail to start" >&2
+    # if still no symlink nor actual file found, simply stop installation
+    echo "ERROR: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd might not be able to start" >&2
+    exit 1
 fi
 set +e
 

--- a/contrib/scriptlets/deb/postinst
+++ b/contrib/scriptlets/deb/postinst
@@ -37,10 +37,22 @@ ldconfig -v > /dev/null 2>&1
 # adjust permissions of shared objects
 chmod 0644 "${LIBS_DIR}"/*.so
 
-set -e
-sqlite=$(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p' | head -n1)
-ln -sf "${sqlite}" "${LIBS_DIR}/libsqlite3.so"
-set +e
+# Iterate over all of the results, so symlink is not created pointing to an actual .so file
+# which might cause issues upon library bump.
+#
+sqlite=""
+for path in $(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p'); do
+    if [ -L "$path" ]; then
+        sqlite="$path"
+        break
+    fi
+done
+
+if [ -n "$sqlite" ]; then
+    ln -sf "$sqlite" "${LIBS_DIR}/libsqlite3.so"
+else
+    echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd may fail to start" >&2
+fi
 
 # ldconfig needs to be executed twice in case libsqlite3.so.0 was not available during a lookup
 ldconfig -v > /dev/null 2>&1

--- a/contrib/scriptlets/deb/postinst
+++ b/contrib/scriptlets/deb/postinst
@@ -40,6 +40,7 @@ chmod 0644 "${LIBS_DIR}"/*.so
 # Iterate over all of the results, so symlink is not created pointing to an actual .so file
 # which might cause issues upon library bump.
 #
+set -e
 sqlite=""
 for path in $(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p'); do
     if [ -L "$path" ]; then
@@ -53,6 +54,7 @@ if [ -n "$sqlite" ]; then
 else
     echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd may fail to start" >&2
 fi
+set +e
 
 # ldconfig needs to be executed twice in case libsqlite3.so.0 was not available during a lookup
 ldconfig -v > /dev/null 2>&1

--- a/contrib/scriptlets/rpm/posttrans
+++ b/contrib/scriptlets/rpm/posttrans
@@ -31,7 +31,7 @@ for path in $(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[
 done
 
 if [ -n "$sqlite" ]; then
-    ln -sf "$sqlite" "${LIBS_DIR}/libsqlite3.so"
+    ln -sf "$sqlite" "/usr/lib/nordvpn/libsqlite3.so"
 else
     echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd may fail to start" >&2
 fi

--- a/contrib/scriptlets/rpm/posttrans
+++ b/contrib/scriptlets/rpm/posttrans
@@ -31,10 +31,18 @@ for path in $(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[
     fi
 done
 
+# if no symlink found, try to assign anything (probably a direct .so file)
+if [ -z "$sqlite" ]; then
+    sqlite=$(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p' | head -n1)
+    echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; using $sqlite for nordvpnd, which may fail to start after lib update" >&2
+fi
+
 if [ -n "$sqlite" ]; then
     ln -sf "$sqlite" "/usr/lib/nordvpn/libsqlite3.so"
 else
-    echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd may fail to start" >&2
+    # if still no symlink nor actual file found, simply stop installation
+    echo "ERROR: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd might not be able to start" >&2
+    exit 1
 fi
 set +e
 # ldconfig needs to be executed twice in case libsqlite3.so.0 was not available during a lookup

--- a/contrib/scriptlets/rpm/posttrans
+++ b/contrib/scriptlets/rpm/posttrans
@@ -22,6 +22,7 @@ ldconfig
 # Iterate over all of the results, so symlink is not created pointing to an actual .so file
 # which might cause issues upon library bump.
 #
+set -e
 sqlite=""
 for path in $(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p'); do
     if [ -L "$path" ]; then
@@ -35,6 +36,7 @@ if [ -n "$sqlite" ]; then
 else
     echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd may fail to start" >&2
 fi
+set +e
 # ldconfig needs to be executed twice in case libsqlite3.so.0 was not available during a lookup
 ldconfig
 

--- a/contrib/scriptlets/rpm/posttrans
+++ b/contrib/scriptlets/rpm/posttrans
@@ -18,10 +18,23 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
 ldconfig
 
 # move the symlink file creation later, otherwise the update scripts will delete it
-set -e
-sqlite=$(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p' | head -n1)
-ln -sf "${sqlite}" /usr/lib/nordvpn/libsqlite3.so
-set +e
+#
+# Iterate over all of the results, so symlink is not created pointing to an actual .so file
+# which might cause issues upon library bump.
+#
+sqlite=""
+for path in $(ldconfig -p 2>/dev/null | grep 'libsqlite3.so.0' | sed -n 's/.*=>[[:space:]]*//p'); do
+    if [ -L "$path" ]; then
+        sqlite="$path"
+        break
+    fi
+done
+
+if [ -n "$sqlite" ]; then
+    ln -sf "$sqlite" "${LIBS_DIR}/libsqlite3.so"
+else
+    echo "WARNING: no symlink to libsqlite3.so.0 found in ldconfig cache; nordvpnd may fail to start" >&2
+fi
 # ldconfig needs to be executed twice in case libsqlite3.so.0 was not available during a lookup
 ldconfig
 


### PR DESCRIPTION
This PR introduces improved selection of the source upon symlink creation during the post installation steps.

On certain distributions or configurations the output of `ldconfig -p` might return entries containing not only stable symlinks but also specific shared objects sem-versioned (which after a library version updates leaves the symlink dangling).
Previous approach always selected the first returned element, now it iterates over all of the results and filter out non-symlinks.

This is to address https://github.com/NordSecurity/nordvpn-linux/issues/1497