### PR TITLE
LVPN-10547: Add validation of login response

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -243,7 +243,7 @@ func main() {
 	httpClientSimple.Transport = request.NewHTTPReTransport(
 		1, 1, "HTTP/1.1", func() http.RoundTripper {
 			return request.NewPublishingRoundTripper(
-				request.NewContextRoundTripper(request.NewStdTransport(), httpGlobalCtx),
+				request.NewContextRoundTripper(createSimpleH1Transport(Environment)(), httpGlobalCtx),
 				httpCallsSubject,
 			)
 		}, nil)
@@ -271,6 +271,7 @@ func main() {
 		httpCallsSubject,
 		daemonEvents.Service.Connect,
 		httpGlobalCtx,
+		Environment,
 	)
 
 	cdnAPI := core.NewCDNAPI(

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -568,7 +568,7 @@ func main() {
 		clientAPI,
 		cdnAPI,
 		repoAPI,
-		core.NewOAuth2(httpClientWithRotator, daemon.BaseURL),
+		core.NewOAuth2(httpClientWithRotator, daemon.BaseURL, validator),
 		Version,
 		daemonEvents,
 		vpnFactory,

--- a/cmd/daemon/transports.go
+++ b/cmd/daemon/transports.go
@@ -44,7 +44,11 @@ func SetBufferSizeForHTTP3() error {
 	return nil
 }
 
-func createH1Transport(resolver network.DNSResolver, fwmark uint32) func() http.RoundTripper {
+func createH1Transport(
+	resolver network.DNSResolver,
+	fwmark uint32,
+	environment string,
+) func() http.RoundTripper {
 	return func() http.RoundTripper {
 		var operr error
 		fwmark := func(fd uintptr) {
@@ -64,7 +68,8 @@ func createH1Transport(resolver network.DNSResolver, fwmark uint32) func() http.
 			},
 			Timeout: request.DefaultTimeout,
 		}
-		return &http.Transport{
+
+		transport := &http.Transport{
 			DialContext: func(ctx context.Context, netw, addr string) (net.Conn, error) {
 				domain, _, ok := strings.Cut(addr, ":")
 				if !ok {
@@ -89,6 +94,27 @@ func createH1Transport(resolver network.DNSResolver, fwmark uint32) func() http.
 			},
 			TLSHandshakeTimeout: request.TransportTimeout,
 		}
+
+		if internal.IsDevEnv(environment) {
+			transport.Proxy = http.ProxyFromEnvironment
+		}
+
+		return transport
+	}
+}
+
+func createSimpleH1Transport(environment string) func() http.RoundTripper {
+	return func() http.RoundTripper {
+		t := &http.Transport{
+			DialContext:         (&net.Dialer{Timeout: request.TransportTimeout}).DialContext,
+			TLSHandshakeTimeout: request.TransportTimeout,
+		}
+
+		if internal.IsDevEnv(environment) {
+			t.Proxy = http.ProxyFromEnvironment
+		}
+
+		return t
 	}
 }
 
@@ -144,6 +170,7 @@ func createTimedOutTransport(
 	httpCallsSubject events.Publisher[events.DataRequestAPI],
 	connectSubject events.PublishSubcriber[events.DataConnect],
 	ctx context.Context,
+	environment string,
 ) http.RoundTripper {
 	transportsStr := os.Getenv(envHTTPTransportsKey)
 	log.Println(internal.InfoPrefix, "http transports to use (environment):", transportsStr)
@@ -160,7 +187,7 @@ func createTimedOutTransport(
 			1,
 			1,
 			"HTTP/1.1",
-			createH1Transport(resolver, fwmark),
+			createH1Transport(resolver, fwmark, environment),
 			nil,
 		)
 		connectSubject.Subscribe(h1Transport.NotifyConnect)

--- a/cmd/daemon/transports_test.go
+++ b/cmd/daemon/transports_test.go
@@ -66,13 +66,13 @@ func TestTransports(t *testing.T) {
 		{
 			comment:     "test older transport small req/resp",
 			inputURL:    serverListSmallURL,
-			transport:   createH1Transport(workingResolver{}, 0)(),
+			transport:   createH1Transport(workingResolver{}, 0, "")(),
 			expectError: false,
 		},
 		{
 			comment:     "test older transport large resp",
 			inputURL:    serverListLargeURL,
-			transport:   createH1Transport(workingResolver{}, 0)(),
+			transport:   createH1Transport(workingResolver{}, 0, "")(),
 			expectError: false,
 		},
 		{
@@ -90,7 +90,7 @@ func TestTransports(t *testing.T) {
 		{
 			comment:     "test non quic/H3 url with H1 transport",
 			inputURL:    nonH3serverURL,
-			transport:   createH1Transport(workingResolver{}, 0)(),
+			transport:   createH1Transport(workingResolver{}, 0, "")(),
 			expectError: false,
 		},
 		{
@@ -125,7 +125,7 @@ func TestH1Transport_RoundTrip(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.ip, func(t *testing.T) {
-			transport := createH1Transport(workingResolver{IP: test.ip}, 0)()
+			transport := createH1Transport(workingResolver{IP: test.ip}, 0, "")()
 			req, err := http.NewRequest(http.MethodGet, serverListSmallURL, nil)
 			assert.NoError(t, err)
 			resp, err := transport.RoundTrip(req)

--- a/core/authentication.go
+++ b/core/authentication.go
@@ -5,10 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
 
+	"github.com/NordSecurity/nordvpn-linux/daemon/response"
 	"github.com/NordSecurity/nordvpn-linux/log"
 )
 
@@ -19,8 +21,9 @@ type Authentication interface {
 }
 
 type OAuth2 struct {
-	baseURL string
-	client  *http.Client
+	baseURL   string
+	client    *http.Client
+	validator response.Validator
 	// challenge is used to login
 	challenge string
 	// verifier is used to retrieve the token
@@ -30,10 +33,11 @@ type OAuth2 struct {
 	sync.Mutex
 }
 
-func NewOAuth2(client *http.Client, baseURL string) *OAuth2 {
+func NewOAuth2(client *http.Client, baseURL string, validator response.Validator) *OAuth2 {
 	return &OAuth2{
-		baseURL: baseURL,
-		client:  client,
+		baseURL:   baseURL,
+		client:    client,
+		validator: validator,
 	}
 }
 
@@ -66,32 +70,20 @@ func (o *OAuth2) Login(regularLogin bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := o.client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	err = ExtractError(resp)
+	body, err := o.doValidatedRequest(req, "validating login response")
 	if err != nil {
 		return "", err
 	}
 
-	body, err := MaxBytesReadAll(resp.Body)
+	var loginResp oAuth2LoginResponse
+	err = json.Unmarshal(body, &loginResp)
 	if err != nil {
 		return "", err
 	}
 
-	var response oAuth2LoginResponse
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		return "", err
-	}
-
-	o.attempt = response.Attempt
-	return response.URI, nil
+	o.attempt = loginResp.Attempt
+	return loginResp.URI, nil
 }
 
 // Token to be used for further API requests.
@@ -114,6 +106,22 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	body, err := o.doValidatedRequest(req, "validating token response")
+	if err != nil {
+		return nil, err
+	}
+
+	var tokenResp LoginResponse
+	err = json.Unmarshal(body, &tokenResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenResp, nil
+}
+
+func (o *OAuth2) doValidatedRequest(req *http.Request, errContext string) ([]byte, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := o.client.Do(req)
@@ -122,8 +130,7 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 	}
 	defer resp.Body.Close()
 
-	err = ExtractError(resp)
-	if err != nil {
+	if err := ExtractError(resp); err != nil {
 		return nil, err
 	}
 
@@ -132,13 +139,11 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 		return nil, err
 	}
 
-	var response LoginResponse
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		return nil, err
+	if err := o.validator.Validate(resp.StatusCode, resp.Header, body); err != nil {
+		return nil, fmt.Errorf("%s: %w", errContext, err)
 	}
 
-	return &response, nil
+	return body, nil
 }
 
 // newProofKeyPair implements PKCE code pair generation from RFC7636.

--- a/core/authentication_test.go
+++ b/core/authentication_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -8,9 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NordSecurity/nordvpn-linux/daemon/response"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOAuth2_Login(t *testing.T) {
@@ -85,13 +88,161 @@ func TestOAuth2_Login(t *testing.T) {
 			server := httptest.NewServer(test.handler)
 			defer server.Close()
 
-			api := NewOAuth2(http.DefaultClient, server.URL)
+			api := NewOAuth2(http.DefaultClient, server.URL, response.NoopValidator{})
 			url, err := api.Login(test.regularLogin)
 			assert.Equal(t, test.hasError, err != nil)
 			if test.hasError {
 				assert.True(t, strings.Contains(err.Error(), test.name))
 			}
 			assert.Equal(t, test.expectedURL, url)
+		})
+	}
+}
+
+func TestOAuth2_Login_Validation(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	loginFixture, err := os.ReadFile("testdata/login_200.json")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		validatorErr error
+		wantEmptyURI bool
+		wantCode     int
+		wantBody     []byte
+		wantHeaders  http.Header
+	}{
+		{
+			name:         "validator rejection blocks login",
+			validatorErr: errors.New("signature mismatch"),
+			wantEmptyURI: true,
+		},
+		{
+			name:     "validator receives correct status code",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "validator receives unmodified response body",
+			wantBody: loginFixture,
+		},
+		{
+			name:        "validator receives response headers",
+			wantHeaders: http.Header{"Content-Type": []string{"application/json"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				rw.Header().Set("Content-Type", "application/json")
+				rw.WriteHeader(http.StatusOK)
+				rw.Write(loginFixture)
+			}))
+			defer server.Close()
+
+			spy := &spyValidator{err: tt.validatorErr}
+			api := NewOAuth2(http.DefaultClient, server.URL, spy)
+
+			uri, err := api.Login(true)
+
+			if tt.validatorErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.validatorErr)
+				assert.NotZero(t, spy.calledWith.code)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.wantEmptyURI {
+				assert.Empty(t, uri)
+			}
+
+			if tt.wantCode != 0 {
+				assert.Equal(t, tt.wantCode, spy.calledWith.code)
+			}
+
+			if tt.wantBody != nil {
+				assert.JSONEq(t, string(tt.wantBody), string(spy.calledWith.body))
+			}
+
+			for key, vals := range tt.wantHeaders {
+				assert.Equal(t, vals, spy.calledWith.headers[key])
+			}
+		})
+	}
+}
+
+func TestOAuth2_Token_Validation(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tokenFixture, err := os.ReadFile("testdata/token_200.json")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		validatorErr error
+		wantNilResp  bool
+		wantCode     int
+		wantBody     []byte
+		wantHeaders  http.Header
+	}{
+		{
+			name:         "validator rejection blocks token exchange",
+			validatorErr: errors.New("signature mismatch"),
+			wantNilResp:  true,
+		},
+		{
+			name:     "validator receives correct status code",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "validator receives unmodified response body",
+			wantBody: tokenFixture,
+		},
+		{
+			name:        "validator receives response headers",
+			wantHeaders: http.Header{"Content-Type": []string{"application/json"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				rw.Header().Set("Content-Type", "application/json")
+				rw.WriteHeader(http.StatusOK)
+				rw.Write(tokenFixture)
+			}))
+			defer server.Close()
+
+			spy := &spyValidator{err: tt.validatorErr}
+			api := NewOAuth2(http.DefaultClient, server.URL, spy)
+
+			resp, err := api.Token("exchange")
+
+			if tt.validatorErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.validatorErr)
+				assert.NotZero(t, spy.calledWith.code)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.wantNilResp {
+				assert.Nil(t, resp)
+			}
+
+			if tt.wantCode != 0 {
+				assert.Equal(t, tt.wantCode, spy.calledWith.code)
+			}
+
+			if tt.wantBody != nil {
+				assert.JSONEq(t, string(tt.wantBody), string(spy.calledWith.body))
+			}
+
+			for key, vals := range tt.wantHeaders {
+				assert.Equal(t, vals, spy.calledWith.headers[key])
+			}
 		})
 	}
 }
@@ -152,7 +303,7 @@ func TestOAuth2_Token(t *testing.T) {
 			server := httptest.NewServer(test.handler)
 			defer server.Close()
 
-			api := NewOAuth2(http.DefaultClient, server.URL)
+			api := NewOAuth2(http.DefaultClient, server.URL, response.NoopValidator{})
 			resp, err := api.Token("exchange")
 			assert.Equal(t, test.hasError, err != nil)
 			if test.hasError {
@@ -163,4 +314,22 @@ func TestOAuth2_Token(t *testing.T) {
 			}
 		})
 	}
+}
+
+type spyValidator struct {
+	err        error
+	calledWith calledWith
+}
+
+type calledWith struct {
+	code    int
+	headers http.Header
+	body    []byte
+}
+
+func (v *spyValidator) Validate(code int, headers http.Header, body []byte) error {
+	v.calledWith.code = code
+	v.calledWith.headers = headers
+	v.calledWith.body = body
+	return v.err
 }


### PR DESCRIPTION
Changes:

- login response is validated before used (for both browser and token flows)
- in dev builds, allow to configure proxy