### PR TITLE
LVPN-10602: Fix DNS address validation

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // #nosec G108 -- http server is not run in production builds
-	"net/netip"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -166,7 +165,7 @@ func main() {
 	)
 
 	// Remove any remains of IPv6 settings and remove overlapping allowlist subnets
-	if err := fsystem.SaveWith(configCleanup); err != nil {
+	if err := fsystem.SaveWith(daemon.ConfigCleanup); err != nil {
 		log.Println(internal.ErrorPrefix, "failed to cleanup config:", err)
 	}
 
@@ -790,27 +789,6 @@ func assignMooseDBPermissions(eventsDbPath string) error {
 		log.Println(err)
 	}
 	return nil
-}
-
-// configCleanup - validate/cleanup DNS addresses, allowlist subnets
-func configCleanup(c config.Config) config.Config {
-	// Remove all nameservers with IPv6 addresses
-	var dnsList []string
-	for _, addr := range c.AutoConnectData.DNS {
-		p, err := netip.ParsePrefix(addr)
-		if err != nil || !p.Addr().Is4() {
-			continue
-		}
-		dnsList = append(dnsList, addr)
-	}
-	c.AutoConnectData.DNS = dnsList
-
-	// Remove overlapping, invalid and IPv6 subnets, if any
-	c.AutoConnectData.Allowlist.NormalizeSubnets(func(removed, reason string) {
-		log.Println(internal.WarningPrefix, "On start, allowlist remove subnet:", removed, "; reason:", reason)
-	})
-
-	return c
 }
 
 // buildClientAPIAndSessionStores creates and configures the client API and session stores

--- a/daemon/migrations.go
+++ b/daemon/migrations.go
@@ -28,7 +28,7 @@ func MigrateDeprecatedRegionalAutoconnect(cm config.Manager) error {
 	})
 }
 
-// configCleanup - validate/cleanup DNS addresses, allowlist subnets
+// ConfigCleanup - validate/cleanup DNS addresses, allowlist subnets
 func ConfigCleanup(c config.Config) config.Config {
 	// Remove all nameservers with IPv6 addresses
 	var dnsList []string

--- a/daemon/migrations.go
+++ b/daemon/migrations.go
@@ -33,7 +33,7 @@ func ConfigCleanup(c config.Config) config.Config {
 	// Remove all nameservers with IPv6 addresses
 	var dnsList []string
 	for _, addr := range c.AutoConnectData.DNS {
-		if internal.IsDNSAddressValid(addr) {
+		if internal.IsAddressValidAsDNSServer(addr) {
 			dnsList = append(dnsList, addr)
 		} else {
 			log.Warn("remove invalid DNS address from the list", addr)
@@ -43,7 +43,7 @@ func ConfigCleanup(c config.Config) config.Config {
 
 	// Remove overlapping, invalid and IPv6 subnets, if any
 	c.AutoConnectData.Allowlist.NormalizeSubnets(func(removed, reason string) {
-		log.Println(internal.WarningPrefix, "On start, allowlist remove subnet:", removed, "; reason:", reason)
+		log.Warn("On start, allowlist remove subnet:", removed, "; reason:", reason)
 	})
 
 	return c

--- a/daemon/migrations.go
+++ b/daemon/migrations.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/log"
 )
 
 // MigrateDeprecatedRegionalAutoconnect removes the deprecated regional group from autoconnect.
@@ -24,4 +26,25 @@ func MigrateDeprecatedRegionalAutoconnect(cm config.Manager) error {
 		}
 		return c
 	})
+}
+
+// configCleanup - validate/cleanup DNS addresses, allowlist subnets
+func ConfigCleanup(c config.Config) config.Config {
+	// Remove all nameservers with IPv6 addresses
+	var dnsList []string
+	for _, addr := range c.AutoConnectData.DNS {
+		if internal.IsDNSAddressValid(addr) {
+			dnsList = append(dnsList, addr)
+		} else {
+			log.Warn("remove invalid DNS address from the list", addr)
+		}
+	}
+	c.AutoConnectData.DNS = dnsList
+
+	// Remove overlapping, invalid and IPv6 subnets, if any
+	c.AutoConnectData.Allowlist.NormalizeSubnets(func(removed, reason string) {
+		log.Println(internal.WarningPrefix, "On start, allowlist remove subnet:", removed, "; reason:", reason)
+	})
+
+	return c
 }

--- a/daemon/rpc_set_dns.go
+++ b/daemon/rpc_set_dns.go
@@ -37,7 +37,7 @@ func (r *RPC) SetDNS(ctx context.Context, in *pb.SetDNSRequest) (*pb.SetDNSRespo
 
 	for _, address := range nameservers {
 		// Do not allow IPv6 servers
-		if !internal.IsDNSAddressValid(address) {
+		if !internal.IsAddressValidAsDNSServer(address) {
 			return &pb.SetDNSResponse{
 				Response: &pb.SetDNSResponse_SetDnsStatus{SetDnsStatus: pb.SetDNSStatus_INVALID_DNS_ADDRESS},
 			}, nil

--- a/daemon/rpc_set_dns.go
+++ b/daemon/rpc_set_dns.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
@@ -38,7 +37,7 @@ func (r *RPC) SetDNS(ctx context.Context, in *pb.SetDNSRequest) (*pb.SetDNSRespo
 
 	for _, address := range nameservers {
 		// Do not allow IPv6 servers
-		if parsedAddress := net.ParseIP(address); parsedAddress == nil || parsedAddress.To4() == nil {
+		if !internal.IsDNSAddressValid(address) {
 			return &pb.SetDNSResponse{
 				Response: &pb.SetDNSResponse_SetDnsStatus{SetDnsStatus: pb.SetDNSStatus_INVALID_DNS_ADDRESS},
 			}, nil

--- a/internal/validators.go
+++ b/internal/validators.go
@@ -1,0 +1,8 @@
+package internal
+
+import "net"
+
+func IsDNSAddressValid(address string) bool {
+	parsedAddress := net.ParseIP(address)
+	return parsedAddress != nil && parsedAddress.To4() != nil
+}

--- a/internal/validators.go
+++ b/internal/validators.go
@@ -1,8 +1,10 @@
 package internal
 
-import "net"
+import "net/netip"
 
-func IsDNSAddressValid(address string) bool {
-	parsedAddress := net.ParseIP(address)
-	return parsedAddress != nil && parsedAddress.To4() != nil
+func IsAddressValidAsDNSServer(address string) bool {
+	parsedAddress, err := netip.ParseAddr(address)
+	// Is4 is true only for genuine 4-byte IPv4 addresses; it rejects IPv6 and
+	// IPv4-mapped IPv6 forms such as "::ffff:192.168.1.1" (those are Is4In6).
+	return err == nil && parsedAddress.Is4()
 }

--- a/internal/validators_test.go
+++ b/internal/validators_test.go
@@ -1,0 +1,65 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"gotest.tools/v3/assert"
+)
+
+func TestIsDNSAddressValid(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name     string
+		address  string
+		expected bool
+	}{
+		// Valid IPv4 addresses.
+		{name: "common public dns", address: "1.1.1.1", expected: true},
+		{name: "google dns", address: "8.8.8.8", expected: true},
+		{name: "loopback", address: "127.0.0.1", expected: true},
+		{name: "private class a", address: "10.0.0.1", expected: true},
+		{name: "private class c", address: "192.168.1.1", expected: true},
+		{name: "all zeros", address: "0.0.0.0", expected: true},
+		{name: "broadcast", address: "255.255.255.255", expected: true},
+		{name: "max single octet", address: "0.0.0.255", expected: true},
+
+		// IPv4-mapped IPv6 collapses to a 4-byte address, so To4() is non-nil.
+		{name: "ipv4-mapped ipv6", address: "::ffff:192.168.1.1", expected: true},
+
+		// Valid IPv6 addresses are rejected because To4() is nil.
+		{name: "ipv6 loopback", address: "::1", expected: false},
+		{name: "ipv6 unspecified", address: "::", expected: false},
+		{name: "ipv6 compressed", address: "2001:db8::1", expected: false},
+		{name: "ipv6 link-local", address: "fe80::1", expected: false},
+		{name: "ipv6 full", address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334", expected: false},
+
+		// Malformed / non-IP input.
+		{name: "empty string", address: "", expected: false},
+		{name: "whitespace only", address: "   ", expected: false},
+		{name: "leading space", address: " 1.1.1.1", expected: false},
+		{name: "trailing space", address: "1.1.1.1 ", expected: false},
+		{name: "octet out of range", address: "256.256.256.256", expected: false},
+		{name: "single octet out of range", address: "192.168.1.256", expected: false},
+		{name: "negative octet", address: "-1.1.1.1", expected: false},
+		{name: "too few octets", address: "1.1.1", expected: false},
+		{name: "too many octets", address: "1.1.1.1.1", expected: false},
+		{name: "trailing dot", address: "1.1.1.1.", expected: false},
+		{name: "leading dot", address: ".1.1.1.1", expected: false},
+		{name: "double dot", address: "1..1.1", expected: false},
+		{name: "letters in octet", address: "1.1.1.a", expected: false},
+		{name: "alphabetic", address: "abc", expected: false},
+		{name: "hostname", address: "example.com", expected: false},
+		{name: "hex notation", address: "0x1.0x1.0x1.0x1", expected: false},
+		{name: "cidr notation", address: "192.168.1.0/24", expected: false},
+		{name: "cidr single host", address: "1.1.1.1/32", expected: false},
+		{name: "address with port", address: "1.1.1.1:53", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsDNSAddressValid(tt.address))
+		})
+	}
+}

--- a/internal/validators_test.go
+++ b/internal/validators_test.go
@@ -7,7 +7,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestIsDNSAddressValid(t *testing.T) {
+func TestIsAddressValidAsDNSServer(t *testing.T) {
 	category.Set(t, category.Unit)
 
 	tests := []struct {
@@ -25,8 +25,8 @@ func TestIsDNSAddressValid(t *testing.T) {
 		{name: "broadcast", address: "255.255.255.255", expected: true},
 		{name: "max single octet", address: "0.0.0.255", expected: true},
 
-		// IPv4-mapped IPv6 collapses to a 4-byte address, so To4() is non-nil.
-		{name: "ipv4-mapped ipv6", address: "::ffff:192.168.1.1", expected: true},
+		// IPv4-mapped IPv6 is written in IPv6 notation, so it is rejected.
+		{name: "ipv4-mapped ipv6", address: "::ffff:192.168.1.1", expected: false},
 
 		// Valid IPv6 addresses are rejected because To4() is nil.
 		{name: "ipv6 loopback", address: "::1", expected: false},
@@ -59,7 +59,7 @@ func TestIsDNSAddressValid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, IsDNSAddressValid(tt.address))
+			assert.Equal(t, tt.expected, IsAddressValidAsDNSServer(tt.address))
 		})
 	}
 }

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -562,5 +562,5 @@ def test_settings_are_kept_after_reboot():
     daemon.restart()
 
     app_settings = settings.Settings()
-    assert app_settings.get("Threat Protection Lite") == "disabled", f"Tpl must be disabled, because of custom DNS"
-    assert app_settings.get("DNS") == "1.1.1.1", f"Custom DNS value is not kept after reboot"
+    assert app_settings.get("Threat Protection Lite") == "disabled", "Tpl must be disabled, because of custom DNS"
+    assert app_settings.get("DNS") == "1.1.1.1", "Custom DNS value is not kept after reboot"

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -557,7 +557,6 @@ def test_settings_are_kept_after_reboot():
     assert app_settings.get("DNS") == "disabled", "DNS must be disabled because TP is enabled"
 
     # set DNS and reboot the system
-
     assert "DNS has been successfully set to '1.1.1.1'." in sh.nordvpn.set("dns", "1.1.1.1"), "Failed to set custom DNS"
 
     daemon.restart()

--- a/test/qa/test_settings.py
+++ b/test/qa/test_settings.py
@@ -525,3 +525,43 @@ def test_lan_discovery_on_off():
     assert "LAN Discovery has been successfully set to 'disabled'." in sh.nordvpn.set("lan-discovery", "off"), "LAN Discovery should be successfully disabled"
     assert not settings.is_lan_discovery_enabled(), "LAN Discovery should be disabled"
 
+
+def test_settings_are_kept_after_reboot():
+    # (set arguments, expected message, settings key, expected value after reboot)
+    toggles = [
+        (("firewall", "off"),         "Firewall has been successfully set to 'disabled'.",               "Firewall",               "disabled"),
+        (("routing", "off"),          "Routing has been successfully set to 'disabled'.",                "Routing",                "disabled"),
+        (("analytics", "off"),        "Analytics has been successfully set to 'disabled'.",              "User Consent",           "disabled"),
+        (("tpl", "on"),               "Threat Protection Lite has been successfully set to 'enabled'.",  "Threat Protection Lite", "enabled"),
+        (("notify", "off"),           "Notifications are set to 'disabled' successfully.",               "Notify",                 "disabled"),
+        (("tray", "off"),             "Tray set to 'disabled' successfully.",                            "Tray",                   "disabled"),
+        (("autoconnect", "on"),       "Auto-connect has been successfully set to 'enabled'.",            "Auto-connect",           "enabled"),
+        (("lan-discovery", "on"),     "LAN Discovery has been successfully set to 'enabled'.",           "LAN Discovery",          "enabled"),
+        (("virtual-location", "off"), "Virtual location has been successfully set to 'disabled'.",       "Virtual Location",       "disabled"),
+        (("arp-ignore", "off"),       "ARP ignore set to 'disabled' successfully.",                      "ARP Ignore",             "disabled"),
+    ]
+
+    for args, message, _, _ in toggles:
+        assert message in sh.nordvpn.set(*args), f"Expected message not shown: {message}"
+
+    assert "Firewall Mark has been successfully set to '0x1234'." in sh.nordvpn.set("fwmark", "0x1234"), "Failed to set firewall mark"
+
+    daemon.restart()
+
+    app_settings = settings.Settings()
+
+    for _, _, key, expected in toggles:
+        assert app_settings.get(key) == expected, f"{key} is incorrect after reboot '{expected}'"
+
+    assert app_settings.get("Firewall Mark") == "0x1234", "Firewall mark is not kept after reboot"
+    assert app_settings.get("DNS") == "disabled", "DNS must be disabled because TP is enabled"
+
+    # set DNS and reboot the system
+
+    assert "DNS has been successfully set to '1.1.1.1'." in sh.nordvpn.set("dns", "1.1.1.1"), "Failed to set custom DNS"
+
+    daemon.restart()
+
+    app_settings = settings.Settings()
+    assert app_settings.get("Threat Protection Lite") == "disabled", f"Tpl must be disabled, because of custom DNS"
+    assert app_settings.get("DNS") == "1.1.1.1", f"Custom DNS value is not kept after reboot"


### PR DESCRIPTION
Add a single place where the DNS address is verified if is valid or not. 
Add test to check that the settings are kept after daemon reboot.