### PR TITLE
LVPN-10677: LibTelio bump to v6.2.3

### DIFF
--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -18,4 +18,4 @@ jobs:
       project-id: ${{ secrets.PROJECT_ID }}
     with:
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v1.6.0
+      triggered-ref: v1.7.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.25.3
 // may also need to update versions in `./lib-versions.env` file.
 require (
 	github.com/NordSecurity/libdrop-go/v9 v9.0.0
-	github.com/NordSecurity/libtelio-go/v6 v6.2.2
+	github.com/NordSecurity/libtelio-go/v6 v6.2.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/NordSecurity/gopenvpn v0.0.0-20230117114932-2252c52984b4 h1:2ozEjYEw4
 github.com/NordSecurity/gopenvpn v0.0.0-20230117114932-2252c52984b4/go.mod h1:tguhorMSnkMcQExNIHWBX6TRhFeGYlERzbeAWZ4j9Uw=
 github.com/NordSecurity/libdrop-go/v9 v9.0.0 h1:Jk46jiQFWFS/9oXzKVLjoEYCCb18YchWtEtuoYmaymI=
 github.com/NordSecurity/libdrop-go/v9 v9.0.0/go.mod h1:EkRRrgEM+Lih3EssmSy4H9LO16NN3meqQsX5wbuIUjY=
-github.com/NordSecurity/libtelio-go/v6 v6.2.2 h1:qEenxbvreSymSHAzHonY5Uz5EHNgx/aeCWr1dLOosHY=
-github.com/NordSecurity/libtelio-go/v6 v6.2.2/go.mod h1:Y68pMZmZ90NKt9veEjyDMZy7cecqoFJ7caHUf9dTebs=
+github.com/NordSecurity/libtelio-go/v6 v6.2.3 h1:HtzzvgtjRau7DVmLkFyqxUAFlMdJveT47/1SqDVfySo=
+github.com/NordSecurity/libtelio-go/v6 v6.2.3/go.mod h1:Y68pMZmZ90NKt9veEjyDMZy7cecqoFJ7caHUf9dTebs=
 github.com/NordSecurity/systray v0.0.0-20240327004800-3e3b59c1b83d h1:oUEFXgFRa9Svcjr+O1stzR3vEXZ5OfQxLUcDjqFcOuo=
 github.com/NordSecurity/systray v0.0.0-20240327004800-3e3b59c1b83d/go.mod h1:PqJ9YgQXNUYUuoLvVrbMmZACufI5xM8JJ5aSuRX5ljg=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/lib-versions.env
+++ b/lib-versions.env
@@ -3,7 +3,7 @@
 # `./go.mod` file as well!
 
 # shellcheck disable=SC2034  # used in the build process later
-LIBTELIO_VERSION=v6.2.2
+LIBTELIO_VERSION=v6.2.3
 LIBDROP_VERSION=v9.0.0
 LIBMOOSE_NORDVPNAPP_VERSION=v23.1.1-nordVpnApp
 LIBMOOSE_WORKER_VERSION=v23.0.2-worker


### PR DESCRIPTION
Bumping libtelio from `6.2.2` to `6.2.3`