### PR TITLE
LVPN-10402: dedicated servers autoconnect

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1193,7 +1193,7 @@ func meshnetErrorToError(code meshpb.MeshnetErrorCode) error {
 	case meshpb.MeshnetErrorCode_NOT_ENABLED:
 		return errors.New(MsgMeshnetNotEnabled)
 	case meshpb.MeshnetErrorCode_TECH_FAILURE:
-		return errors.New(MsgMeshnetNordlynxMustBeEnabled)
+		return errors.New(MsgNordlynxMustBeEnabled)
 	case meshpb.MeshnetErrorCode_TUNNEL_CLOSED:
 		return errors.New(DisconnectNotConnected)
 	case meshpb.MeshnetErrorCode_CONFLICT_WITH_PQ:

--- a/cli/cli_connect.go
+++ b/cli/cli_connect.go
@@ -171,11 +171,15 @@ func (c *cmd) Connect(ctx *cli.Context) error {
 		case internal.CodeDedicatedServersNotReady:
 			rpcErr = errors.New(DedicatedServersServerNotReadyMessage)
 		case internal.CodeDedicatedServersNoNordlynx:
-			rpcErr = errors.New(DedicatedServersNoNordlynxMessage)
+			rpcErr = errors.New(MsgNordlynxMustBeEnabled)
 		case internal.CodeDedicatedServersCanNotConnect:
 			rpcErr = errors.New(DedicatedServersCanNotConnectMessage)
 		case internal.CodeDedicatedServersSessionMaxLimitReached:
 			rpcErr = errors.New(DedicatedServersConnectionLimitReached)
+		case internal.CodeDedicatedServersPq:
+			rpcErr = errors.New(internal.ServerUnavailableErrorMessage)
+		case internal.CodeDedicatedServersServerNotSetUp:
+			rpcErr = errors.New(c.injectLinkIntoMessage(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin, DedicatedServersNoServersAvailable))
 		case internal.CodeVPNRunning:
 			color.Yellow(client.ConnectConnected)
 		case internal.CodeNothingToDo:

--- a/cli/cli_set_autoconnect.go
+++ b/cli/cli_set_autoconnect.go
@@ -96,6 +96,18 @@ func (c *cmd) SetAutoConnect(ctx *cli.Context) error {
 		return formatError(errors.New(NoDedidcatedIPServerMessage))
 	case internal.CodeDedicatedIPServiceButNoServers:
 		return formatError(errors.New(NoPreferredDedicatedIPLocationSelected))
+	case internal.CodeDedicatedServersRenewError:
+		return errors.New(c.injectLinkIntoMessage(client.DedicatedServersUpselURL, client.DedicatedServersUpselURLLogin, DedicatedServersNoServiceMessage))
+	case internal.CodeDedicatedServersServiceButNoServers:
+		return errors.New(c.injectLinkIntoMessage(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin, DedicatedServersNoServersAvailable))
+	case internal.CodeDedicatedServersNotReady:
+		return errors.New(DedicatedServersServerNotReadyMessage)
+	case internal.CodeDedicatedServersNoNordlynx:
+		return errors.New(DedicatedServersAutoconnectNordlynxMessage)
+	case internal.CodeDedicatedServersPq:
+		return errors.New(internal.ServerUnavailableErrorMessage)
+	case internal.CodeDedicatedServersServerNotSetUp:
+		return errors.New(c.injectLinkIntoMessage(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin, DedicatedServersNoServersAvailable))
 	case internal.CodeSuccess:
 		color.Green(fmt.Sprintf(MsgSetSuccess, "Auto-connect", nstrings.GetBoolLabel(flag)))
 	}

--- a/cli/cli_set_postquantum_vpn.go
+++ b/cli/cli_set_postquantum_vpn.go
@@ -38,6 +38,8 @@ func (c *cmd) SetPostquantumVpn(ctx *cli.Context) error {
 		return formatError(errors.New(SetPqAndMeshnet))
 	case internal.CodePqWithoutNordlynx:
 		return formatError(fmt.Errorf(SetPqUnavailable, resp.Data[0]))
+	case internal.CodeDedicatedServersPq:
+		return formatError(errors.New(DedicatedServerPQMessage))
 	case internal.CodeSuccess:
 		color.Green(fmt.Sprintf(MsgSetSuccess, "Post-quantum VPN", nstrings.GetBoolLabel(flag)))
 		flag, _ := strconv.ParseBool(resp.Data[0])

--- a/cli/cli_set_technology.go
+++ b/cli/cli_set_technology.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -67,6 +68,8 @@ func (c *cmd) SetTechnology(ctx *cli.Context) error {
 		color.Yellow(fmt.Sprintf(MsgAlreadySet, "Technology", strings.Join(resp.Data, " ")))
 	case internal.CodeFeatureHidden:
 		return formatError(argsParseError(ctx))
+	case internal.CodeDedicatedServersNoNordlynx:
+		return errors.New(DedicatedServersAutoconnectNordlynxMessage)
 	case internal.CodeSuccessWithoutAC:
 		// must be right before CodeSuccess
 		color.Yellow(SetAutoConnectForceOff)

--- a/cli/messages.go
+++ b/cli/messages.go
@@ -138,13 +138,12 @@ Example: nordvpn set meshnet off
 Supported values for <enabled>: 1, true, enable, on, enabled
 Example: nordvpn set meshnet on`
 
-	MsgSetMeshnetSuccess            = "Meshnet is set to '%s' successfully."
-	MsgMeshnetAlreadyEnabled        = "Meshnet is already enabled."
-	MsgMeshnetAlreadyDisabled       = "Meshnet is already disabled."
-	MsgMeshnetNotEnabled            = "Meshnet is not enabled. Use the \"nordvpn set meshnet on\" command to enable it."
-	MsgMeshnetNordlynxMustBeEnabled = "NordLynx technology must be set to use this feature."
-	MsgMeshnetVersionNotSupported   = "Current application version does not support the Meshnet feature."
-	MsgMeshnetUsage                 = "Meshnet is a way to safely access other devices, no matter where in the world they are. Once set up, Meshnet functions just like a secure local area network (LAN) — it connects devices directly. It also allows securely sending files to other devices. Use the \"nordvpn set meshnet on\" command to enable Meshnet. Learn more: https://meshnet.nordvpn.com/?utm_medium=app&utm_source=nordvpn-linux-cli&utm_campaign=meshnet-documentation&nm=app&ns=nordvpn-linux-cli&nc=meshnet-documentation"
+	MsgSetMeshnetSuccess          = "Meshnet is set to '%s' successfully."
+	MsgMeshnetAlreadyEnabled      = "Meshnet is already enabled."
+	MsgMeshnetAlreadyDisabled     = "Meshnet is already disabled."
+	MsgMeshnetNotEnabled          = "Meshnet is not enabled. Use the \"nordvpn set meshnet on\" command to enable it."
+	MsgMeshnetVersionNotSupported = "Current application version does not support the Meshnet feature."
+	MsgMeshnetUsage               = "Meshnet is a way to safely access other devices, no matter where in the world they are. Once set up, Meshnet functions just like a secure local area network (LAN) — it connects devices directly. It also allows securely sending files to other devices. Use the \"nordvpn set meshnet on\" command to enable Meshnet. Learn more: https://meshnet.nordvpn.com/?utm_medium=app&utm_source=nordvpn-linux-cli&utm_campaign=meshnet-documentation&nm=app&ns=nordvpn-linux-cli&nc=meshnet-documentation"
 
 	MsgMeshnetRefreshUsage = "Refreshes the Meshnet in case it was not updated automatically."
 	MsgMeshnetPeerUnknown  = "Peer '%s' is unknown."
@@ -397,10 +396,14 @@ Your browsing activities remain private, regardless of your choice.
 	SetARPIgnoreNothingToSet = "ARP ignore is already set to '%s'."
 	SetARPIgnoreWarning      = "You’ve turned off arp-ignore. This is an advanced privacy setting and should only be off if your network setup requires ARP responses."
 
-	DedicatedServersNoServiceMessage       = "Get a server that's exclusively yours. Enjoy your own IP with resources and speed reserved entirely for you. Use it with port forwarding to host services and access devices remotely. To get a personal dedicated server, continue in the browser: %s"
-	DedicatedServersNoServersAvailable     = "Setup your dedicated server. One last step - pick a server location.\n%s"
-	DedicatedServersServerNotReadyMessage  = "Activating your dedicated server. This may take a few minutes."
-	DedicatedServersNoNordlynxMessage      = "NordLynx technology must be set to use this feature."
-	DedicatedServersCanNotConnectMessage   = "Couldn't connect. Please try again."
-	DedicatedServersConnectionLimitReached = "Too many connections or device limit reached"
+	DedicatedServersNoServiceMessage           = "Get a server that's exclusively yours. Enjoy your own IP with resources and speed reserved entirely for you. Use it with port forwarding to host services and access devices remotely. To get a personal dedicated server, continue in the browser: %s"
+	DedicatedServersNoServersAvailable         = "Setup your dedicated server. One last step - pick a server location.\n%s"
+	DedicatedServersServerNotReadyMessage      = "Activating your dedicated server. This may take a few minutes."
+	DedicatedServersNoNordlynxMessage          = "NordLynx technology must be set to use this feature."
+	DedicatedServersCanNotConnectMessage       = "Couldn't connect. Please try again."
+	DedicatedServersConnectionLimitReached     = "Too many connections or device limit reached"
+	DedicatedServersAutoconnectNordlynxMessage = "Auto-connect to Dedicated Server requires NordLynx protocol."
+	DedicatedServerPQMessage                   = "Post-quantum encryption is not compatible with Dedicated Server."
+
+	MsgNordlynxMustBeEnabled = "NordLynx technology must be set to use this feature."
 )

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -744,7 +744,7 @@ func main() {
 	if ok, _ := authChecker.IsLoggedIn(); ok {
 		go daemon.StartNC("[startup]", notificationClient)
 		if err := rpc.RegisterDedicatedServers(); err != nil {
-			log.Println(internal.ErrorPrefix, "failed to sync device:", err)
+			log.Println(internal.WarningPrefix, "failed to sync device:", err)
 		}
 	}
 	if cfg.Mesh {

--- a/daemon/jobs.go
+++ b/daemon/jobs.go
@@ -319,6 +319,32 @@ func (r *RPC) fallbackTechnology(targetTechnology config.Technology) error {
 	return nil
 }
 
+// fallbackDedicatedServer changes autoconnection target to a generic(fastest) server if the current target is set to a
+// dedicated server and user doesn't have a dedicated server subscription or feature is disabled in the remote config.
+// New config is saved and returned.
+func (r *RPC) fallbackDedicatedServer(cfg config.Config) config.Config {
+	serviceData, err := r.ac.GetDedicatedServerService()
+	if err != nil {
+		log.Println(internal.WarningPrefix,
+			"getting dedicated servers service status to determine if fallback is needed:", err)
+		return cfg
+	}
+
+	if !serviceData.Active || !r.remoteConfigGetter.IsFeatureEnabled(remote.FeatureDedicatedServer) {
+		cfg.AutoConnectData.Group = config.ServerGroup_UNDEFINED
+		cfg.AutoConnectData.ServerTag = ""
+		if err := r.cm.SaveWith(func(c config.Config) config.Config {
+			c.AutoConnectData = cfg.AutoConnectData
+			return c
+		}); err != nil {
+			log.Println(internal.ErrorPrefix,
+				"failed to save config after a fallback from dedicated server:", err)
+		}
+	}
+
+	return cfg
+}
+
 // StartAutoConnect connect to VPN server if autoconnect is enabled
 func (r *RPC) StartAutoConnect(timeoutFn network.CalculateRetryDelayForAttempt) error {
 	tries := 1
@@ -368,6 +394,10 @@ func (r *RPC) doAutoConnect() error {
 				return fmt.Errorf("falling back to OpenVPN technology: %s", err)
 			}
 		}
+	}
+
+	if cfg.AutoConnectData.Group == config.ServerGroup_DEDICATED_SERVER {
+		cfg = r.fallbackDedicatedServer(cfg)
 	}
 
 	server := connectServer{}

--- a/daemon/jobs_test.go
+++ b/daemon/jobs_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/auth"
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
 	"github.com/NordSecurity/nordvpn-linux/core"
 	"github.com/NordSecurity/nordvpn-linux/core/mesh"
 	daemonevents "github.com/NordSecurity/nordvpn-linux/daemon/events"
@@ -191,6 +192,70 @@ func TestDoAutoConnect(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestDoAutoConnect_DedicatedServerFallback_ServiceExpired(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	mockConfigManager := newMockConfigManager()
+	updateAutoconnectData(mockConfigManager, config.AutoConnectData{
+		Group:     config.ServerGroup_DEDICATED_SERVER,
+		ServerTag: "Dedicated Server",
+	})
+
+	rpc := testRPC()
+	rpc.cm = mockConfigManager
+	rpc.doAutoConnect()
+
+	// Verify that settings are not modified if service is available
+	assert.Equal(t, config.ServerGroup_DEDICATED_SERVER, mockConfigManager.c.AutoConnectData.Group,
+		"Unexpected autoconnect group target change after doAutoConnect. Group should remain set to %s.", config.ServerGroup_DEDICATED_SERVER.String())
+	assert.Equal(t, "Dedicated Server", mockConfigManager.c.AutoConnectData.ServerTag,
+		"Unexpected autoconnect target ServerTag change after doAutoConnect. ServerTag should remain set to DedicatedServer.")
+
+	authMock := rpc.ac.(*workingLoginChecker)
+	authMock.dedicatedServerErr = errors.New("failed to fetch ds service")
+
+	rpc.doAutoConnect()
+	// Verify that setting are not modified if service fetch failed
+	assert.Equal(t, config.ServerGroup_DEDICATED_SERVER, mockConfigManager.c.AutoConnectData.Group,
+		"Unexpected autoconnect group target change after doAutoConnect. Group should remain set to %s.", config.ServerGroup_DEDICATED_SERVER.String())
+	assert.Equal(t, "Dedicated Server", mockConfigManager.c.AutoConnectData.ServerTag,
+		"Unexpected autoconnect target ServerTag change after doAutoConnect. ServerTag should remain set to DedicatedServer.")
+
+	authMock.dedicatedServerErr = nil
+	authMock.isDedicatedServersExpired = true
+
+	rpc.doAutoConnect()
+
+	// Verify that settings are  modified if service is not available
+	assert.NotEqual(t, config.ServerGroup_DEDICATED_SERVER, mockConfigManager.c.AutoConnectData.Group,
+		"Group should be unset when dedicated servers service is not available.")
+	assert.Equal(t, "", mockConfigManager.c.AutoConnectData.ServerTag,
+		"ServerTag should be unset when dedicated servers service is not available.")
+}
+
+func TestDoAutoConnect_DedicatedServerFallback_FeatureDisabledInRemoteConfig(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	mockConfigManager := newMockConfigManager()
+	updateAutoconnectData(mockConfigManager, config.AutoConnectData{
+		Group:     config.ServerGroup_DEDICATED_SERVER,
+		ServerTag: "Dedicated Server",
+	})
+
+	remoteConfigMock := mock.NewRemoteConfigMock()
+	remoteConfigMock.AddFeatureToggle(remote.FeatureDedicatedServer, false)
+
+	rpc := testRPC()
+	rpc.cm = mockConfigManager
+	rpc.remoteConfigGetter = remoteConfigMock
+
+	rpc.doAutoConnect()
+	assert.NotEqual(t, config.ServerGroup_DEDICATED_SERVER, mockConfigManager.c.AutoConnectData.Group,
+		"Group should be unset when dedicated servers feature is disabled in remote config.")
+	assert.Equal(t, "", mockConfigManager.c.AutoConnectData.ServerTag,
+		"ServerTag should be unset when dedicated servers feature is disabled in remote config.")
 }
 
 type meshRenewChecker struct{}

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -39,6 +39,12 @@ func determineServerGroupIDs(server *core.Server) []config.ServerGroup {
 	return ids
 }
 
+// isDedicatedServer returns true if either serverTag or serverGroup represents the dedicated server group
+func isDedicatedServer(serverTag string, serverGroup string) bool {
+	return groupConvert(serverTag) == config.ServerGroup_DEDICATED_SERVER ||
+		groupConvert(serverGroup) == config.ServerGroup_DEDICATED_SERVER
+}
+
 // Connect initiates and handles the VPN connection process
 func (r *RPC) Connect(in *pb.ConnectRequest, srv pb.Daemon_ConnectServer) (retErr error) {
 	return r.connectFromRequest(in, srv, pb.ConnectionSource_MANUAL)
@@ -169,6 +175,10 @@ func (r *RPC) connectWithStoredServerSelection(ctx context.Context,
 		if cfg.Technology != config.Technology_NORDLYNX {
 			return true, srv.Send(&pb.Payload{Type: internal.CodeDedicatedServersNoNordlynx})
 		}
+		// third, if technology is correct, check if post quantum is enabled(pq is not supported for dedicated servers)
+		if cfg.AutoConnectData.PostquantumVpn {
+			return true, srv.Send(&pb.Payload{Type: internal.CodeDedicatedServersPq})
+		}
 	}
 
 	expirationCheckResult := r.isVPNExpired()
@@ -205,17 +215,20 @@ func (r *RPC) connectWithParameters(ctx context.Context,
 	}
 	r.connectionInfo.SetInitialConnecting()
 
-	if groupConvert(in.ServerGroup) == config.ServerGroup_DEDICATED_SERVER ||
-		groupConvert(in.ServerTag) == config.ServerGroup_DEDICATED_SERVER {
+	if isDedicatedServer(in.ServerTag, in.ServerGroup) {
 		// first, check if feature is enabled at all
 		if !r.remoteConfigGetter.IsFeatureEnabled(remote.FeatureDedicatedServer) {
 			// if user is trying to connect here while this feature is disabled,
 			// show general error because anyways he should not get here
-			return true, srv.Send(&pb.Payload{Type: internal.CodeFailure})
+			return true, srv.Send(&pb.Payload{Type: internal.CodeGroupNonexisting})
 		}
 		// second, if feature is enabled, check if technology is correct
 		if cfg.Technology != config.Technology_NORDLYNX {
 			return true, srv.Send(&pb.Payload{Type: internal.CodeDedicatedServersNoNordlynx})
+		}
+		// third, if technology is correct, check if post quantum is enabled(pq is not supported for dedicated servers)
+		if cfg.AutoConnectData.PostquantumVpn {
+			return true, srv.Send(&pb.Payload{Type: internal.CodeDedicatedServersPq})
 		}
 	}
 

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -1068,6 +1068,7 @@ func TestConnect_DedicatedServers(t *testing.T) {
 	tests := []struct {
 		name                       string
 		isDedicatedServersExpired  bool
+		postQuantum                bool
 		dedicatedServersResponse   core.DedicatedServers
 		connectResponse            core.DedicatedServerConnectResponse
 		technology                 config.Technology
@@ -1220,6 +1221,13 @@ func TestConnect_DedicatedServers(t *testing.T) {
 			connectErr:                 core.ErrDedicatedServersInvalidFormData,
 			expectedStatus:             internal.CodeDedicatedServersCanNotConnect,
 		},
+		{
+			name:                      "post quantum is on",
+			isDedicatedServersExpired: false,
+			postQuantum:               true,
+			technology:                config.Technology_NORDLYNX,
+			expectedStatus:            internal.CodeDedicatedServersPq,
+		},
 	}
 
 	for _, test := range tests {
@@ -1245,6 +1253,7 @@ func TestConnect_DedicatedServers(t *testing.T) {
 
 			configManagerMock := rpc.cm.(*mockConfigManager)
 			configManagerMock.c.Technology = test.technology
+			configManagerMock.c.AutoConnectData.PostquantumVpn = test.postQuantum
 
 			mockRPCServer := &mockRPCServer{}
 			err := rpc.Connect(&pb.ConnectRequest{ServerTag: "dedicated_server"}, mockRPCServer)

--- a/daemon/rpc_set_autoconnect.go
+++ b/daemon/rpc_set_autoconnect.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
 	"github.com/NordSecurity/nordvpn-linux/core"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
@@ -28,6 +29,20 @@ func (r *RPC) SetAutoConnect(ctx context.Context, in *pb.SetAutoconnectRequest) 
 		return &pb.Payload{
 			Type: internal.CodeNothingToDo,
 		}, nil
+	}
+
+	if in.GetEnabled() && isDedicatedServer(in.ServerTag, in.ServerGroup) {
+		if !r.remoteConfigGetter.IsFeatureEnabled(remote.FeatureDedicatedServer) {
+			return &pb.Payload{Type: internal.CodeGroupNonexisting}, nil
+		}
+
+		if cfg.Technology != config.Technology_NORDLYNX {
+			return &pb.Payload{Type: internal.CodeDedicatedServersNoNordlynx}, nil
+		}
+
+		if cfg.AutoConnectData.PostquantumVpn {
+			return &pb.Payload{Type: internal.CodeDedicatedServersPq}, nil
+		}
 	}
 
 	if in.GetEnabled() {

--- a/daemon/rpc_set_autoconnect_test.go
+++ b/daemon/rpc_set_autoconnect_test.go
@@ -6,37 +6,35 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/auth"
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/core"
 	"github.com/NordSecurity/nordvpn-linux/daemon/events"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	devicekey "github.com/NordSecurity/nordvpn-linux/device_key"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	testauth "github.com/NordSecurity/nordvpn-linux/test/mock/auth"
+	testcore "github.com/NordSecurity/nordvpn-linux/test/mock/core"
+	testdevicekey "github.com/NordSecurity/nordvpn-linux/test/mock/devicekey"
 
 	"github.com/stretchr/testify/assert"
 )
-
-type mockAutoconnectAuthChecker struct{}
-
-func (mockAutoconnectAuthChecker) IsLoggedIn() (bool, error)   { return true, nil }
-func (mockAutoconnectAuthChecker) IsMFAEnabled() (bool, error) { return false, nil }
-func (mockAutoconnectAuthChecker) IsVPNExpired() (bool, error) { return false, nil }
-func (mockAutoconnectAuthChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
-	return []auth.DedicatedIPService{}, nil
-}
-func (mockAutoconnectAuthChecker) GetDedicatedServerService() (auth.DedicatedServerService, error) {
-	return auth.DedicatedServerService{}, nil
-}
 
 func TestAutoconnect(t *testing.T) {
 	category.Set(t, category.Unit)
 
 	tests := []struct {
-		testName             string
-		server               string
-		config               config.Config
-		isDedicatedIPExpired bool
-		returnCode           int64
-		eventPublished       bool
-		expectedError        error
+		testName                        string
+		server                          string
+		config                          config.Config
+		isDedicatedIPExpired            bool
+		isDedicatedServerExpired        bool
+		isDedicatedServerFeatureEnabled bool
+		dedicatedServerList             core.DedicatedServers
+		returnCode                      int64
+		eventPublished                  bool
+		expectedError                   error
 	}{
 		{
 			testName:       "autoconnect works for OpenVPN, obfuscate = off",
@@ -151,6 +149,14 @@ func TestAutoconnect(t *testing.T) {
 			eventPublished: false,
 		},
 		{
+			testName:             "works for dedicated ip if subscription is not expired",
+			server:               "dedicated_ip",
+			config:               config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_NORDLYNX},
+			isDedicatedIPExpired: false,
+			returnCode:           internal.CodeSuccess,
+			eventPublished:       true,
+		},
+		{
 			testName:             "fails to connect dedicated IP when subscription expired",
 			server:               "dedicated_ip",
 			config:               config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_NORDLYNX},
@@ -158,15 +164,116 @@ func TestAutoconnect(t *testing.T) {
 			returnCode:           internal.CodeDedicatedIPRenewError,
 			eventPublished:       false,
 		},
+		{
+			testName:                        "works for dedicated servers if subscription is available and tech is set to NordLynx",
+			server:                          "dedicated_server",
+			config:                          config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_NORDLYNX},
+			isDedicatedServerExpired:        false,
+			isDedicatedServerFeatureEnabled: true,
+			dedicatedServerList:             core.DedicatedServers{core.DedicatedServer{Status: core.DedicatedServerStatusRunning}},
+			returnCode:                      internal.CodeSuccess,
+			eventPublished:                  true,
+		},
+		{
+			testName:                        "fails to connect to a dedicated server if tech is not set to NordLynx",
+			server:                          "dedicated_server",
+			config:                          config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_OPENVPN},
+			isDedicatedServerExpired:        false,
+			isDedicatedServerFeatureEnabled: true,
+			dedicatedServerList:             core.DedicatedServers{core.DedicatedServer{Status: core.DedicatedServerStatusRunning}},
+			returnCode:                      internal.CodeDedicatedServersNoNordlynx,
+			eventPublished:                  false,
+		},
+		{
+			testName:                        "fails to connect to a dedicated server if server is not ready",
+			server:                          "dedicated_server",
+			config:                          config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_NORDLYNX},
+			isDedicatedServerExpired:        false,
+			isDedicatedServerFeatureEnabled: true,
+			dedicatedServerList:             core.DedicatedServers{core.DedicatedServer{Status: "not running"}},
+			returnCode:                      internal.CodeDedicatedServersNotReady,
+			eventPublished:                  false,
+		},
+		{
+			testName:                        "fails to connect to a dedicated server if dedicated server list is empty",
+			server:                          "dedicated_server",
+			config:                          config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_NORDLYNX},
+			isDedicatedServerExpired:        false,
+			isDedicatedServerFeatureEnabled: true,
+			dedicatedServerList:             core.DedicatedServers{},
+			returnCode:                      internal.CodeDedicatedServersServiceButNoServers,
+			eventPublished:                  false,
+		},
+		{
+			testName:                        "fails to connect to a dedicated server if service is expired",
+			server:                          "dedicated_server",
+			config:                          config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_NORDLYNX},
+			isDedicatedServerExpired:        true,
+			isDedicatedServerFeatureEnabled: true,
+			dedicatedServerList:             core.DedicatedServers{},
+			returnCode:                      internal.CodeDedicatedServersRenewError,
+			eventPublished:                  false,
+		},
+		{
+			testName:                        "fails to connect to a dedicated server if feature is disabled in remote config",
+			server:                          "dedicated_server",
+			config:                          config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP}, Technology: config.Technology_NORDLYNX},
+			isDedicatedServerExpired:        false,
+			isDedicatedServerFeatureEnabled: false,
+			dedicatedServerList:             core.DedicatedServers{core.DedicatedServer{Status: core.DedicatedServerStatusRunning}},
+			returnCode:                      internal.CodeGroupNonexisting,
+			eventPublished:                  false,
+		},
+		{
+			testName:                        "fails to connect to a dedicated server if post quantum is on",
+			server:                          "dedicated_server",
+			config:                          config.Config{AutoConnectData: config.AutoConnectData{Obfuscate: false, Protocol: config.Protocol_UDP, PostquantumVpn: true}, Technology: config.Technology_NORDLYNX},
+			isDedicatedServerExpired:        false,
+			isDedicatedServerFeatureEnabled: true,
+			dedicatedServerList:             core.DedicatedServers{core.DedicatedServer{Status: core.DedicatedServerStatusRunning}},
+			returnCode:                      internal.CodeDedicatedServersPq,
+			eventPublished:                  false,
+		},
 	}
 
 	for _, test := range tests {
-		mockAuthChecker := mockAutoconnectAuthChecker{}
+		mockRemoteConfig := mock.NewRemoteConfigMock()
+		mockRemoteConfig.AddFeatureToggle(remote.FeatureDedicatedServer, test.isDedicatedServerFeatureEnabled)
+
+		dipServices := []auth.DedicatedIPService{
+			{
+				ServerIDs: []int64{1},
+			},
+		}
+		if test.isDedicatedIPExpired {
+			dipServices = []auth.DedicatedIPService{}
+		}
+		mockAuthChecker := testauth.AuthCheckerMock{
+			LoggedIn: true,
+			DedicatedServerService: auth.DedicatedServerService{
+				Active: !test.isDedicatedServerExpired,
+			},
+			DIPServices: dipServices}
+
+		mockDedicatedServersAPI := testcore.DedicatedServersAPIMock{
+			DedicatedServersResponse: test.dedicatedServerList,
+			ConnectResponse:          core.DedicatedServerConnectResponse{},
+		}
+
 		mockConfigManager := newMockConfigManager()
 		mockPublisherSubscriber := events.MockPublisherSubscriber[bool]{}
 		mockEvents := events.Events{Settings: &events.SettingsEvents{Autoconnect: &mockPublisherSubscriber}}
 		dm := DataManager{serversData: ServersData{Servers: serversList()}}
-		r := RPC{cm: mockConfigManager, ac: mockAuthChecker, events: &mockEvents, dm: &dm, serversAPI: &mockServersAPI{}}
+		r := RPC{cm: mockConfigManager,
+			ac:                  &mockAuthChecker,
+			events:              &mockEvents,
+			dm:                  &dm,
+			serversAPI:          &mockServersAPI{},
+			dedicatedServersAPI: &mockDedicatedServersAPI,
+			dedicatedServerKeyManager: &testdevicekey.MockDeviceKeyManager{
+				DedicatedServerRegistrationData: &devicekey.DedicatedServersConnectionData{},
+			},
+			remoteConfigGetter: mockRemoteConfig}
 		request := pb.SetAutoconnectRequest{Enabled: true}
 
 		request.ServerTag = test.server
@@ -243,7 +350,8 @@ func TestAutoconnect_SavesCorrectAutoconnectData(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mockAuthChecker := mockAutoconnectAuthChecker{}
+		mockAuthChecker := testauth.AuthCheckerMock{
+			LoggedIn: true}
 		mockConfigManager := newMockConfigManager()
 		mockPublisherSubscriber := events.MockPublisherSubscriber[bool]{}
 		mockEvents := events.Events{
@@ -261,7 +369,7 @@ func TestAutoconnect_SavesCorrectAutoconnectData(t *testing.T) {
 		}
 		r := RPC{
 			cm:         mockConfigManager,
-			ac:         mockAuthChecker,
+			ac:         &mockAuthChecker,
 			events:     &mockEvents,
 			dm:         &dm,
 			serversAPI: &mockServersAPI{},

--- a/daemon/rpc_set_postquantum.go
+++ b/daemon/rpc_set_postquantum.go
@@ -24,6 +24,10 @@ func (r *RPC) SetPostQuantum(ctx context.Context, in *pb.SetGenericRequest) (*pb
 		return &pb.Payload{Type: internal.CodePqAndMeshnetSimultaneously}, nil
 	}
 
+	if in.GetEnabled() && cfg.AutoConnect && cfg.AutoConnectData.Group == config.ServerGroup_DEDICATED_SERVER {
+		return &pb.Payload{Type: internal.CodeDedicatedServersPq}, nil
+	}
+
 	if cfg.Technology != config.Technology_NORDLYNX {
 		return &pb.Payload{Type: internal.CodePqWithoutNordlynx,
 			Data: []string{config.TechNameToUpperCamelCase(cfg.Technology)}}, nil

--- a/daemon/rpc_set_postquantum_test.go
+++ b/daemon/rpc_set_postquantum_test.go
@@ -23,6 +23,7 @@ func (*mockPostquantumVpnConfigManager) SaveWith(f config.SaveFunc) error {
 
 func (m *mockPostquantumVpnConfigManager) Load(c *config.Config) error {
 	c.Mesh = m.c.Mesh
+	c.AutoConnect = m.c.AutoConnect
 	c.AutoConnectData = m.c.AutoConnectData
 	c.Technology = m.c.Technology
 	return nil
@@ -74,14 +75,20 @@ func TestSetPostquantumVpn(t *testing.T) {
 		Data: []string{"NordWhisper"},
 	}
 
+	conflictDedicatedServerPayload := pb.Payload{
+		Type: internal.CodeDedicatedServersPq,
+	}
+
 	tests := []struct {
-		testName       string
-		pq             bool
-		meshnet        bool
-		vpnActive      bool
-		tech           config.Technology
-		payload        *pb.Payload
-		eventPublished bool
+		testName               string
+		pq                     bool
+		meshnet                bool
+		vpnActive              bool
+		tech                   config.Technology
+		autoconnect            bool
+		autoconnectTargetGroup config.ServerGroup
+		payload                *pb.Payload
+		eventPublished         bool
 	}{
 		{
 			testName:       "pq off mesh is off tech unknown",
@@ -154,12 +161,24 @@ func TestSetPostquantumVpn(t *testing.T) {
 			payload:        &conflictNordWhisperPayload,
 			eventPublished: false,
 		},
+		{
+			testName:               "pq is off autoconnect target is a dedicated server",
+			pq:                     true,
+			meshnet:                false,
+			vpnActive:              false,
+			autoconnect:            true,
+			autoconnectTargetGroup: config.ServerGroup_DEDICATED_SERVER,
+			tech:                   config.Technology_NORDLYNX,
+			payload:                &conflictDedicatedServerPayload,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			mockConfigManager.c.Mesh = test.meshnet
 			mockConfigManager.c.Technology = test.tech
+			mockConfigManager.c.AutoConnect = test.autoconnect
+			mockConfigManager.c.AutoConnectData.Group = test.autoconnectTargetGroup
 			mockConfigManager.c.AutoConnectData.PostquantumVpn = !test.pq
 
 			mockNetworker.ConnectRetries = 0

--- a/daemon/rpc_set_technology.go
+++ b/daemon/rpc_set_technology.go
@@ -34,6 +34,14 @@ func (r *RPC) SetTechnology(ctx context.Context, in *pb.SetTechnologyRequest) (*
 		}, nil
 	}
 
+	if cfg.AutoConnect &&
+		cfg.AutoConnectData.Group == config.ServerGroup_DEDICATED_SERVER &&
+		in.GetTechnology() != config.Technology_NORDLYNX {
+		return &pb.Payload{
+			Type: internal.CodeDedicatedServersNoNordlynx,
+		}, nil
+	}
+
 	v, err := r.factory(in.GetTechnology())
 	if err != nil {
 		log.Println(internal.ErrorPrefix, err)

--- a/daemon/rpc_set_technology_test.go
+++ b/daemon/rpc_set_technology_test.go
@@ -94,3 +94,37 @@ func TestSetTechnology_NordWhisper(t *testing.T) {
 		})
 	}
 }
+
+func TestSetTechnology_DedicatedServer(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	configManager := mock.NewMockConfigManager()
+	configManager.Cfg = &config.Config{
+		Technology:  config.Technology_NORDLYNX,
+		AutoConnect: true,
+		AutoConnectData: config.AutoConnectData{
+			Group: config.ServerGroup_DEDICATED_SERVER,
+		},
+	}
+
+	networker := networker.Mock{}
+
+	remoteConfigGetter := mock.NewRemoteConfigMock()
+	remoteConfigGetter.NordWhisperEnabled = true
+
+	r := RPC{
+		remoteConfigGetter: remoteConfigGetter,
+		cm:                 configManager,
+		netw:               &networker,
+		factory:            func(t config.Technology) (vpn.VPN, error) { return nil, nil },
+		events:             events.NewEventsEmpty(),
+	}
+
+	resp, _ := r.SetTechnology(context.Background(), &pb.SetTechnologyRequest{
+		Technology: config.Technology_OPENVPN,
+	})
+
+	assert.Equal(t, internal.CodeDedicatedServersNoNordlynx, resp.Type, "Invalid response code by the daemon.")
+	assert.Equal(t, config.Technology_NORDLYNX, configManager.Cfg.Technology,
+		"Technology should not be changed when daemon responds with a non-success code.")
+}

--- a/daemon/servers.go
+++ b/daemon/servers.go
@@ -670,6 +670,9 @@ func selectDedicatedServer(authChecker auth.Checker,
 		normalizedStatusValue == string(core.DedicatedServerStatusStopping) {
 		return result, internal.NewErrorWithCode(internal.CodeDedicatedServersCanNotConnect)
 	}
+	if normalizedStatusValue == string(core.DedicatedServerStatusNew) {
+		return result, internal.NewErrorWithCode(internal.CodeDedicatedServersServerNotSetUp)
+	}
 	if normalizedStatusValue != string(core.DedicatedServerStatusRunning) {
 		return result, internal.NewErrorWithCode(internal.CodeDedicatedServersNotReady)
 	}

--- a/internal/codes.go
+++ b/internal/codes.go
@@ -79,6 +79,8 @@ const (
 	CodeDedicatedServersNoNordlynx             int64 = 3065
 	CodeDedicatedServersCanNotConnect          int64 = 3066
 	CodeDedicatedServersSessionMaxLimitReached int64 = 3067
+	CodeDedicatedServersPq                     int64 = 3068
+	CodeDedicatedServersServerNotSetUp         int64 = 3069
 )
 
 type ErrorWithCode struct {

--- a/tray/actions.go
+++ b/tray/actions.go
@@ -213,7 +213,7 @@ func (ti *Instance) connectWithUIEvent(
 		case internal.CodeDedicatedServersNotReady:
 			ti.notify(Force, cli.DedicatedServersServerNotReadyMessage)
 		case internal.CodeDedicatedServersNoNordlynx:
-			ti.notify(Force, cli.DedicatedServersNoNordlynxMessage)
+			ti.notify(Force, cli.MsgNordlynxMustBeEnabled)
 		case internal.CodeDedicatedServersCanNotConnect:
 			ti.notify(Force, cli.DedicatedServersCanNotConnectMessage)
 		case internal.CodeDedicatedServersSessionMaxLimitReached:

--- a/tray/actions_test.go
+++ b/tray/actions_test.go
@@ -128,7 +128,7 @@ func TestConnect_DedicatedServersErrorPaths(t *testing.T) {
 		{
 			name:     "no nordlynx notifies user",
 			code:     internal.CodeDedicatedServersNoNordlynx,
-			wantBody: cli.DedicatedServersNoNordlynxMessage,
+			wantBody: cli.MsgNordlynxMustBeEnabled,
 		},
 		{
 			name:     "server is stopping or stopped",


### PR DESCRIPTION
Adds handling of dedicated server related errors and a fallback in of expired 

When user's autoconnect target is a dedicated server and their service expires, autoconnect target will be set to the fastest available server.
