### PR TITLE
LVPN-10587: Use lumberjack for user processes

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -71,20 +71,16 @@ func main() {
 		}
 	}()
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatalln(err)
-	}
-	configDir, err := internal.GetConfigDirPath(homeDir)
+	configDir, err := internal.GetConfigDirPath()
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	// Setup logging
 	fileLogger := &lumberjack.Logger{
-		Filename:   filepath.Join(configDir, "cli.log"),
-		MaxSize:    500,
-		MaxBackups: 3,
+		Filename:   filepath.Join(configDir, internal.CLILogFileName),
+		MaxSize:    100,
+		MaxBackups: 1,
 		MaxAge:     28,
 		Compress:   true,
 	}

--- a/cmd/fileshare/log_cgo.go
+++ b/cmd/fileshare/log_cgo.go
@@ -3,14 +3,11 @@
 package main
 
 import (
-	"io"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/NordSecurity/nordvpn-linux/internal"
-	"golang.org/x/sys/unix"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 /*
@@ -33,39 +30,4 @@ func redirectNativeOutput(f *os.File) {
 	if internal.IsProdEnv(Environment) {
 		signal.Notify(make(chan os.Signal, 1), syscall.SIGABRT)
 	}
-}
-
-func redirectFDsToLumberjack(lj *lumberjack.Logger) (cleanup func() error, err error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-
-	// Point fd 1 and fd 2 at the pipe's write end.
-	// This is what makes C printf/fprintf(stderr,...) land in the pipe.
-	if err := unix.Dup2(int(w.Fd()), int(os.Stdout.Fd())); err != nil {
-		return nil, err
-	}
-	if err := unix.Dup2(int(w.Fd()), int(os.Stderr.Fd())); err != nil {
-		return nil, err
-	}
-	// Keep Go's *os.File handles consistent with the underlying fds.
-	os.Stdout = w
-	os.Stderr = w
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_, _ = io.Copy(lj, r) // streams chunks straight into lumberjack
-	}()
-
-	cleanup = func() error {
-		_ = w.Close() // EOF for the goroutine
-		<-done        // wait for drain
-		return lj.Close()
-	}
-	if internal.IsProdEnv(Environment) {
-		signal.Notify(make(chan os.Signal, 1), syscall.SIGABRT)
-	}
-	return cleanup, nil
 }

--- a/cmd/fileshare/log_cgo.go
+++ b/cmd/fileshare/log_cgo.go
@@ -3,11 +3,14 @@
 package main
 
 import (
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/NordSecurity/nordvpn-linux/internal"
+	"golang.org/x/sys/unix"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 /*
@@ -30,4 +33,39 @@ func redirectNativeOutput(f *os.File) {
 	if internal.IsProdEnv(Environment) {
 		signal.Notify(make(chan os.Signal, 1), syscall.SIGABRT)
 	}
+}
+
+func redirectFDsToLumberjack(lj *lumberjack.Logger) (cleanup func() error, err error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// Point fd 1 and fd 2 at the pipe's write end.
+	// This is what makes C printf/fprintf(stderr,...) land in the pipe.
+	if err := unix.Dup2(int(w.Fd()), int(os.Stdout.Fd())); err != nil {
+		return nil, err
+	}
+	if err := unix.Dup2(int(w.Fd()), int(os.Stderr.Fd())); err != nil {
+		return nil, err
+	}
+	// Keep Go's *os.File handles consistent with the underlying fds.
+	os.Stdout = w
+	os.Stderr = w
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(lj, r) // streams chunks straight into lumberjack
+	}()
+
+	cleanup = func() error {
+		_ = w.Close() // EOF for the goroutine
+		<-done        // wait for drain
+		return lj.Close()
+	}
+	if internal.IsProdEnv(Environment) {
+		signal.Notify(make(chan os.Signal, 1), syscall.SIGABRT)
+	}
+	return cleanup, nil
 }

--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -56,7 +56,7 @@ func main() {
 	defer stopLevelWatcher()
 
 	if lj, ok := logFile.(*lumberjack.Logger); ok {
-		if cleanup, err := redirectFDsToLumberjack(lj); err != nil {
+		if cleanup, err := redirectStdOutputToLumberjack(lj); err != nil {
 			log.Error("failed to redirect stdout to logger", err)
 		} else {
 			defer cleanup()

--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/netutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 var (
@@ -45,19 +46,24 @@ func main() {
 			panic(r)
 		}
 	}()
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		os.Exit(int(childprocess.CodeFailedToEnable))
-	}
 
-	logFile := internal.UserLogOutput(internal.FileshareLogFileName)
-	redirectNativeOutput(logFile)
+	logFile := internal.UserLogOutput(internal.FileshareLogFileName, internal.MaxUserLogSizeMB)
 	stopLevelWatcher := log.SetupLogger(
 		logFile,
 		internal.LogLevelFile,
 		log.DefaultLevel(),
 	)
 	defer stopLevelWatcher()
+
+	if lj, ok := logFile.(*lumberjack.Logger); ok {
+		if cleanup, err := redirectFDsToLumberjack(lj); err != nil {
+			log.Error("failed to redirect stdout to logger", err)
+		} else {
+			defer cleanup()
+		}
+	} else if f, ok := logFile.(*os.File); ok {
+		redirectNativeOutput(f)
+	}
 
 	processStatus := fileshare_process.NewFileshareGRPCProcessManager().ProcessStatus()
 	switch processStatus {
@@ -160,7 +166,7 @@ func main() {
 		os.Exit(int(childprocess.CodeFailedToEnable))
 	}
 
-	configDirPath, err := internal.GetConfigDirPath(homeDir)
+	configDirPath, err := internal.GetConfigDirPath()
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "failed to get path to OS configuration directory:", err)
 		os.Exit(int(childprocess.CodeFailedToEnable))

--- a/cmd/fileshare/redirect_to_lumberjack.go
+++ b/cmd/fileshare/redirect_to_lumberjack.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"golang.org/x/sys/unix"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// redirectStdOutputToLumberjack - redirects the stdout and stderr to lumberjack
+func redirectStdOutputToLumberjack(lj *lumberjack.Logger) (cleanup func() error, retErr error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if retErr != nil {
+			_ = w.Close()
+			_ = r.Close()
+		}
+	}()
+
+	// Point fd 1 and fd 2 at the pipe's write end.
+	// This is what makes C printf/fprintf(stderr,...) land in the pipe.
+	if err := unix.Dup2(int(w.Fd()), int(os.Stdout.Fd())); err != nil {
+		return nil, err
+	}
+	if err := unix.Dup2(int(w.Fd()), int(os.Stderr.Fd())); err != nil {
+		return nil, err
+	}
+	// Keep Go's *os.File handles consistent with the underlying fds.
+	os.Stdout = w
+	os.Stderr = w
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(lj, r) // streams chunks straight into lumberjack
+	}()
+
+	cleanup = func() error {
+		_ = w.Close() // EOF for the goroutine
+		<-done        // wait for drain
+		return lj.Close()
+	}
+	if internal.IsProdEnv(Environment) {
+		signal.Notify(make(chan os.Signal, 1), syscall.SIGABRT)
+	}
+	return cleanup, nil
+}

--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -202,13 +202,6 @@ func startFileshare(uid uint32) (chan<- norduser.FileshareManagementMsg, <-chan 
 }
 
 func startSnap() {
-	stopLevelWatcher := log.SetupLogger(
-		internal.UserLogOutput(internal.NorduserdLogFileName),
-		internal.LogLevelFile,
-		log.DefaultLevel(),
-	)
-	defer stopLevelWatcher()
-
 	group, err := user.LookupGroup(internal.NordvpnGroup)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "Unable to retrieve nordvpn group:", err)
@@ -305,13 +298,6 @@ func startSnap() {
 }
 
 func start() {
-	stopLevelWatcher := log.SetupLogger(
-		internal.UserLogOutput(internal.NorduserdLogFileName),
-		internal.LogLevelFile,
-		log.DefaultLevel(),
-	)
-	defer stopLevelWatcher()
-
 	connURL := internal.GetNorduserSocketFork(os.Geteuid())
 	if err := os.Remove(connURL); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Println(internal.ErrorPrefix, "Failed to remove old socket file:", err)
@@ -363,6 +349,13 @@ func start() {
 }
 
 func main() {
+	stopLevelWatcher := log.SetupLogger(
+		internal.UserLogOutput(internal.NorduserdLogFileName, internal.MaxUserLogSizeMB),
+		internal.LogLevelFile,
+		log.DefaultLevel(),
+	)
+	defer stopLevelWatcher()
+
 	if snapconf.IsUnderSnap() {
 		startSnap()
 	} else {

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -78,6 +78,8 @@ const (
 	Norduserd = "norduserd"
 
 	NorduserdLogFileName = "norduserd" + LogFileExtension
+	CLILogFileName       = "cli" + LogFileExtension
+	MaxUserLogSizeMB     = 100
 
 	// FileshareHistoryFile is the storage file used by libdrop
 	FileshareHistoryFileName = "fileshare_history.db"
@@ -189,10 +191,17 @@ func GetNorduserSocketFork(uid int) string {
 	return fmt.Sprintf("/tmp/%d-%s.sock", uid, Norduserd)
 }
 
-func getHomeDirPath(homeDirectory string) (string, error) {
+func getHomeDirPath() (string, error) {
+	var homeDirectory string
 	snapUserDataDir := os.Getenv("SNAP_USER_COMMON")
 	if snapUserDataDir != "" {
 		homeDirectory = snapUserDataDir
+	} else {
+		if dir, err := os.UserHomeDir(); err != nil {
+			return "", errors.New("cannot get user home dir")
+		} else {
+			homeDirectory = dir
+		}
 	}
 
 	_, err := os.Stat(homeDirectory)
@@ -204,8 +213,8 @@ func getHomeDirPath(homeDirectory string) (string, error) {
 }
 
 // GetConfigDirPath returns the directory used to store local user config
-func GetConfigDirPath(homeDirectory string) (string, error) {
-	homeDirectory, err := getHomeDirPath(homeDirectory)
+func GetConfigDirPath() (string, error) {
+	homeDirectory, err := getHomeDirPath()
 	if err != nil {
 		return "", err
 	}
@@ -219,8 +228,8 @@ func GetConfigDirPath(homeDirectory string) (string, error) {
 }
 
 // GetCacheDirPath returns the directory used to store local user logs
-func GetCacheDirPath(homeDirectory string) (string, error) {
-	homeDirectory, err := getHomeDirPath(homeDirectory)
+func GetCacheDirPath() (string, error) {
+	homeDirectory, err := getHomeDirPath()
 	if err != nil {
 		return "", err
 	}

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"golang.org/x/sys/unix"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 const (
@@ -620,33 +621,21 @@ func isProcessRunning(executablePath string, readdir readdirFunc, readfile readf
 
 // UserLogOutput opens logFileName in the user's cache directory and returns it.
 // Falls back to os.Stdout if the file cannot be opened.
-func UserLogOutput(logFileName string) *os.File {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return os.Stdout
-	}
-	cacheDirPath, err := GetCacheDirPath(homeDir)
+func UserLogOutput(logFileName string, maxSizeMb int) io.Writer {
+	cacheDirPath, err := GetCacheDirPath()
 	if err != nil {
 		return os.Stdout
 	}
 
-	root, err := os.OpenRoot(cacheDirPath)
-	if err != nil {
-		return os.Stdout
+	// Setup logging
+	logFile := filepath.Join(cacheDirPath, logFileName)
+	fileLogger := &lumberjack.Logger{
+		Filename:   logFile,
+		MaxSize:    maxSizeMb,
+		MaxBackups: 1,
+		MaxAge:     28,
+		Compress:   true,
 	}
-	defer func() {
-		if err := root.Close(); err != nil {
-			log.Errorf("failed to close root '%s': %v", cacheDirPath, err)
-		}
-	}()
 
-	logFile, err := root.OpenFile(
-		logFileName,
-		os.O_WRONLY|os.O_APPEND|os.O_CREATE,
-		PermUserRW,
-	)
-	if err != nil {
-		return os.Stdout
-	}
-	return logFile
+	return fileLogger
 }


### PR DESCRIPTION
* Use lumberjack for for norduserd and fileshare processes. Decreases the max log size for CLI to 100mb.
* Refactor `GetConfigDirPath` and `GetCacheDirPath` to automatically calculate the home folder and not get it as parameter.