### PR TITLE
Fix notification upon DS in new state, or with PQ enabled

### DIFF
--- a/internal/codes.go
+++ b/internal/codes.go
@@ -83,7 +83,7 @@ const (
 	CodeDedicatedServersNoNordlynx             int64 = 3068
 	CodeDedicatedServersCanNotConnect          int64 = 3069
 	CodeDedicatedServersSessionMaxLimitReached int64 = 3070
-	CodeDedicatedServersPq                     int64 = 71
+	CodeDedicatedServersPq                     int64 = 3071
 	CodeDedicatedServersServerNotSetUp         int64 = 3072
 )
 

--- a/tray/actions.go
+++ b/tray/actions.go
@@ -210,6 +210,8 @@ func (ti *Instance) connectWithUIEvent(
 			ti.notifyServiceExpired(client.DedicatedServersUpselURL, client.DedicatedServersUpselURLLogin, cli.DedicatedServersNoServiceMessage)
 		case internal.CodeDedicatedServersServiceButNoServers:
 			ti.notifyServiceExpired(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin, cli.DedicatedServersNoServersAvailable)
+		case internal.CodeDedicatedServersServerNotSetUp:
+			ti.notifyServiceExpired(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin, cli.DedicatedServersNoServersAvailable)
 		case internal.CodeDedicatedServersNotReady:
 			ti.notify(Force, cli.DedicatedServersServerNotReadyMessage)
 		case internal.CodeDedicatedServersNoNordlynx:
@@ -218,6 +220,8 @@ func (ti *Instance) connectWithUIEvent(
 			ti.notify(Force, cli.DedicatedServersCanNotConnectMessage)
 		case internal.CodeDedicatedServersSessionMaxLimitReached:
 			ti.notify(Force, cli.DedicatedServersConnectionLimitReached)
+		case internal.CodeDedicatedServersPq:
+			ti.notify(Force, internal.ServerUnavailableErrorMessage)
 		case internal.CodeConnecting:
 		case internal.CodeConnected:
 			return true

--- a/tray/actions_test.go
+++ b/tray/actions_test.go
@@ -140,6 +140,19 @@ func TestConnect_DedicatedServersErrorPaths(t *testing.T) {
 			code:     internal.CodeDedicatedServersSessionMaxLimitReached,
 			wantBody: cli.DedicatedServersConnectionLimitReached,
 		},
+		{
+			name: "server is in new state",
+			code: internal.CodeDedicatedServersServerNotSetUp,
+			wantBody: fmt.Sprintf(
+				cli.DedicatedServersNoServersAvailable,
+				client.DedicatedServersSetupURL,
+			),
+		},
+		{
+			name:     "with post-quantun cryptography enabled, connection can't be established",
+			code:     internal.CodeDedicatedServersPq,
+			wantBody: internal.ServerUnavailableErrorMessage,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Changes under this PR:
- upon connection to a DS display appropriate notification when server is in `new` state (eg. display notification with CAT for a user to finish server configuration)
- upon connection to a DS with post-quantum enabled, display appropriate notification 
- cover both changes with UT