### PR TITLE
LVPN-10737: fix /user/services request spam

### DIFF
--- a/daemon/rpc_account.go
+++ b/daemon/rpc_account.go
@@ -57,7 +57,6 @@ func dipServicesToProtobuf(dipServices []auth.DedicatedIPService) []*pb.Dedidcat
 func (r *RPC) setDedicatedIPServerData(accountInfo *pb.AccountResponse) (*pb.AccountResponse, error) {
 	dipServices, err := r.ac.GetDedicatedIPServices()
 	if err != nil {
-		log.Error("getting dedicated ip services:", err)
 		if errors.Is(err, core.ErrUnauthorized) {
 			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken},
 				fmt.Errorf("getting dedicated ip services: %w", err)

--- a/daemon/rpc_account.go
+++ b/daemon/rpc_account.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
+	"google.golang.org/protobuf/proto"
 )
 
 func findLatestDIPExpirationData(dipServices []auth.DedicatedIPService) (string, error) {
@@ -114,12 +115,14 @@ func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.Acco
 	if accountInfo, ok := r.dm.GetAccountData(req.Full); ok {
 		// because Dedicated IP and Dedicated Servers service data is using it's own caching that is updated with NC
 		// events, we can always try to fetch it to keep the returned information more accurate
-		dedicatedIPServerAccountInfo, err := r.setDedicatedIPServerData(accountInfo)
+		// because account info is provided by reference, it is cloned so that it is not overwritten in case of errors.
+		dedicatedServerIPAccountInfo := proto.Clone(accountInfo).(*pb.AccountResponse)
+		dedicatedServerIPAccountInfo, err := r.setDedicatedIPServerData(accountInfo)
 		if err != nil {
 			log.Error("getting dedicated servers/ip service data:", err)
 			return accountInfo, nil
 		}
-		return dedicatedIPServerAccountInfo, nil
+		return dedicatedServerIPAccountInfo, nil
 	}
 
 	accountInfo := &pb.AccountResponse{}

--- a/daemon/rpc_account.go
+++ b/daemon/rpc_account.go
@@ -117,7 +117,8 @@ func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.Acco
 		// events, we can always try to fetch it to keep the returned information more accurate
 		// because account info is provided by reference, it is cloned so that it is not overwritten in case of errors.
 		dedicatedServerIPAccountInfo := proto.Clone(accountInfo).(*pb.AccountResponse)
-		dedicatedServerIPAccountInfo, err := r.setDedicatedIPServerData(accountInfo)
+		var err error
+		dedicatedServerIPAccountInfo, err = r.setDedicatedIPServerData(dedicatedServerIPAccountInfo)
 		if err != nil {
 			log.Error("getting dedicated servers/ip service data:", err)
 			return accountInfo, nil

--- a/daemon/rpc_account.go
+++ b/daemon/rpc_account.go
@@ -54,15 +54,16 @@ func dipServicesToProtobuf(dipServices []auth.DedicatedIPService) []*pb.Dedidcat
 }
 
 // setDedicatedIPServerData sets Dedicated IP and Dedicated Server related fields in the accountInfo
-func (r *RPC) setDedicatedIPServerData(accountInfo *pb.AccountResponse) *pb.AccountResponse {
+func (r *RPC) setDedicatedIPServerData(accountInfo *pb.AccountResponse) (*pb.AccountResponse, error) {
 	dipServices, err := r.ac.GetDedicatedIPServices()
 	if err != nil {
 		log.Error("getting dedicated ip services:", err)
 		if errors.Is(err, core.ErrUnauthorized) {
-			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken}
-		} else {
-			return &pb.AccountResponse{Type: internal.CodeTokenRenewError}
+			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken},
+				fmt.Errorf("getting dedicated ip services: %w", err)
 		}
+		return &pb.AccountResponse{Type: internal.CodeTokenRenewError},
+			fmt.Errorf("getting dedicated ip services: %w", err)
 	}
 
 	accountInfo.DedicatedIpStatus = internal.CodeSuccess
@@ -76,8 +77,8 @@ func (r *RPC) setDedicatedIPServerData(accountInfo *pb.AccountResponse) *pb.Acco
 		accountInfo.DedicatedIpServices = dipServicesToProtobuf(dipServices)
 		dedicatedIPExpirationDate, err = findLatestDIPExpirationData(dipServices)
 		if err != nil {
-			log.Error("getting latest dedicated ip expiration date:", err)
-			return &pb.AccountResponse{Type: internal.CodeTokenRenewError}
+			return &pb.AccountResponse{Type: internal.CodeTokenRenewError},
+				fmt.Errorf("getting latest dedicated ip expiration date: %w", err)
 		}
 	}
 
@@ -85,11 +86,12 @@ func (r *RPC) setDedicatedIPServerData(accountInfo *pb.AccountResponse) *pb.Acco
 
 	dedicatedServerService, err := r.ac.GetDedicatedServerService()
 	if err != nil {
-		log.Error("getting dedicated server service:", err)
 		if errors.Is(err, core.ErrUnauthorized) {
-			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken}
+			return &pb.AccountResponse{Type: internal.CodeExpiredAccessToken},
+				fmt.Errorf("getting dedicated server service: %w", err)
 		}
-		return &pb.AccountResponse{Type: internal.CodeTokenRenewError}
+		return &pb.AccountResponse{Type: internal.CodeTokenRenewError},
+			fmt.Errorf("getting dedicated server service: %w", err)
 	}
 
 	accountInfo.DedicatedServerStatus = internal.CodeNoService
@@ -98,7 +100,7 @@ func (r *RPC) setDedicatedIPServerData(accountInfo *pb.AccountResponse) *pb.Acco
 		accountInfo.DedicatedServersServiceExpiresAt = dedicatedServerService.ExpiresAt
 	}
 
-	return accountInfo
+	return accountInfo, nil
 }
 
 // AccountInfo returns user account information.
@@ -113,18 +115,19 @@ func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.Acco
 	if accountInfo, ok := r.dm.GetAccountData(req.Full); ok {
 		// because Dedicated IP and Dedicated Servers service data is using it's own caching that is updated with NC
 		// events, we can always try to fetch it to keep the returned information more accurate
-		dedicatedIPServerAccountInfo := r.setDedicatedIPServerData(accountInfo)
-		if dedicatedIPServerAccountInfo.Type == internal.CodeSuccess {
-			return dedicatedIPServerAccountInfo, nil
+		dedicatedIPServerAccountInfo, err := r.setDedicatedIPServerData(accountInfo)
+		if err != nil {
+			log.Error("getting dedicated servers/ip service data:", err)
+			return accountInfo, nil
 		}
-		return accountInfo, nil
+		return dedicatedIPServerAccountInfo, nil
 	}
 
 	accountInfo := &pb.AccountResponse{}
 
 	vpnExpired, err := r.ac.IsVPNExpired()
 	if err != nil {
-		log.Error("checking VPN expiration: ", err)
+		log.Error("checking VPN expiration:", err)
 		return &pb.AccountResponse{Type: internal.CodeTokenRenewError}, nil
 	} else if vpnExpired {
 		accountInfo.Type = internal.CodeNoService
@@ -132,8 +135,9 @@ func (r *RPC) AccountInfo(ctx context.Context, req *pb.AccountRequest) (*pb.Acco
 		accountInfo.Type = internal.CodeSuccess
 	}
 
-	accountInfo = r.setDedicatedIPServerData(accountInfo)
-	if accountInfo.Type != internal.CodeSuccess {
+	accountInfo, err = r.setDedicatedIPServerData(accountInfo)
+	if err != nil {
+		log.Error("getting dedicated servers/ip service data:", err)
 		return accountInfo, nil
 	}
 

--- a/daemon/rpc_account_test.go
+++ b/daemon/rpc_account_test.go
@@ -275,7 +275,26 @@ func TestAccountInfo_CacheIsUpdatedIfDedicatedServersIPServiceIsNotAvailable(t *
 		name                   string
 		dedicatedIPServices    []auth.DedicatedIPService
 		dedicatedServerService auth.DedicatedServerService
-	}{}
+	}{
+		{
+			name:                   "no dedicated servers/ip service",
+			dedicatedIPServices:    []auth.DedicatedIPService{},
+			dedicatedServerService: auth.DedicatedServerService{Active: false},
+		},
+		{
+			name: "no dedicated servers service, dedicated ip service is available",
+			dedicatedIPServices: []auth.DedicatedIPService{
+				{
+					ExpiresAt: "2026-02-24",
+				},
+			},
+		},
+		{
+			name:                   "no dedicated ip service, dedicated server is available",
+			dedicatedIPServices:    []auth.DedicatedIPService{},
+			dedicatedServerService: auth.DedicatedServerService{Active: true},
+		},
+	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -299,6 +318,8 @@ func TestAccountInfo_CacheIsUpdatedIfDedicatedServersIPServiceIsNotAvailable(t *
 
 			resp, _ := r.AccountInfo(context.Background(), &pb.AccountRequest{Full: false})
 			assert.Equal(t, cachedResponse.String(), resp.String(), "Non-full request should not update the cache.")
+
+			dataManager.accountData.unset()
 
 			updatedResponse, _ := r.AccountInfo(context.Background(), &pb.AccountRequest{Full: true})
 			resp, _ = r.AccountInfo(context.Background(), &pb.AccountRequest{Full: false})

--- a/daemon/rpc_account_test.go
+++ b/daemon/rpc_account_test.go
@@ -298,15 +298,13 @@ func TestAccountInfo_CacheIsUpdatedIfDedicatedServersIPServiceIsNotAvailable(t *
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cachedResponse := userResponseToAccountResponse(user1)
 			dataManager := NewDataManager("", "", "", "", events.NewDataUpdateEvents())
-			dataManager.SetAccountData(cachedResponse)
 
-			authCheckerMock := testauth.AuthCheckerMock{LoggedIn: true}
+			authCheckerMock := testauth.AuthCheckerMock{LoggedIn: true, VPNExpired: true}
 			configManagerMock := mock.NewMockConfigManager()
 
 			credentialsAPIMock := testcore.CredentialsAPIMock{}
-			credentialsAPIMock.CurrentUserResponse = user2
+			credentialsAPIMock.CurrentUserResponse = user1
 
 			r := RPC{
 				dm:             dataManager,
@@ -316,14 +314,13 @@ func TestAccountInfo_CacheIsUpdatedIfDedicatedServersIPServiceIsNotAvailable(t *
 				events:         events.NewEventsEmpty(),
 			}
 
+			r.AccountInfo(context.Background(), &pb.AccountRequest{Full: false})
+
 			resp, _ := r.AccountInfo(context.Background(), &pb.AccountRequest{Full: false})
-			assert.Equal(t, cachedResponse.String(), resp.String(), "Non-full request should not update the cache.")
 
-			dataManager.accountData.unset()
-
-			updatedResponse, _ := r.AccountInfo(context.Background(), &pb.AccountRequest{Full: true})
-			resp, _ = r.AccountInfo(context.Background(), &pb.AccountRequest{Full: false})
-			assert.Equal(t, updatedResponse.String(), resp.String(), "Cache should be updated after a full request.")
+			expectedResponse := userResponseToAccountResponse(user1)
+			expectedResponse.Type = internal.CodeNoService
+			assert.Equal(t, resp.String(), expectedResponse.String(), "Cache should be updated after the initial request.")
 		})
 	}
 }

--- a/daemon/rpc_account_test.go
+++ b/daemon/rpc_account_test.go
@@ -159,11 +159,12 @@ func TestAccountInfo_FailedRequestDoesntUpdateTheCache(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                      string
-		isVPNExpiredErr           error
-		getDedicatedIPServicesErr error
-		loadConfigErr             error
-		currentUserErr            error
+		name                          string
+		isVPNExpiredErr               error
+		getDedicatedIPServicesErr     error
+		getDedicatedServersServiceErr error
+		loadConfigErr                 error
+		currentUserErr                error
 	}{
 		{
 			name:            "get vpn expired fail",
@@ -181,12 +182,17 @@ func TestAccountInfo_FailedRequestDoesntUpdateTheCache(t *testing.T) {
 			name:           "get current user fail",
 			currentUserErr: errors.New("get current user error"),
 		},
+		{
+			name:                          "get dedicated servers service fail",
+			getDedicatedServersServiceErr: errors.New("get dedicated servers error"),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			authCheckerMock.IsVPNExpiredErr = test.isVPNExpiredErr
 			authCheckerMock.GetDedicatedIPServicesErr = test.getDedicatedIPServicesErr
+			authCheckerMock.GetDedicatedServerServiceErr = test.getDedicatedServersServiceErr
 			configManagerMock.LoadErr = test.loadConfigErr
 			credentialsAPIMock.CurrentUserErr = test.currentUserErr
 
@@ -258,6 +264,45 @@ func TestAccountInfo_ContainsServiceData(t *testing.T) {
 				response.DedicatedServerStatus,
 				test.expectedStatus,
 				"Invalid dedicated servers service status in AccountInfo response.")
+		})
+	}
+}
+
+func TestAccountInfo_CacheIsUpdatedIfDedicatedServersIPServiceIsNotAvailable(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name                   string
+		dedicatedIPServices    []auth.DedicatedIPService
+		dedicatedServerService auth.DedicatedServerService
+	}{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cachedResponse := userResponseToAccountResponse(user1)
+			dataManager := NewDataManager("", "", "", "", events.NewDataUpdateEvents())
+			dataManager.SetAccountData(cachedResponse)
+
+			authCheckerMock := testauth.AuthCheckerMock{LoggedIn: true}
+			configManagerMock := mock.NewMockConfigManager()
+
+			credentialsAPIMock := testcore.CredentialsAPIMock{}
+			credentialsAPIMock.CurrentUserResponse = user2
+
+			r := RPC{
+				dm:             dataManager,
+				ac:             &authCheckerMock,
+				cm:             configManagerMock,
+				credentialsAPI: &credentialsAPIMock,
+				events:         events.NewEventsEmpty(),
+			}
+
+			resp, _ := r.AccountInfo(context.Background(), &pb.AccountRequest{Full: false})
+			assert.Equal(t, cachedResponse.String(), resp.String(), "Non-full request should not update the cache.")
+
+			updatedResponse, _ := r.AccountInfo(context.Background(), &pb.AccountRequest{Full: true})
+			resp, _ = r.AccountInfo(context.Background(), &pb.AccountRequest{Full: false})
+			assert.Equal(t, updatedResponse.String(), resp.String(), "Cache should be updated after a full request.")
 		})
 	}
 }


### PR DESCRIPTION
Because of faulty caching mechanism in the AccountInfo RPC handler, data is never cached.

Fresh data is fetched each time. When fresh data is fetched and user's VPN service is expired, a notification is emitted. This notification triggers AccountInfo request in tray, resulting in a permanent loop.