### PR TITLE
LVPN-10420: fix pause menu shadow clipping on the left side

### DIFF
--- a/gui/lib/theme/context_menu_theme.dart
+++ b/gui/lib/theme/context_menu_theme.dart
@@ -22,7 +22,6 @@ final class ContextMenuTheme extends ThemeExtension<ContextMenuTheme>
   final Duration animationDuration;
   final Curve animationCurve;
   final List<BoxShadow> menuBoxShadow;
-  final double menuShadowMargin;
   final double menuGap;
 
   ContextMenuTheme({
@@ -40,7 +39,6 @@ final class ContextMenuTheme extends ThemeExtension<ContextMenuTheme>
     required this.animationDuration,
     required this.animationCurve,
     required this.menuBoxShadow,
-    required this.menuShadowMargin,
     required this.menuGap,
   });
 }

--- a/gui/lib/theme/context_menu_theme.tailor.dart
+++ b/gui/lib/theme/context_menu_theme.tailor.dart
@@ -24,7 +24,6 @@ mixin _$ContextMenuThemeTailorMixin on ThemeExtension<ContextMenuTheme> {
   Duration get animationDuration;
   Curve get animationCurve;
   List<BoxShadow> get menuBoxShadow;
-  double get menuShadowMargin;
   double get menuGap;
 
   @override
@@ -43,7 +42,6 @@ mixin _$ContextMenuThemeTailorMixin on ThemeExtension<ContextMenuTheme> {
     Duration? animationDuration,
     Curve? animationCurve,
     List<BoxShadow>? menuBoxShadow,
-    double? menuShadowMargin,
     double? menuGap,
   }) {
     return ContextMenuTheme(
@@ -61,7 +59,6 @@ mixin _$ContextMenuThemeTailorMixin on ThemeExtension<ContextMenuTheme> {
       animationDuration: animationDuration ?? this.animationDuration,
       animationCurve: animationCurve ?? this.animationCurve,
       menuBoxShadow: menuBoxShadow ?? this.menuBoxShadow,
-      menuShadowMargin: menuShadowMargin ?? this.menuShadowMargin,
       menuGap: menuGap ?? this.menuGap,
     );
   }
@@ -87,7 +84,6 @@ mixin _$ContextMenuThemeTailorMixin on ThemeExtension<ContextMenuTheme> {
       animationDuration: t < 0.5 ? animationDuration : other.animationDuration,
       animationCurve: t < 0.5 ? animationCurve : other.animationCurve,
       menuBoxShadow: t < 0.5 ? menuBoxShadow : other.menuBoxShadow,
-      menuShadowMargin: t < 0.5 ? menuShadowMargin : other.menuShadowMargin,
       menuGap: t < 0.5 ? menuGap : other.menuGap,
     );
   }
@@ -147,10 +143,6 @@ mixin _$ContextMenuThemeTailorMixin on ThemeExtension<ContextMenuTheme> {
               menuBoxShadow,
               other.menuBoxShadow,
             ) &&
-            const DeepCollectionEquality().equals(
-              menuShadowMargin,
-              other.menuShadowMargin,
-            ) &&
             const DeepCollectionEquality().equals(menuGap, other.menuGap));
   }
 
@@ -172,7 +164,6 @@ mixin _$ContextMenuThemeTailorMixin on ThemeExtension<ContextMenuTheme> {
       const DeepCollectionEquality().hash(animationDuration),
       const DeepCollectionEquality().hash(animationCurve),
       const DeepCollectionEquality().hash(menuBoxShadow),
-      const DeepCollectionEquality().hash(menuShadowMargin),
       const DeepCollectionEquality().hash(menuGap),
     );
   }
@@ -195,6 +186,5 @@ extension ContextMenuThemeBuildContextProps on BuildContext {
   Duration get animationDuration => contextMenuTheme.animationDuration;
   Curve get animationCurve => contextMenuTheme.animationCurve;
   List<BoxShadow> get menuBoxShadow => contextMenuTheme.menuBoxShadow;
-  double get menuShadowMargin => contextMenuTheme.menuShadowMargin;
   double get menuGap => contextMenuTheme.menuGap;
 }

--- a/gui/lib/theme/theme.dart
+++ b/gui/lib/theme/theme.dart
@@ -882,7 +882,6 @@ final class NordVpnTheme {
       menuBoxShadow: mode == ThemeMode.light
           ? AppBoxShadows.lightPopover
           : AppBoxShadows.darkPopover,
-      menuShadowMargin: 6,
       menuGap: AppSpacing.spacing2,
     );
   }

--- a/gui/lib/widgets/context_menu/context_menu.dart
+++ b/gui/lib/widgets/context_menu/context_menu.dart
@@ -150,15 +150,26 @@ class _ContextMenuState extends State<ContextMenu>
             alignment: AlignmentDirectional.topStart,
             child: FadeTransition(
               opacity: _animation,
-              child: SizeTransition(
-                sizeFactor: _animation,
-                axisAlignment: -1,
-                child: Padding(
-                  padding: EdgeInsets.only(bottom: theme.menuShadowMargin),
-                  child: _MenuPanel(
-                    items: widget.items,
-                    width: menuWidth,
-                    onItemTapped: _onItemTapped,
+              // Shadow around the menu panel. Needs to be a parent of SizeTransition to avoid clipping.
+              child: SizedBox(
+                width: menuWidth,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: theme.menuRadius,
+                    border: Border.all(
+                      color: theme.menuBorderColor,
+                      width: theme.menuBorderWidth,
+                    ),
+                    boxShadow: theme.menuBoxShadow,
+                  ),
+                  child: SizeTransition(
+                    sizeFactor: _animation,
+                    axisAlignment: -1,
+                    child: _MenuPanel(
+                      items: widget.items,
+                      width: menuWidth,
+                      onItemTapped: _onItemTapped,
+                    ),
                   ),
                 ),
               ),
@@ -185,16 +196,8 @@ class _MenuPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = context.contextMenuTheme;
 
-    return Container(
+    return SizedBox(
       width: width,
-      decoration: BoxDecoration(
-        borderRadius: theme.menuRadius,
-        border: Border.all(
-          color: theme.menuBorderColor,
-          width: theme.menuBorderWidth,
-        ),
-        boxShadow: theme.menuBoxShadow,
-      ),
       child: Material(
         color: theme.menuColor,
         borderRadius: theme.menuRadius,


### PR DESCRIPTION
SizeTransition automatically clips the size of it's children. Because of that, shadow of it's children(pause menu and context menu) is not visible on the left side - because it's clipped.

To fix that, the relationship was changed so that SizeTransition is a child of a SizedBox that contains the shadow.