### PR TITLE
LVPN-10581, LVPN-10512: Fix tray status is not updating

### DIFF
--- a/tray/daemon_state_handler.go
+++ b/tray/daemon_state_handler.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (ti *Instance) onDaemonStateEvent(item *pb.AppState) {
+	log.Debugf("app state received %v\n", item)
 	changed := false
 	switch st := item.GetState().(type) {
 	case *pb.AppState_Error:

--- a/tray/fileshare_manager.go
+++ b/tray/fileshare_manager.go
@@ -22,11 +22,11 @@ func NewFileshareManager() FileshareManager {
 
 // UpdateFileshareConnection updates the fileshare gRPC connection based on the meshnetEnabled status
 func (fs *FileshareManager) UpdateFileshareConnection(meshnetEnabled bool) {
-	log.Println(internal.InfoPrefix, "Updating tray's fileshare connection", getFlagText(meshnetEnabled))
 	if !meshnetEnabled {
 		fs.fileshareClient = nil
 		return
 	}
+	log.Debug("Updating tray's fileshare connection", getFlagText(meshnetEnabled))
 
 	if fs.fileshareClient == nil {
 		// Meshnet is enabled, we must connect to the fileshare daemon

--- a/tray/menu.go
+++ b/tray/menu.go
@@ -447,10 +447,8 @@ func buildSettingsSubitems(ti *Instance, menu *systray.MenuItem) {
 		return
 	}
 
-	ti.state.mu.RLock()
 	notificationsEnabled := ti.state.notificationsStatus == Enabled
 	trayEnabled := ti.state.trayStatus == Enabled
-	ti.state.mu.RUnlock()
 
 	notificationsCheckbox := menu.AddSubMenuItemCheckbox(
 		labelNotifications,

--- a/tray/monitor.go
+++ b/tray/monitor.go
@@ -484,6 +484,7 @@ func (ti *Instance) setVpnStatus(
 ) bool {
 	changed := false
 	var notificationText, notificationArg string
+
 	func() {
 		ti.state.mu.Lock()
 		defer ti.state.mu.Unlock()
@@ -498,8 +499,10 @@ func (ti *Instance) setVpnStatus(
 		ti.state.vpnHostname = vpnHostname
 		ti.state.vpnStatus = vpnStatus
 
+		newServerName := ti.state.serverName()
+
 		statusChanged := oldVpnStatus != vpnStatus
-		serverNameChanged := oldServerName != ti.state.serverName()
+		serverNameChanged := oldServerName != newServerName
 		changed = statusChanged || serverNameChanged
 
 		if statusChanged {
@@ -507,7 +510,7 @@ func (ti *Instance) setVpnStatus(
 			switch vpnStatus {
 			case pb.ConnectionState_CONNECTED:
 				notificationText = labelConnectedFormat
-				notificationArg = ti.state.serverName()
+				notificationArg = newServerName
 			case pb.ConnectionState_PAUSED:
 				fallthrough
 			case pb.ConnectionState_DISCONNECTED:
@@ -518,10 +521,10 @@ func (ti *Instance) setVpnStatus(
 			case pb.ConnectionState_UNKNOWN_STATE, pb.ConnectionState_CONNECTING:
 			}
 		} else if serverNameChanged {
-			log.Printf("%s VPN server name changed from %s to %s\n", logTag, oldServerName, ti.state.serverName())
-			if ti.state.serverName() != "" && oldServerName != "" && vpnStatus == pb.ConnectionState_CONNECTED {
+			log.Printf("%s VPN server name changed from %s to %s\n", logTag, oldServerName, newServerName)
+			if newServerName != "" && oldServerName != "" && vpnStatus == pb.ConnectionState_CONNECTED {
 				notificationText = labelConnectedFormat
-				notificationArg = ti.state.serverName()
+				notificationArg = newServerName
 			}
 		}
 	}()

--- a/tray/state_listener.go
+++ b/tray/state_listener.go
@@ -46,7 +46,7 @@ func (l *stateListener) Stop() {
 	}
 }
 
-func (l *stateListener) consumeStream(server grpc.ServerStreamingClient[pb.AppState]) {
+func (l *stateListener) consumeStream(ctx context.Context, server grpc.ServerStreamingClient[pb.AppState]) {
 	for {
 		state, err := server.Recv()
 		if err != nil {
@@ -57,19 +57,20 @@ func (l *stateListener) consumeStream(server grpc.ServerStreamingClient[pb.AppSt
 		select {
 		case l.queue <- state:
 		case <-time.After(time.Second):
-			log.Printf("%s %s App state consumer's queue is full, dropping\n", logTag, internal.WarningPrefix)
+			log.Warnf(logTag, "App state consumer's queue is full, dropping: %v\n", state)
+		case <-ctx.Done():
+			return
 		}
 	}
 }
 
-func (c *stateListener) handleAppState(ctx context.Context) {
+func (l *stateListener) handleAppState(ctx context.Context) {
 	for {
 		select {
-		case item := <-c.queue:
-			c.onDataFunc(item)
+		case item := <-l.queue:
+			l.onDataFunc(item)
 
 		case <-ctx.Done():
-			defer close(c.queue)
 			return
 		}
 	}
@@ -95,9 +96,11 @@ func (l *stateListener) listen(ctx context.Context) {
 	for {
 		if err := RetryWithBackoff(ctx, backoffConfig, op); err != nil {
 			log.Printf("%s %s listen to daemon's state stream: %s\n", logTag, internal.InfoPrefix, err)
-			return
+			break
 		}
 
-		l.consumeStream(server)
+		l.consumeStream(ctx, server)
 	}
+
+	close(l.queue)
 }

--- a/tray/state_listener.go
+++ b/tray/state_listener.go
@@ -57,7 +57,7 @@ func (l *stateListener) consumeStream(ctx context.Context, server grpc.ServerStr
 		select {
 		case l.queue <- state:
 		case <-time.After(time.Second):
-			log.Warnf(logTag, "App state consumer's queue is full, dropping: %v\n", state)
+			log.Warnf("%s App state consumer's queue is full, dropping: %v\n", logTag, state)
 		case <-ctx.Done():
 			return
 		}

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -260,7 +260,9 @@ func (ti *Instance) Start() {
 
 	ti.state.vpnStatus = pb.ConnectionState_DISCONNECTED
 	ti.state.notificationsStatus = Invalid
-	ti.renderChan = make(chan struct{})
+	// allow more events to be queued in case one goroutine is busy building the UI,
+	// while multiple events are received from the daemon
+	ti.renderChan = make(chan struct{}, 5)
 	ti.initialDataLoadChan = make(chan struct{})
 
 	go ti.syncWithDaemon()
@@ -294,25 +296,14 @@ func (ti *Instance) updateIcon() {
 
 func (ti *Instance) renderLoop(ctx context.Context) {
 	for {
+		log.Debug("Render tray loop")
+
 		// Wait for any checkbox operations to complete before rebuilding menu
 		ti.checkboxSync.WaitForOperations()
 		systray.ResetMenu()
 
-		ti.state.mu.RLock()
-		ti.updateIcon()
-		buildConnectionSection(ti)
-		buildSettingsSection(ti)
-		buildAccountSection(ti)
-		buildDaemonErrorSection(ti)
-		addDebugSection(ti)
-		buildQuitButton(ti)
-		systray.Refresh()
-		ti.state.mu.RUnlock()
+		ti.rebuildTray()
 		<-ti.renderChan
-
-		if ti.debugMode {
-			log.Println(internal.DebugPrefix, "Render")
-		}
 
 		select {
 		case <-ctx.Done():
@@ -320,4 +311,19 @@ func (ti *Instance) renderLoop(ctx context.Context) {
 		default:
 		}
 	}
+}
+
+func (ti *Instance) rebuildTray() {
+	ti.state.mu.RLock()
+	defer ti.state.mu.RUnlock()
+
+	// called functions must not contain Lock or RLock calls
+	ti.updateIcon()
+	buildConnectionSection(ti)
+	buildSettingsSection(ti)
+	buildAccountSection(ti)
+	buildDaemonErrorSection(ti)
+	addDebugSection(ti)
+	buildQuitButton(ti)
+	systray.Refresh()
 }


### PR DESCRIPTION
Make `renderChan` buffered channel to not miss rebuilds because of daemon notifications.
To prevent deadlock remove locks from the functions called by `rebuildTray`.