### PR TITLE
LVPN-10676: force device key registration when device is not recognized

### DIFF
--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -318,14 +318,13 @@ func (r *RPC) connect(
 			log.Println(internal.ErrorPrefix, "failed to fetch the device key for dedicated server connection")
 			return false, internal.ErrUnhandled
 		}
-		creds.NordLynxPrivateKey = dedicatedServersDeviceData.DevicePrivateKey
 
 		dedicatedServerConnectionData, err := getDedicatedServerConnectionData(
 			r.dedicatedServersAPI,
 			serverSelection.server.DedicatedServerUUID,
 			*dedicatedServersDeviceData)
 		if errors.Is(err, core.ErrDedicatedServersDeviceNotFound) {
-			dedicatedServersDeviceData := r.dedicatedServerKeyManager.ForceRegisterDedicatedServers()
+			dedicatedServersDeviceData = r.dedicatedServerKeyManager.ForceRegisterDedicatedServers()
 			if dedicatedServersDeviceData == nil {
 				log.Println(internal.ErrorPrefix, "failed to force dedicated server device registration")
 				return true, srv.Send(&pb.Payload{Type: internal.CodeDedicatedServersCanNotConnect})
@@ -351,6 +350,8 @@ func (r *RPC) connect(
 			}
 			return false, internal.ErrUnhandled
 		}
+
+		creds.NordLynxPrivateKey = dedicatedServersDeviceData.DevicePrivateKey
 		serverSelection.server.Station = dedicatedServerConnectionData.ip
 		serverSelection.server.DedicatedServersPort = dedicatedServerConnectionData.port
 		serverSelection.server.NordLynxPublicKey = dedicatedServerConnectionData.publicKey

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -324,6 +324,18 @@ func (r *RPC) connect(
 			r.dedicatedServersAPI,
 			serverSelection.server.DedicatedServerUUID,
 			*dedicatedServersDeviceData)
+		if errors.Is(err, core.ErrDedicatedServersDeviceNotFound) {
+			dedicatedServersDeviceData := r.dedicatedServerKeyManager.ForceRegisterDedicatedServers()
+			if dedicatedServersDeviceData == nil {
+				log.Println(internal.ErrorPrefix, "failed to force dedicated server device registration")
+				return true, srv.Send(&pb.Payload{Type: internal.CodeDedicatedServersCanNotConnect})
+			}
+			dedicatedServerConnectionData, err = getDedicatedServerConnectionData(
+				r.dedicatedServersAPI,
+				serverSelection.server.DedicatedServerUUID,
+				*dedicatedServersDeviceData)
+		}
+
 		if err != nil {
 			log.Println(internal.ErrorPrefix, "fetching dedicated server connection data:", err)
 			switch {

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -1396,6 +1396,10 @@ func TestDedicatedServers_ForceRegistration(t *testing.T) {
 		core.ErrDedicatedServersDeviceNotFound)
 	assert.Equal(t, newDeviceKey, dedicatedServersAPIMock.ConnectRequest.DevicePublicKey,
 		"Key sent in a connect request should be equal to newly registered key.")
+
+	networkerMock := rpc.netw.(*testnetworker.Mock)
+	assert.Equal(t, newDevicePrivateKey, networkerMock.ProvidedCredentials.NordLynxPrivateKey,
+		"Key used to connect to the VPN server should be equal to newly registered key.")
 }
 
 func Test_serverGroupIDs_ExtractsAllIDs(t *testing.T) {

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -1278,7 +1278,7 @@ func TestDedicatedServers_Internals(t *testing.T) {
 	category.Set(t, category.Unit)
 
 	serverUUID := uuid.MustParse("af0bc2b1-785a-4455-bfe0-5397c39c4f4e")
-	serverAddress := "1.2.3.4"
+	serverAddress := "100.34.50.2"
 	serverPort := int64(55555)
 	dedicatedServer := core.DedicatedServer{
 		UUID:   serverUUID.String(),
@@ -1324,6 +1324,78 @@ func TestDedicatedServers_Internals(t *testing.T) {
 	assert.Equal(t, devicePrivateKey, networkerMock.ProvidedCredentials.NordLynxPrivateKey,
 		"DeviceKey should be used in place of NordlynxPrivateKey in case of dedicated server connections.")
 	assert.Equal(t, serverPort, networkerMock.ProvidedServerData.DedicatedServerPort)
+}
+
+func TestDedicatedServers_ForceRegistration(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	serverUUID := uuid.MustParse("af0bc2b1-785a-4455-bfe0-5397c39c4f4e")
+	serverAddress := "44.44.44.44"
+	serverPort := int64(55555)
+	dedicatedServer := core.DedicatedServer{
+		UUID:   serverUUID.String(),
+		Name:   "server 1",
+		Status: core.DedicatedServerStatusRunning,
+		IP:     serverAddress,
+	}
+	dedicatedServers := core.DedicatedServers{dedicatedServer}
+
+	serverPublicKey := "server_public_key"
+	rpc := testRPCLocal(t)
+
+	connectResponse := core.DedicatedServerConnectResponse{
+		ServerEndpoint:  serverAddress + ":" + strconv.Itoa(int(serverPort)),
+		ServerPublicKey: serverPublicKey,
+	}
+
+	connectErr := core.ErrDedicatedServersDeviceNotFound
+	getConnectErrFunc := func() error {
+		err := connectErr
+		// set to nil so that no error will be returned for the next call
+		connectErr = nil
+		return err
+	}
+
+	dedicatedServersAPIMock := testcore.DedicatedServersAPIMock{
+		DedicatedServersResponse: dedicatedServers,
+		ConnectResponse:          connectResponse,
+		GetConnectErrFunc:        getConnectErrFunc,
+	}
+	rpc.dedicatedServersAPI = &dedicatedServersAPIMock
+
+	rpc.ac = &workingLoginChecker{
+		isDedicatedServersExpired: false,
+	}
+
+	staleDeviceKey := "stale device key"
+	staleDevicePrivateKey := "stale device private key"
+
+	newDeviceKey := "new device key"
+	newDevicePrivateKey := "new device private key"
+
+	deviceKeyManagerMock := testdevicekey.MockDeviceKeyManager{
+		DedicatedServerRegistrationData: &devicekey.DedicatedServersConnectionData{
+			DevicePublicKey:  staleDeviceKey,
+			DevicePrivateKey: staleDevicePrivateKey,
+		},
+		DedicatedServerForcedRegistrationData: &devicekey.DedicatedServersConnectionData{
+			DevicePublicKey:  newDeviceKey,
+			DevicePrivateKey: newDevicePrivateKey,
+		},
+	}
+	rpc.dedicatedServerKeyManager = &deviceKeyManagerMock
+
+	configManagerMock := rpc.cm.(*mockConfigManager)
+	configManagerMock.c.Technology = config.Technology_NORDLYNX
+
+	mockRPCServer := &mockRPCServer{}
+	err := rpc.Connect(&pb.ConnectRequest{ServerTag: "dedicated_server"}, mockRPCServer)
+	assert.Nil(t, err, "Unexpected error returned by Connect.")
+
+	assert.True(t, deviceKeyManagerMock.WasKeyForceRegistered, "Key should be forcibly registered when API returns %w",
+		core.ErrDedicatedServersDeviceNotFound)
+	assert.Equal(t, newDeviceKey, dedicatedServersAPIMock.ConnectRequest.DevicePublicKey,
+		"Key sent in a connect request should be equal to newly registered key.")
 }
 
 func Test_serverGroupIDs_ExtractsAllIDs(t *testing.T) {

--- a/device_key/device_key_manager.go
+++ b/device_key/device_key_manager.go
@@ -54,6 +54,7 @@ type DedicatedServersKeyManager interface {
 	// isn't.
 	// Returns the connection data if it is available. Returns nil if data is not available.
 	CheckAndRegisterDedicatedServers() *DedicatedServersConnectionData
+	ForceRegisterDedicatedServers() *DedicatedServersConnectionData
 	DeviceKeyInvalidator
 }
 
@@ -188,29 +189,24 @@ type registerFunc func(deviceKey string,
 	isKeyNew bool,
 	cfg *config.Config) (*config.Config, error)
 
-// CheckAndRegisterDedicatedServers checks if device key is registered for the dedicated servers and registers it if not.
-// Returns true if the key was successfully registered.
-//
-// Thread-safe.
-func (d *DeviceKeyManagerImpl) CheckAndRegisterDedicatedServers() *DedicatedServersConnectionData {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
+func (d *DeviceKeyManagerImpl) registerDedicatedServer(force bool) *DedicatedServersConnectionData {
 	var cfg config.Config
 	if err := d.configManager.Load(&cfg); err != nil {
 		log.Println(internal.ErrorPrefix, err)
 		return nil
 	}
 
-	if isDedicatedServersRegistrationInfoCorrect(cfg) {
-		return &DedicatedServersConnectionData{
-			DeviceUUID:       cfg.DeviceUUID,
-			DevicePublicKey:  d.keyGenerator.Public(cfg.DeviceKey),
-			DevicePrivateKey: cfg.DeviceKey,
+	if !force {
+		if isDedicatedServersRegistrationInfoCorrect(cfg) {
+			return &DedicatedServersConnectionData{
+				DeviceUUID:       cfg.DeviceUUID,
+				DevicePublicKey:  d.keyGenerator.Public(cfg.DeviceKey),
+				DevicePrivateKey: cfg.DeviceKey,
+			}
 		}
 	}
 
-	newConfig, err := d.registerKey(&cfg, d.registerDedicatedServer)
+	newConfig, err := d.registerKey(&cfg, d.registerDedicatedServerKey)
 	if err != nil {
 		log.Println(internal.ErrorPrefix, "failed to register device key for dedicated servers:", err)
 		return nil
@@ -230,6 +226,28 @@ func (d *DeviceKeyManagerImpl) CheckAndRegisterDedicatedServers() *DedicatedServ
 		DevicePublicKey:  d.keyGenerator.Public(newConfig.DeviceKey),
 		DevicePrivateKey: newConfig.DeviceKey,
 	}
+}
+
+// CheckAndRegisterDedicatedServers checks if device key is registered for the dedicated servers and registers it if not.
+// Returns nil if key was not successfully registered.
+//
+// Thread-safe.
+func (d *DeviceKeyManagerImpl) CheckAndRegisterDedicatedServers() *DedicatedServersConnectionData {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.registerDedicatedServer(false)
+}
+
+// ForceRegisterDedicatedServers registers device key for dedicated servers ignoring existing registration data.
+// Returns nil if key was not successfully registered.
+//
+// Thread-safe.
+func (d *DeviceKeyManagerImpl) ForceRegisterDedicatedServers() *DedicatedServersConnectionData {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.registerDedicatedServer(true)
 }
 
 func (d *DeviceKeyManagerImpl) InvalidateDeviceKeyData() error {
@@ -314,7 +332,7 @@ func (d *DeviceKeyManagerImpl) registerMeshnet(deviceKey string,
 	return cfg, nil
 }
 
-func (d *DeviceKeyManagerImpl) registerDedicatedServer(deviceKey string,
+func (d *DeviceKeyManagerImpl) registerDedicatedServerKey(deviceKey string,
 	distroName string,
 	_ bool,
 	cfg *config.Config) (*config.Config, error) {

--- a/test/mock/core/dedicated_servers.go
+++ b/test/mock/core/dedicated_servers.go
@@ -16,6 +16,9 @@ type DedicatedServersAPIMock struct {
 
 	DedicatedServerErr error
 	ConnectErr         error
+	// GetConnectErrFunc is called when it is not nil. The returned error will be returned by
+	// DedicatedServerConnectCheck. Used to test handling of device not existing error fallbacks.
+	GetConnectErrFunc func() error
 }
 
 func (*DedicatedServersAPIMock) RegisterDevice(core.DevicesRequest) (core.DevicesResponse, error) {
@@ -33,5 +36,13 @@ func (d *DedicatedServersAPIMock) DedicatedServers() (core.DedicatedServers, err
 func (d *DedicatedServersAPIMock) DedicatedServerConnectCheck(serverUUID string, connectRequest core.DedicatedServerConnectRequest) (core.DedicatedServerConnectResponse, error) {
 	d.ConnectRequest = connectRequest
 	d.ConnectServerUUID = serverUUID
-	return d.ConnectResponse, d.ConnectErr
+
+	var connectErr error
+	if d.ConnectErr != nil {
+		connectErr = d.ConnectErr
+	} else if d.GetConnectErrFunc != nil {
+		connectErr = d.GetConnectErrFunc()
+	}
+
+	return d.ConnectResponse, connectErr
 }

--- a/test/mock/devicekey/device_key_manager.go
+++ b/test/mock/devicekey/device_key_manager.go
@@ -3,9 +3,11 @@ package devicekey
 import devicekey "github.com/NordSecurity/nordvpn-linux/device_key"
 
 type MockDeviceKeyManager struct {
-	DedicatedServerRegistrationData *devicekey.DedicatedServersConnectionData
+	DedicatedServerRegistrationData       *devicekey.DedicatedServersConnectionData
+	DedicatedServerForcedRegistrationData *devicekey.DedicatedServersConnectionData
 
 	WasKeyRegistered        bool
+	WasKeyForceRegistered   bool
 	WasDeviceKeyInvalidated bool
 }
 
@@ -15,6 +17,14 @@ func (m *MockDeviceKeyManager) CheckAndRegisterDedicatedServers() *devicekey.Ded
 	}
 	m.WasKeyRegistered = true
 	return m.DedicatedServerRegistrationData
+}
+
+func (m *MockDeviceKeyManager) ForceRegisterDedicatedServers() *devicekey.DedicatedServersConnectionData {
+	if m.DedicatedServerForcedRegistrationData == nil {
+		return nil
+	}
+	m.WasKeyForceRegistered = true
+	return m.DedicatedServerForcedRegistrationData
 }
 
 func (m *MockDeviceKeyManager) InvalidateDeviceKeyData() error {


### PR DESCRIPTION
When device is deleted from dedicated servers web interface, the registration data(primarily device UUID) stored on the device becomes invalidated. In such cases, calls to /v1/dedicated-servers/<server-uuid>/connect return error 910001(device not found).

This PR adds forced key re-registration so that user doesn't have to manually set settings to default to be able to connect.