### PR TITLE
LVPN-10244: fix GUI connection card icon switching for specialty servers

### DIFF
--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -212,6 +212,11 @@ func (r *RPC) connectWithParameters(ctx context.Context,
 	if err := r.cm.Load(&cfg); err != nil {
 		log.Error(err)
 	}
+	prelimGroup := groupConvert(in.GetServerTag())
+	if prelimGroup == config.ServerGroup_UNDEFINED {
+		prelimGroup = groupConvert(in.GetServerGroup())
+	}
+	r.RequestedConnParams.Set(source, ServerParameters{Group: prelimGroup})
 	r.connectionInfo.SetInitialConnecting()
 
 	if isDedicatedServer(in.ServerTag, in.ServerGroup) {

--- a/daemon/rpc_state_test.go
+++ b/daemon/rpc_state_test.go
@@ -213,3 +213,55 @@ func TestRpcState_HandlePauseEvents(t *testing.T) {
 		require.Equal(t, pb.PauseEventType_RECONNECT_FAILED, status.Type)
 	})
 }
+
+func TestRpcState_PreliminaryGroupAttachedToConnectingStatus(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name          string
+		prelimGroup   config.ServerGroup
+		expectedGroup config.ServerGroup
+	}{
+		{
+			name:          "specialty group is attached to connecting status",
+			prelimGroup:   config.ServerGroup_P2P,
+			expectedGroup: config.ServerGroup_P2P,
+		},
+		{
+			name:          "undefined group when connecting by server name",
+			prelimGroup:   config.ServerGroup_UNDEFINED,
+			expectedGroup: config.ServerGroup_UNDEFINED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+			ts.connParams.Set(
+				pb.ConnectionSource_MANUAL,
+				ServerParameters{Group: tt.prelimGroup},
+			)
+
+			go statusStream(ts.stateChan, ts.stopChan, testUID, ts.srv, ts.connParams)
+
+			ts.stateChan <- events.DataConnectChangeNotif{
+				Status: types.ConnectionStatus{
+					State: pb.ConnectionState_CONNECTING,
+					IP:    netip.MustParseAddr(testIP),
+				},
+			}
+
+			ts.srv.wg.Wait()
+
+			require.Len(t, ts.srv.states, 1)
+			status := ts.srv.states[0].GetConnectionStatus()
+			require.NotNil(t, status)
+			assert.Equal(t, pb.ConnectionState_CONNECTING, status.State)
+			require.NotNil(t, status.Parameters)
+			assert.Empty(t, status.Parameters.ServerName)
+			assert.Empty(t, status.Parameters.Country)
+			assert.Empty(t, status.Parameters.City)
+			assert.Equal(t, tt.expectedGroup, status.Parameters.Group)
+		})
+	}
+}

--- a/gui/lib/data/models/vpn_status.dart
+++ b/gui/lib/data/models/vpn_status.dart
@@ -68,6 +68,7 @@ abstract class VpnStatus with _$VpnStatus {
             convertToVpnProtocol(
               statusResponse.technology,
               statusResponse.protocol,
-            );
+            ) &&
+        connectionParameters.group == statusResponse.parameters.group;
   }
 }


### PR DESCRIPTION
LVPN-10244: fix GUI connection card icon switching for specialty servers
Repro steps:
1. Click Double VPN in the servers list -> connects, shows country flag
2. Click P2P -> briefly shows the **Double VPN** icon, then country flag
3. Click Onion over VPN -> briefly shows the **P2P** icon, then country flag