### PR TITLE
LVPN-10294: Integrate libtelio ENS feature

### DIFF
--- a/daemon/rpc_vpn_connection_error.go
+++ b/daemon/rpc_vpn_connection_error.go
@@ -8,6 +8,6 @@ import (
 // HandleVPNConnectionError is the placeholder (for now) listener for generic VPN connection
 // error events published on the internal VPN events bus
 func (r *RPC) HandleVPNConnectionError(e events.VPNConnectionErrorEvent) error {
-	log.Debug("received VPN connection error event, code:", e.Code)
+	log.Debug("received VPN connection error event, code:", e.Code.String())
 	return nil
 }

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -71,17 +71,21 @@ func eventCallbackWrap(callbackHandler *telioCallbackHandler) eventCb {
 
 type callbackHandler interface {
 	handleEvent(teliogo.Event) error
-	setMonitoringContext(ctx context.Context)
+	setConnectionMonitoringContext(ctx context.Context)
 }
 
 type telioCallbackHandler struct {
-	mu                sync.Mutex
-	statesChan        chan<- state
-	monitoringContext context.Context
+	mu                          sync.Mutex
+	statesChan                  chan<- state
+	connectionMonitoringContext context.Context
+	vpnErrorsChan               chan<- teliogo.VpnConnectionError
 }
 
-func newTelioCallbackHandler(statesChan chan<- state) *telioCallbackHandler {
-	return &telioCallbackHandler{statesChan: statesChan}
+func newTelioCallbackHandler(
+	statesChan chan<- state,
+	vpnErrorsChan chan<- teliogo.VpnConnectionError,
+) *telioCallbackHandler {
+	return &telioCallbackHandler{statesChan: statesChan, vpnErrorsChan: vpnErrorsChan}
 }
 
 func (t *telioCallbackHandler) handleEvent(e teliogo.Event) error {
@@ -92,6 +96,13 @@ func (t *telioCallbackHandler) handleEvent(e teliogo.Event) error {
 		log.Printf(internal.InfoPrefix+" received event %T: %s\n", e, maskPublicKey(string(eventBytes)))
 	}
 
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	ctx := t.connectionMonitoringContext
+	if ctx == nil {
+		return nil
+	}
+
 	var st state
 	switch evt := e.(type) {
 	case teliogo.EventNode:
@@ -100,34 +111,39 @@ func (t *telioCallbackHandler) handleEvent(e teliogo.Event) error {
 			PublicKey: evt.Body.PublicKey,
 			IsExit:    evt.Body.IsExit,
 		}
-	default:
-		// ignore
-		return nil
-	}
 
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.monitoringContext != nil {
 		select {
 		case t.statesChan <- st:
-		case <-t.monitoringContext.Done(): // drop if nobody is listening
-			if t.monitoringContext.Err() != nil {
-				log.Println(internal.ErrorPrefix, "canceling event monitoring:", t.monitoringContext.Err())
+		case <-ctx.Done(): // drop if nobody is listening
+			if ctx.Err() != nil {
+				log.Debug("canceling connection state monitoring:", ctx.Err())
 			}
-			t.monitoringContext = nil
+			t.connectionMonitoringContext = nil
+			return nil
 		case <-time.After(1 * time.Second):
 			log.Println(internal.ErrorPrefix, "telio event was dropped because of timeout:", st)
 		}
+
+		if evt.Body.VpnConnectionError != nil {
+			select {
+			case t.vpnErrorsChan <- *evt.Body.VpnConnectionError:
+			default:
+				log.Debug("dropping ENS connection error, monitor busy:", *evt.Body.VpnConnectionError)
+			}
+		}
+
+	default:
+		// ignore
 	}
 
 	return nil
 }
 
-func (t *telioCallbackHandler) setMonitoringContext(ctx context.Context) {
+func (t *telioCallbackHandler) setConnectionMonitoringContext(ctx context.Context) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.monitoringContext = ctx
+	t.connectionMonitoringContext = ctx
 }
 
 func eventsBuffer(recvChan <-chan state, sendChan chan<- state, ctx context.Context) {
@@ -195,12 +211,13 @@ func eventsBuffer(recvChan <-chan state, sendChan chan<- state, ctx context.Cont
 // 7. VPN connected, calling Disable - tunnel must be re-initiated with the originally saved values provided to Start
 // 8. VPN disconnected, calling Disable - tunnel must be destroyed
 type Libtelio struct {
-	state                   vpn.State
-	lib                     lib
-	events                  <-chan state
-	cancelConnectionMonitor func()
-	active                  bool
-	tun                     tunnel.T
+	state                      vpn.State
+	lib                        lib
+	stateEvents                <-chan state
+	vpnErrorEvents             <-chan teliogo.VpnConnectionError
+	cancelConnectionMonitoring func()
+	active                     bool
+	tun                        tunnel.T
 	// This must be the one given from the public interface and
 	// retrieved from the API
 	currentServer     vpn.ServerData
@@ -212,6 +229,18 @@ type Libtelio struct {
 	eventsPublisher   *vpn.Events
 	callbackHandler   callbackHandler
 	mu                sync.Mutex
+}
+
+func defaultErrorNotificationService() *teliogo.FeatureErrorNotificationService {
+	return &teliogo.FeatureErrorNotificationService{
+		BufferSize:  5,
+		AllowOnlyPq: false,
+		Backoff: teliogo.Backoff{
+			InitialS: 2,
+			MaximalS: nil,
+		},
+		RootCertificateOverride: nil,
+	}
 }
 
 // defaultPrefix is the default address used by NordLynx when meshnet is not enabled
@@ -233,6 +262,10 @@ func handleTelioConfig(eventPath string, prod bool, vpnLibCfg vpn.LibConfigGette
 		telioConfig.Nurse = nil
 	}
 
+	if telioConfig.ErrorNotificationService == nil {
+		telioConfig.ErrorNotificationService = defaultErrorNotificationService()
+	}
+
 	return &telioConfig, nil
 }
 
@@ -251,7 +284,8 @@ func New(
 	appVersion string,
 	eventsPublisher *vpn.Events,
 ) (*Libtelio, error) {
-	events := make(chan state)
+	stateEvents := make(chan state)
+	errorEvents := make(chan teliogo.VpnConnectionError, 1)
 	features, err := handleTelioConfig(eventPath, prod, vpnLibCfg)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "failed to get telio config:", err)
@@ -263,6 +297,7 @@ func New(
 			EnableBatterySavingDefaults().
 			EnableFlushEventsOnStopTimeoutSeconds().
 			EnableNicknames().
+			EnableErrorNotificationService().
 			Build()
 
 		defaultTelioConfig.Nurse.HeartbeatInterval = defaultHeartbeatInterval
@@ -280,7 +315,7 @@ func New(
 
 	var loggerCb teliogo.TelioLoggerCb = &telioLoggerCb{}
 	teliogo.SetGlobalLogger(teliogo.TelioLogLevelInfo, loggerCb)
-	telioCallbackHandler := newTelioCallbackHandler(events)
+	telioCallbackHandler := newTelioCallbackHandler(stateEvents, errorEvents)
 	lib, err := teliogo.NewTelio(*features, eventCallbackWrap(telioCallbackHandler))
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "failed to create telio instance:", err)
@@ -289,8 +324,9 @@ func New(
 
 	return &Libtelio{
 		lib:             lib,
-		events:          events,
+		stateEvents:     stateEvents,
 		state:           vpn.ExitedState,
+		vpnErrorEvents:  errorEvents,
 		fwmark:          fwmark,
 		eventsPublisher: eventsPublisher,
 		callbackHandler: telioCallbackHandler,
@@ -351,17 +387,20 @@ func (l *Libtelio) connect(
 	postQuantum bool,
 ) error {
 	ctx, cancel := context.WithCancel(context.Background())
-	l.cancelConnectionMonitor = cancel
-	l.callbackHandler.setMonitoringContext(ctx)
+	l.cancelConnectionMonitoring = cancel
+	l.callbackHandler.setConnectionMonitoringContext(ctx)
 
 	bufferedEventsChan := make(chan state)
-	go eventsBuffer(l.events, bufferedEventsChan, ctx)
+	go eventsBuffer(l.stateEvents, bufferedEventsChan, ctx)
 
 	// Start monitoring connection events before connecting to not miss any
 	isConnectedC := isConnected(ctx,
 		bufferedEventsChan,
 		connParameters{pubKey: serverPublicKey, server: l.currentServer},
 		l.eventsPublisher)
+
+	// Start monitoring ENS connection errors before connecting so no early error is missed.
+	startConnectionErrorMonitor(ctx, l.vpnErrorEvents, l.eventsPublisher)
 
 	var err error
 	endpoint := net.JoinHostPort(serverIP.String(), "51820")
@@ -431,8 +470,8 @@ func (l *Libtelio) Stop() error {
 
 // disconnect from all the exit nodes, including VPN server
 func (l *Libtelio) disconnect() error {
-	if l.cancelConnectionMonitor != nil {
-		l.cancelConnectionMonitor()
+	if l.cancelConnectionMonitoring != nil {
+		l.cancelConnectionMonitoring()
 	}
 
 	if err := l.lib.DisconnectFromExitNodes(); err != nil {
@@ -772,7 +811,7 @@ func isConnected(ctx context.Context,
 	connectedCh := make(chan interface{})
 	go func() {
 		wg.Done() // signal that goroutine has started
-		monitorConnection(ctx, stateCh, connectedCh, connParams, eventsPublisher)
+		monitorConnectionState(ctx, stateCh, connectedCh, connParams, eventsPublisher)
 	}()
 
 	wg.Wait() // wait until goroutine is started
@@ -785,10 +824,10 @@ type connParameters struct {
 	server vpn.ServerData
 }
 
-// monitorConnection awaits for incoming state changes from the states chan and publishes appropriate events. Upon
+// monitorConnectionState awaits for incoming state changes from the states chan and publishes appropriate events. Upon
 // detecting the 'connected' state for the first time it will send true via isConnected channel and close it afterwards.
 // If goroutine is canceled before detecting 'connected', false will be sent via isConnected channel.
-func monitorConnection(
+func monitorConnectionState(
 	ctx context.Context,
 	states <-chan state,
 	isConnected chan<- interface{},
@@ -843,5 +882,60 @@ func monitorConnection(
 			}
 			return
 		}
+	}
+}
+
+// startConnectionErrorMonitor starts connection error monitoring in a goroutine and returns only
+// once it is running
+func startConnectionErrorMonitor(
+	ctx context.Context,
+	errorsChan <-chan teliogo.VpnConnectionError,
+	eventsPublisher *vpn.Events,
+) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		wg.Done()
+		monitorConnectionErrors(ctx, errorsChan, eventsPublisher)
+	}()
+
+	wg.Wait()
+}
+
+// monitorConnectionErrors awaits ENS connection errors extracted from telio node events,
+// maps them to the protocol-agnostic events and publishes them on the internal VPN event bus.
+func monitorConnectionErrors(
+	ctx context.Context,
+	errorsChan <-chan teliogo.VpnConnectionError,
+	eventsPublisher *vpn.Events,
+) {
+	for {
+		select {
+		case connErr := <-errorsChan:
+			eventsPublisher.ConnectionError.Publish(events.VPNConnectionErrorEvent{
+				Code: toVPNConnectionError(connErr),
+			})
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// toVPNConnectionError maps a libtelio ENS error to the protocol-agnostic events enum.
+func toVPNConnectionError(connErr teliogo.VpnConnectionError) events.VPNConnectionError {
+	switch connErr {
+	case teliogo.VpnConnectionErrorUnknown:
+		return events.VPNConnectionErrorUnknown
+	case teliogo.VpnConnectionErrorConnectionLimitReached:
+		return events.VPNConnectionErrorConnectionLimitReached
+	case teliogo.VpnConnectionErrorServerMaintenance:
+		return events.VPNConnectionErrorServerMaintenance
+	case teliogo.VpnConnectionErrorUnauthenticated:
+		return events.VPNConnectionErrorUnauthenticated
+	case teliogo.VpnConnectionErrorSuperseded:
+		return events.VPNConnectionErrorSuperseded
+	default:
+		return events.VPNConnectionErrorUnknown
 	}
 }

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -936,6 +936,7 @@ func toVPNConnectionError(connErr teliogo.VpnConnectionError) events.VPNConnecti
 	case teliogo.VpnConnectionErrorSuperseded:
 		return events.VPNConnectionErrorSuperseded
 	default:
+		log.Debug("unhandled telio VPN connection error, mapping to unknown:", connErr)
 		return events.VPNConnectionErrorUnknown
 	}
 }

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -33,8 +33,8 @@ const (
 
 type callbackHandlerStub struct{}
 
-func (callbackHandlerStub) handleEvent(teliogo.Event) error          { return nil }
-func (callbackHandlerStub) setMonitoringContext(ctx context.Context) {}
+func (callbackHandlerStub) handleEvent(teliogo.Event) error                    { return nil }
+func (callbackHandlerStub) setConnectionMonitoringContext(ctx context.Context) {}
 
 type mockLib struct{}
 
@@ -129,7 +129,8 @@ func TestIsConnected(t *testing.T) {
 
 func TestEventCallback_DoesntBlock(t *testing.T) {
 	stateC := make(chan state)
-	callbackHandler := newTelioCallbackHandler(stateC)
+	vpnErrorsC := make(chan teliogo.VpnConnectionError)
+	callbackHandler := newTelioCallbackHandler(stateC, vpnErrorsC)
 	cb := eventCallbackWrap(callbackHandler)
 	var event teliogo.Event
 
@@ -170,6 +171,7 @@ func Test_TelioConfig(t *testing.T) {
 	category.Set(t, category.Integration)
 
 	expectedCfg := toTelioFeatures(t, telioRemoteTestConfig)
+	expectedCfg.ErrorNotificationService = defaultErrorNotificationService()
 
 	remoteConfigGetter := mockVersionGetter{telioRemoteTestConfig}
 
@@ -493,7 +495,7 @@ func TestLibtelio_connect(t *testing.T) {
 			// Create instance
 			libtelio := &Libtelio{
 				lib:             mockLib{},
-				events:          events,
+				stateEvents:     events,
 				state:           vpn.ExitedState,
 				fwmark:          123,
 				eventsPublisher: pub,
@@ -546,7 +548,8 @@ func Test_EventCallback(t *testing.T) {
 	category.Set(t, category.Unit)
 
 	stateChan := make(chan state)
-	callbackHandler := newTelioCallbackHandler(stateChan)
+	vpnErrorsChan := make(chan teliogo.VpnConnectionError)
+	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
 
 	var wg sync.WaitGroup
 	callbackHandlerEventNonBlocking := func() {
@@ -567,7 +570,7 @@ func Test_EventCallback(t *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	// add a context, callbackHandled should start sending events via stateChan
-	callbackHandler.setMonitoringContext(ctx)
+	callbackHandler.setConnectionMonitoringContext(ctx)
 
 	wg.Add(1)
 	go func() {
@@ -593,5 +596,186 @@ func Test_EventCallback(t *testing.T) {
 	case <-stateChan:
 		assert.Fail(t, "Event sent when no context was provided.")
 	default:
+	}
+}
+
+func TestToVPNConnectionError_MapsAllCodes(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name     string
+		input    teliogo.VpnConnectionError
+		expected events.VPNConnectionError
+	}{
+		{
+			name:     "unknown",
+			input:    teliogo.VpnConnectionErrorUnknown,
+			expected: events.VPNConnectionErrorUnknown,
+		},
+		{
+			name:     "connection limit reached",
+			input:    teliogo.VpnConnectionErrorConnectionLimitReached,
+			expected: events.VPNConnectionErrorConnectionLimitReached,
+		},
+		{
+			name:     "server maintenance",
+			input:    teliogo.VpnConnectionErrorServerMaintenance,
+			expected: events.VPNConnectionErrorServerMaintenance,
+		},
+		{
+			name:     "unauthenticated",
+			input:    teliogo.VpnConnectionErrorUnauthenticated,
+			expected: events.VPNConnectionErrorUnauthenticated,
+		},
+		{
+			name:     "superseded",
+			input:    teliogo.VpnConnectionErrorSuperseded,
+			expected: events.VPNConnectionErrorSuperseded,
+		},
+		{
+			name:     "unmapped value falls back to unknown",
+			input:    teliogo.VpnConnectionError(99),
+			expected: events.VPNConnectionErrorUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, toVPNConnectionError(tt.input))
+		})
+	}
+}
+
+func TestHandleEvent_ForwardsVPNConnectionError(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	stateChan := make(chan state, 1)
+	vpnErrorsChan := make(chan teliogo.VpnConnectionError, 1)
+	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	callbackHandler.setConnectionMonitoringContext(ctx)
+
+	connErr := teliogo.VpnConnectionErrorServerMaintenance
+	callbackHandler.handleEvent(teliogo.EventNode{
+		Body: teliogo.TelioNode{
+			State:              teliogo.NodeStateConnected,
+			IsExit:             true,
+			VpnConnectionError: &connErr,
+		},
+	})
+
+	select {
+	case <-stateChan:
+	default:
+		assert.Fail(t, "node state was not forwarded")
+	}
+
+	select {
+	case got := <-vpnErrorsChan:
+		assert.Equal(t, connErr, got)
+	default:
+		assert.Fail(t, "VPN connection error was not forwarded")
+	}
+}
+
+func TestHandleEvent_NoVPNConnectionError_DoesNotForwardError(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	stateChan := make(chan state, 1)
+	vpnErrorsChan := make(chan teliogo.VpnConnectionError, 1)
+	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	callbackHandler.setConnectionMonitoringContext(ctx)
+
+	callbackHandler.handleEvent(teliogo.EventNode{
+		Body: teliogo.TelioNode{
+			State:  teliogo.NodeStateConnected,
+			IsExit: true,
+		},
+	})
+
+	select {
+	case <-stateChan:
+	default:
+		assert.Fail(t, "node state was not forwarded")
+	}
+
+	select {
+	case <-vpnErrorsChan:
+		assert.Fail(t, "no error should be forwarded for a healthy node event")
+	default:
+	}
+}
+
+func TestHandleEvent_DropsVPNConnectionError_WhenMonitorBusy(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	stateChan := make(chan state, 1)
+	vpnErrorsChan := make(chan teliogo.VpnConnectionError, 1)
+	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	callbackHandler.setConnectionMonitoringContext(ctx)
+
+	buffered := teliogo.VpnConnectionErrorUnauthenticated
+	vpnErrorsChan <- buffered
+
+	dropped := teliogo.VpnConnectionErrorServerMaintenance
+	callbackHandler.handleEvent(teliogo.EventNode{
+		Body: teliogo.TelioNode{
+			State:              teliogo.NodeStateConnected,
+			IsExit:             true,
+			VpnConnectionError: &dropped,
+		},
+	})
+
+	select {
+	case <-stateChan:
+	default:
+		assert.Fail(t, "node state was not forwarded")
+	}
+
+	select {
+	case got := <-vpnErrorsChan:
+		assert.Equal(t, buffered, got)
+	default:
+		assert.Fail(t, "the already-buffered error should have been kept")
+	}
+
+	select {
+	case <-vpnErrorsChan:
+		assert.Fail(t, "the second error should have been dropped, not buffered")
+	default:
+	}
+}
+
+func TestMonitorConnectionErrors_PublishesMappedEvent(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	pub := vpn.NewInternalVPNEvents()
+	received := make(chan events.VPNConnectionErrorEvent, 1)
+	pub.ConnectionError.Subscribe(func(e events.VPNConnectionErrorEvent) error {
+		received <- e
+		return nil
+	})
+
+	errorsChan := make(chan teliogo.VpnConnectionError, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go monitorConnectionErrors(ctx, errorsChan, pub)
+
+	errorsChan <- teliogo.VpnConnectionErrorSuperseded
+
+	select {
+	case got := <-received:
+		assert.Equal(t, events.VPNConnectionErrorSuperseded, got.Code)
+	case <-time.After(time.Second):
+		assert.Fail(t, "ConnectionError event was not published")
 	}
 }

--- a/events/events.go
+++ b/events/events.go
@@ -77,6 +77,23 @@ const (
 	VPNConnectionErrorSuperseded
 )
 
+func (e VPNConnectionError) String() string {
+	switch e {
+	case VPNConnectionErrorUnknown:
+		return "unknown error"
+	case VPNConnectionErrorConnectionLimitReached:
+		return "connection limit reached"
+	case VPNConnectionErrorServerMaintenance:
+		return "server maintenance"
+	case VPNConnectionErrorUnauthenticated:
+		return "unauthenticated"
+	case VPNConnectionErrorSuperseded:
+		return "superseded by newer connection"
+	default:
+		return "unrecognized error code"
+	}
+}
+
 // VPNConnectionErrorEvent is sent on the internal VPN event bus when a VPN connection error happens.
 type VPNConnectionErrorEvent struct {
 	Code VPNConnectionError


### PR DESCRIPTION
Added support for libtelio's Error Notification Service (ENS) in the daemon. VPN connection errors reported by libtelio node events are now extracted, mapped to protocol-agnostic VPN error codes, and published on the internal VPN event bus.