### PR TITLE
LVPN-10582: Handle duplicated ServerMaintenance event

### DIFF
--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -18,4 +18,4 @@ jobs:
       project-id: ${{ secrets.PROJECT_ID }}
     with:
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v1.7.3
+      triggered-ref: v1.7.4

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon"
 	"github.com/NordSecurity/nordvpn-linux/daemon/device"
 	"github.com/NordSecurity/nordvpn-linux/daemon/dns"
+	"github.com/NordSecurity/nordvpn-linux/daemon/ens"
 	daemonevents "github.com/NordSecurity/nordvpn-linux/daemon/events"
 	"github.com/NordSecurity/nordvpn-linux/daemon/firewall"
 	"github.com/NordSecurity/nordvpn-linux/daemon/firewall/nft"
@@ -645,6 +646,9 @@ func main() {
 	)
 
 	internalVpnEvents.ConnectionError.Subscribe(rpc.HandleVPNConnectionError)
+	ensMonitor := ens.NewMonitor(httpGlobalCtx, netw, rcConfig, rpc.ReconnectOnServerMaintenanceEvent)
+	internalVpnEvents.ConnectionError.Subscribe(ensMonitor.HandleENSNotification)
+	ensMonitor.Start()
 
 	meshService := meshnet.NewServer(
 		authChecker,

--- a/daemon/ens/ens_monitoring.go
+++ b/daemon/ens/ens_monitoring.go
@@ -1,0 +1,90 @@
+package ens
+
+import (
+	"context"
+	"time"
+
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/log"
+	"github.com/NordSecurity/nordvpn-linux/networker"
+)
+
+const (
+	logPrefix = "[ens]"
+	evChSize  = 2
+)
+
+type ConnectCallback func() error
+
+type Monitor struct {
+	eventsCh    chan events.VPNConnectionErrorEvent
+	ctx         context.Context
+	netw        networker.Networker
+	reconnectFn ConnectCallback
+	rc          remote.ConfigGetter
+}
+
+func NewMonitor(ctx context.Context, netw networker.Networker, rc remote.ConfigGetter, connectCallback ConnectCallback) *Monitor {
+	return &Monitor{
+		eventsCh:    make(chan events.VPNConnectionErrorEvent, evChSize),
+		ctx:         ctx,
+		netw:        netw,
+		rc:          rc,
+		reconnectFn: connectCallback,
+	}
+}
+
+func (m *Monitor) HandleENSNotification(e events.VPNConnectionErrorEvent) error {
+	select {
+	case m.eventsCh <- e:
+	case <-m.ctx.Done():
+		log.Debug(logPrefix, "ignore event because context is done", e)
+	case <-time.After(10 * time.Millisecond):
+		log.Warn(logPrefix, "channel is full dropping ENS event", e)
+	}
+	return nil
+}
+
+func (m *Monitor) Start() {
+	if m.reconnectFn == nil {
+		log.Fatal(logPrefix, "connect callback is nil")
+	}
+	go m.run()
+}
+
+func (m *Monitor) run() {
+	log.Info(logPrefix, "start ENS monitoring")
+
+	for {
+		select {
+		case e, ok := <-m.eventsCh:
+			if !ok {
+				continue
+			}
+
+			if !m.rc.IsFeatureEnabled(remote.FeatureENS) {
+				continue
+			}
+
+			log.Debug(logPrefix, "event received", e)
+			if e.Code != events.VPNConnectionErrorServerMaintenance {
+				log.Debug(logPrefix, "ignoring", e)
+				continue
+			}
+
+			if !m.netw.IsVPNActive() {
+				log.Debug(logPrefix, "ignoring because VPN is not connected", e)
+				continue
+			}
+			// TODO: check if current server == event.server and check r.RequestedConnParams
+			if err := m.reconnectFn(); err != nil {
+				log.Error(logPrefix, "failed to reconnect", err)
+			}
+
+		case <-m.ctx.Done():
+			log.Info(logPrefix, "stop ENS monitoring")
+			return
+		}
+	}
+}

--- a/daemon/ens/ens_monitoring.go
+++ b/daemon/ens/ens_monitoring.go
@@ -15,7 +15,7 @@ const (
 	evChSize  = 2
 )
 
-type ConnectCallback func() error
+type ConnectCallback func(serverPublicKey string) error
 
 type Monitor struct {
 	eventsCh    chan events.VPNConnectionErrorEvent
@@ -77,8 +77,15 @@ func (m *Monitor) run() {
 				log.Debug(logPrefix, "ignoring because VPN is not connected", e)
 				continue
 			}
-			// TODO: check if current server == event.server and check r.RequestedConnParams
-			if err := m.reconnectFn(); err != nil {
+
+			currServer, _ := m.netw.GetConnectionParameters()
+			eventIsForDifferentServer := currServer.NordLynxPublicKey != e.ServerPublicKey
+			if eventIsForDifferentServer {
+				log.Debug(logPrefix, "ignoring ENS event for non-current server", e)
+				continue
+			}
+
+			if err := m.reconnectFn(e.ServerPublicKey); err != nil {
 				log.Error(logPrefix, "failed to reconnect", err)
 			}
 

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
 	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/helpers"
@@ -18,82 +19,136 @@ import (
 func TestENSMonitoring(t *testing.T) {
 	category.Set(t, category.Unit)
 
+	const serverKey = "current-server-key"
+
 	ctx, cancelFn := context.WithCancel(context.Background())
 	netw := &networker.Mock{
-		VpnActive: true,
+		VpnActive:               true,
+		ActiveServerDataPresent: true,
+		ActiveServerData:        vpn.ServerData{NordLynxPublicKey: serverKey},
 	}
 	rc := mock.NewRemoteConfigMock()
 	rc.FeatureToggles[remote.FeatureENS] = true
 
 	callbackCount := atomic.Int32{}
 	ch := make(chan any)
-	monitor := NewMonitor(
-		ctx,
-		netw,
-		rc,
-		func() error {
-			callbackCount.Add(1)
-			ch <- 1
-			return nil
-		},
-	)
-
+	monitor := NewMonitor(ctx, netw, rc, func(_ string) error {
+		callbackCount.Add(1)
+		ch <- 1
+		return nil
+	})
 	monitor.Start()
 
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
-
+	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
+		Code:            events.VPNConnectionErrorServerMaintenance,
+		ServerPublicKey: serverKey,
+	}))
 	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
 	assert.Equal(t, 1, int(callbackCount.Load()))
 
-	// events except VPNConnectionErrorServerMaintenance are ignored
-	for _, ev := range []events.VPNConnectionError{
-		events.VPNConnectionErrorSuperseded,
-		events.VPNConnectionErrorUnknown,
-		events.VPNConnectionErrorConnectionLimitReached,
-		events.VPNConnectionErrorUnauthenticated,
-		events.VPNConnectionErrorSuperseded,
-	} {
-		monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: ev})
-		helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
-		assert.Equal(t, 1, int(callbackCount.Load()))
-	}
-
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
+		Code:            events.VPNConnectionErrorServerMaintenance,
+		ServerPublicKey: serverKey,
+	}))
 	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
 	assert.Equal(t, 2, int(callbackCount.Load()))
 
 	cancelFn()
 
 	// after stopping the monitoring, events are ignored
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
+		Code:            events.VPNConnectionErrorServerMaintenance,
+		ServerPublicKey: serverKey,
+	}))
 	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
 	assert.Equal(t, 2, int(callbackCount.Load()))
 }
 
-func TestENSMonitoringWhenENSIsDisabledFromRC(t *testing.T) {
+func TestENSMonitoringEventFiltering(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	netw := &networker.Mock{
-		VpnActive: true,
-	}
-	rc := mock.NewRemoteConfigMock()
-	rc.FeatureToggles[remote.FeatureENS] = false
-	callbackCount := atomic.Int32{}
-	ch := make(chan any)
-	monitor := NewMonitor(
-		context.Background(),
-		netw,
-		rc,
-		func() error {
-			callbackCount.Add(1)
-			ch <- 1
-			return nil
+	const serverKey = "server-key"
+
+	tests := []struct {
+		name            string
+		ensEnabled      bool
+		serverKey       string
+		event           events.VPNConnectionErrorEvent
+		expectReconnect bool
+	}{
+		{
+			name:            "maintenance event for current server triggers reconnect",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance, ServerPublicKey: serverKey},
+			expectReconnect: true,
 		},
-	)
+		{
+			name:            "maintenance event with stale server key is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance, ServerPublicKey: "stale-key"},
+			expectReconnect: false,
+		},
+		{
+			name:            "ENS feature disabled ignores maintenance event",
+			ensEnabled:      false,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "superseded error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorSuperseded, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "unknown error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorUnknown, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "connection limit error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorConnectionLimitReached, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "unauthenticated error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorUnauthenticated, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+	}
 
-	monitor.Start()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			netw := &networker.Mock{
+				VpnActive:               true,
+				ActiveServerDataPresent: true,
+				ActiveServerData:        vpn.ServerData{NordLynxPublicKey: tt.serverKey},
+			}
+			rc := mock.NewRemoteConfigMock()
+			rc.FeatureToggles[remote.FeatureENS] = tt.ensEnabled
 
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
-	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
-	assert.Equal(t, 0, int(callbackCount.Load()))
+			callbackCalled := atomic.Bool{}
+			ch := make(chan any, 1)
+			monitor := NewMonitor(t.Context(), netw, rc, func(_ string) error {
+				callbackCalled.Store(true)
+				ch <- 1
+				return nil
+			})
+			monitor.Start()
+
+			assert.NilError(t, monitor.HandleENSNotification(tt.event))
+			helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
+			assert.Equal(t, tt.expectReconnect, callbackCalled.Load())
+		})
+	}
 }

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -1,0 +1,100 @@
+package ens
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/helpers"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	"github.com/NordSecurity/nordvpn-linux/test/mock/networker"
+	"gotest.tools/v3/assert"
+)
+
+func TestENSMonitoring(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	netw := &networker.Mock{
+		VpnActive: true,
+	}
+	rc := mock.NewRemoteConfigMock()
+	rc.FeatureToggles[remote.FeatureENS] = true
+
+	callbackCount := atomic.Int32{}
+	ch := make(chan any)
+	monitor := NewMonitor(
+		ctx,
+		netw,
+		rc,
+		func() error {
+			callbackCount.Add(1)
+			ch <- 1
+			return nil
+		},
+	)
+
+	monitor.Start()
+
+	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+
+	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
+	assert.Equal(t, 1, int(callbackCount.Load()))
+
+	// events except VPNConnectionErrorServerMaintenance are ignored
+	for _, ev := range []events.VPNConnectionError{
+		events.VPNConnectionErrorSuperseded,
+		events.VPNConnectionErrorUnknown,
+		events.VPNConnectionErrorConnectionLimitReached,
+		events.VPNConnectionErrorUnauthenticated,
+		events.VPNConnectionErrorSuperseded,
+	} {
+		monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: ev})
+		helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
+		assert.Equal(t, 1, int(callbackCount.Load()))
+	}
+
+	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
+	assert.Equal(t, 2, int(callbackCount.Load()))
+
+	cancelFn()
+
+	// after stopping the monitoring, events are ignored
+	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
+	assert.Equal(t, 2, int(callbackCount.Load()))
+}
+
+func TestENSMonitoringWhenENSIsDisabledFromRC(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	ctx, _ := context.WithCancel(context.Background())
+	netw := &networker.Mock{
+		VpnActive: true,
+	}
+	rc := mock.NewRemoteConfigMock()
+	rc.FeatureToggles[remote.FeatureENS] = false
+	callbackCount := atomic.Int32{}
+	ch := make(chan any)
+	monitor := NewMonitor(
+		ctx,
+		netw,
+		rc,
+		func() error {
+			callbackCount.Add(1)
+			ch <- 1
+			return nil
+		},
+	)
+
+	monitor.Start()
+
+	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
+	assert.Equal(t, 0, int(callbackCount.Load()))
+}

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -73,7 +73,6 @@ func TestENSMonitoring(t *testing.T) {
 func TestENSMonitoringWhenENSIsDisabledFromRC(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	ctx, _ := context.WithCancel(context.Background())
 	netw := &networker.Mock{
 		VpnActive: true,
 	}
@@ -82,7 +81,7 @@ func TestENSMonitoringWhenENSIsDisabledFromRC(t *testing.T) {
 	callbackCount := atomic.Int32{}
 	ch := make(chan any)
 	monitor := NewMonitor(
-		ctx,
+		context.Background(),
 		netw,
 		rc,
 		func() error {

--- a/daemon/jobs.go
+++ b/daemon/jobs.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -410,14 +411,14 @@ func (r *RPC) doAutoConnect() error {
 		groupTag = cfg.AutoConnectData.Group.String()
 	}
 
-	err = r.connectFromRequest(
-		&pb.ConnectRequest{
+	err = r.executeConnect(&server, func(ctx context.Context) (bool, error) {
+		param := &pb.ConnectRequest{
 			ServerTag:   cfg.AutoConnectData.ServerTag,
 			ServerGroup: groupTag,
-		},
-		&server,
-		pb.ConnectionSource_AUTO,
-	)
+		}
+		return r.connectWithParameters(ctx, param, &server, pb.ConnectionSource_AUTO, "")
+	})
+
 	if err == nil && server.err == nil {
 		log.Println(internal.InfoPrefix, "auto-connect success")
 		r.RequestedConnParams.Set(

--- a/daemon/rpc.go
+++ b/daemon/rpc.go
@@ -133,7 +133,7 @@ func NewRPC(
 		dedicatedServerKeyManager: dedicatedServersKeyManager,
 		initialLoginType:          NewAtomicLoginType(),
 	}
-	reconnectScheduler := NewReconnectScheduler(r.connectFromLastSelection, connectionInfo, pauseEvents)
+	reconnectScheduler := NewReconnectScheduler(r.ConnectFromLastSelection, connectionInfo, pauseEvents)
 	r.pauseManager = reconnectScheduler
 	return r
 }

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -45,7 +45,7 @@ func (r *RPC) ConnectFromLastSelection(srv pb.Daemon_ConnectServer,
 	})
 }
 
-func (r *RPC) ReconnectOnServerMaintenanceEvent() (exitErr error) {
+func (r *RPC) ReconnectOnServerMaintenanceEvent(serverPublicKey string) (exitErr error) {
 	srv := &connectServer{}
 	defer func() {
 		if exitErr != nil || srv.err != nil {
@@ -54,7 +54,7 @@ func (r *RPC) ReconnectOnServerMaintenanceEvent() (exitErr error) {
 	}()
 
 	return r.executeConnect(srv, func(ctx context.Context) (bool, error) {
-		return r.reconnectOnServerMaintenance(ctx, srv)
+		return r.reconnectOnServerMaintenance(ctx, srv, serverPublicKey)
 	})
 }
 
@@ -88,7 +88,15 @@ func (r *RPC) executeConnect(srv pb.Daemon_ConnectServer, fn func(context.Contex
 func (r *RPC) reconnectOnServerMaintenance(
 	ctx context.Context,
 	srv pb.Daemon_ConnectServer,
+	serverPublicKey string,
 ) (bool, error) {
+	currConn, isCurrConnActive := r.netw.GetConnectionParameters()
+	eventIsForDifferentServer := currConn.NordLynxPublicKey != serverPublicKey
+	if isCurrConnActive && eventIsForDifferentServer {
+		log.Debug("ignoring maintenance event, server has changed since ENS check")
+		return false, nil
+	}
+
 	reqParams := r.RequestedConnParams.Get()
 	currentServer := r.lastServerSelection.Server
 	log.Debug("[ens]", reqParams, currentServer)

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -31,10 +31,35 @@ func determineServerGroupIDs(server *core.Server) []config.ServerGroup {
 
 // Connect initiates and handles the VPN connection process
 func (r *RPC) Connect(in *pb.ConnectRequest, srv pb.Daemon_ConnectServer) (retErr error) {
-	return r.connectFromRequest(in, srv, pb.ConnectionSource_MANUAL)
+	return r.executeConnect(srv, func(ctx context.Context) (bool, error) {
+		return r.connectWithParameters(ctx, in, srv, pb.ConnectionSource_MANUAL, "")
+	})
 }
 
-func (r *RPC) connectFromRequest(in *pb.ConnectRequest, srv pb.Daemon_ConnectServer, source pb.ConnectionSource) error {
+func (r *RPC) ConnectFromLastSelection(srv pb.Daemon_ConnectServer,
+	source pb.ConnectionSource,
+	pauseDuration time.Duration,
+) error {
+	return r.executeConnect(srv, func(ctx context.Context) (bool, error) {
+		return r.connectWithStoredServerSelection(ctx, srv, pauseDuration)
+	})
+}
+
+func (r *RPC) ReconnectOnServerMaintenanceEvent() (exitErr error) {
+	srv := &connectServer{}
+	defer func() {
+		if exitErr != nil || srv.err != nil {
+			exitErr = errors.Join(exitErr, srv.err)
+		}
+	}()
+
+	return r.executeConnect(srv, func(ctx context.Context) (bool, error) {
+		return r.reconnectOnServerMaintenance(ctx, srv)
+	})
+}
+
+// executeConnect - ensures that no two connect functions are executed in the same time
+func (r *RPC) executeConnect(srv pb.Daemon_ConnectServer, fn func(context.Context) (bool, error)) error {
 	var err error
 	var didFail bool
 	// TODO: Currently this only listens to a given context in `netw.Start()`, therefore gets
@@ -47,7 +72,7 @@ func (r *RPC) connectFromRequest(in *pb.ConnectRequest, srv pb.Daemon_ConnectSer
 	// In order to fix this, all of expensive operations should implement `ctx.Done()` handling
 	// and have context bypassed to them.
 	if !r.connectContext.TryExecuteWith(func(ctx context.Context) {
-		didFail, err = r.connectWithParameters(ctx, in, srv, source)
+		didFail, err = fn(ctx)
 	}) {
 		return srv.Send(&pb.Payload{Type: internal.CodeNothingToDo})
 	}
@@ -60,23 +85,39 @@ func (r *RPC) connectFromRequest(in *pb.ConnectRequest, srv pb.Daemon_ConnectSer
 	return err
 }
 
-func (r *RPC) connectFromLastSelection(srv pb.Daemon_ConnectServer,
-	source pb.ConnectionSource,
-	pauseDuration time.Duration) error {
-	var err error
-	var didFail bool
-	if !r.connectContext.TryExecuteWith(func(ctx context.Context) {
-		didFail, err = r.connectWithStoredServerSelection(ctx, srv, pauseDuration)
-	}) {
-		return srv.Send(&pb.Payload{Type: internal.CodeNothingToDo})
+func (r *RPC) reconnectOnServerMaintenance(
+	ctx context.Context,
+	srv pb.Daemon_ConnectServer,
+) (bool, error) {
+	reqParams := r.RequestedConnParams.Get()
+	currentServer := r.lastServerSelection.Server
+	log.Debug("[ens]", reqParams, currentServer)
+
+	group := ""
+	if reqParams.Group != config.ServerGroup_UNDEFINED {
+		group = reqParams.Group.String()
 	}
 
-	// set connection status to "Disconnected"
-	if didFail || err != nil {
-		r.events.Service.Disconnect.Publish(events.DataDisconnect{})
+	var serverTag string
+	var hostname string
+	if currentServer != nil {
+		hostname = currentServer.Hostname
 	}
 
-	return err
+	if currentServer != nil && reqParams.ServerName != "" {
+		// specific server name was selected. Use server country + city instead
+		c := currentServer.Country()
+		serverTag = internal.SnakeCase(c.Code) + " " + internal.SnakeCase(c.City.Name)
+	} else {
+		// otherwise reuse whatever was already used to connect
+		serverTag = internal.SnakeCase(reqParams.CountryCode) + " " + internal.SnakeCase(reqParams.City)
+	}
+	req := pb.ConnectRequest{
+		ServerGroup: group,
+		ServerTag:   serverTag,
+	}
+
+	return r.connectWithParameters(ctx, &req, srv, pb.ConnectionSource_AUTO, hostname)
 }
 
 // determineServerSelectionRule determines the server selection rule based on the provided
@@ -131,9 +172,11 @@ func (r *RPC) isVPNExpired() int64 {
 	return internal.CodeSuccess
 }
 
-func (r *RPC) connectWithStoredServerSelection(ctx context.Context,
+func (r *RPC) connectWithStoredServerSelection(
+	ctx context.Context,
 	srv pb.Daemon_ConnectServer,
-	pauseDuration time.Duration) (bool, error) {
+	pauseDuration time.Duration,
+) (bool, error) {
 	if ok, err := r.ac.IsLoggedIn(); !ok {
 		if errors.Is(err, core.ErrUnauthorized) {
 			_ = srv.Send(&pb.Payload{Type: internal.CodeRevokedAccessToken})
@@ -169,7 +212,6 @@ func (r *RPC) connectWithStoredServerSelection(ctx context.Context,
 	if expirationCheckResult != internal.CodeSuccess {
 		return true, srv.Send(&pb.Payload{Type: expirationCheckResult})
 	}
-
 	return r.connect(ctx,
 		srv,
 		cfg,
@@ -177,13 +219,15 @@ func (r *RPC) connectWithStoredServerSelection(ctx context.Context,
 		r.RequestedConnParams.Get().ServerParameters,
 		time.Now(),
 		false,
-		pauseDuration)
+		pauseDuration,
+	)
 }
 
 func (r *RPC) connectWithParameters(ctx context.Context,
 	in *pb.ConnectRequest,
 	srv pb.Daemon_ConnectServer,
 	source pb.ConnectionSource,
+	excludedServer string,
 ) (didFail bool, retErr error) {
 	pauseDuration := r.pauseManager.CancelReconnection()
 	if ok, err := r.ac.IsLoggedIn(); !ok {
@@ -236,11 +280,10 @@ func (r *RPC) connectWithParameters(ctx context.Context,
 
 	inputServerTag := internal.RemoveNonAlphanumeric(in.GetServerTag())
 
-	log.Println(internal.DebugPrefix, "picking servers for", cfg.Technology, "technology", "input",
-		in.GetServerTag(), in.GetServerGroup())
+	log.Debug("picking servers for", cfg.Technology, "technology", "input",
+		in.GetServerTag(), in.GetServerGroup(), excludedServer)
 
-	serverSelection, err := selectServer(r, &insights, cfg, inputServerTag, in.GetServerGroup())
-
+	serverSelection, err := selectServer(r, &insights, cfg, inputServerTag, in.GetServerGroup(), excludedServer)
 	if err != nil {
 		var errorCode *internal.ErrorWithCode
 		if errors.As(err, &errorCode) {

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -186,6 +186,7 @@ func (c *workingLoginChecker) GetDedicatedIPServices() ([]auth.DedicatedIPServic
 
 	return c.dedicatedIPService, nil
 }
+
 func (c *workingLoginChecker) GetDedicatedServerService() (auth.DedicatedServerService, error) {
 	return auth.DedicatedServerService{Active: !c.isDedicatedServersExpired}, c.dedicatedServerErr
 }
@@ -1465,7 +1466,7 @@ func TestReconnectOnServerMaintenance(t *testing.T) {
 	assert.Equal(t, "it1.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
 
 	// reconnect will take the server city + country. Server selection finds second server, it2
-	failed, err = rpc.reconnectOnServerMaintenance(ctx, server)
+	failed, err = rpc.reconnectOnServerMaintenance(ctx, server, "")
 	assert.False(t, failed)
 	assert.NoError(t, err)
 	assert.Equal(t, "it2.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
@@ -1475,7 +1476,7 @@ func TestReconnectOnServerMaintenance(t *testing.T) {
 	assert.Equal(t, "Rome", p.City)
 
 	// reconnect will use the city + country, and server selection finds first server, it1
-	failed, err = rpc.reconnectOnServerMaintenance(ctx, server)
+	failed, err = rpc.reconnectOnServerMaintenance(ctx, server, "")
 	assert.False(t, failed)
 	assert.NoError(t, err)
 	assert.Equal(t, "it1.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
@@ -1483,4 +1484,56 @@ func TestReconnectOnServerMaintenance(t *testing.T) {
 	p = rpc.RequestedConnParams.Get()
 	assert.Equal(t, "IT", p.CountryCode)
 	assert.Equal(t, "Rome", p.City)
+}
+
+func TestReconnectOnServerMaintenance_ServerKeyGuard(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	const activeKey = "current-nordlynx-key"
+
+	tests := []struct {
+		name          string
+		eventKey      string
+		expectSkipped bool
+	}{
+		{
+			name:          "skips reconnect when connected server changed since ENS check",
+			eventKey:      "stale-key",
+			expectSkipped: true,
+		},
+		{
+			name:          "proceeds with reconnect when server key still matches",
+			eventKey:      activeKey,
+			expectSkipped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rpc := testRPCLocal(t)
+			rpc.serversAPI = core_test.NewMockServersAPI()
+			rpc.netw = &testnetworker.Mock{
+				VpnActive:               true,
+				ActiveServerDataPresent: true,
+				ActiveServerData:        vpn.ServerData{NordLynxPublicKey: activeKey},
+			}
+			rpc.cm.SaveWith(func(c config.Config) config.Config {
+				return config.Config{Technology: config.Technology_NORDLYNX}
+			})
+			rpc.RequestedConnParams.Set(pb.ConnectionSource_AUTO, serverpicker.ServerParameters{
+				CountryCode: "IT",
+				City:        "Rome",
+			})
+
+			failed, err := rpc.reconnectOnServerMaintenance(context.Background(), &mockRPCServer{}, tt.eventKey)
+
+			assert.False(t, failed)
+			assert.NoError(t, err)
+			if tt.expectSkipped {
+				assert.Nil(t, rpc.lastServerSelection.Server)
+			} else {
+				assert.NotNil(t, rpc.lastServerSelection.Server)
+			}
+		})
+	}
 }

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -398,9 +399,9 @@ func TestRPCConnect(t *testing.T) {
 				if test.setup != nil {
 					test.setup(rpc)
 				}
-				firstOpenEventCouter := 0
+				firstOpenEventCounter := 0
 				firstOpenListener := func(any) error {
-					firstOpenEventCouter++
+					firstOpenEventCounter++
 					return nil
 				}
 				rpc.events.Service.FirstTimeOpened.Subscribe(firstOpenListener)
@@ -423,13 +424,13 @@ func TestRPCConnect(t *testing.T) {
 				switch test.resp {
 				case internal.CodeConnected:
 					assert.NoError(t, err)
-					assert.Equal(t, firstOpenEventCouter, 1)
+					assert.Equal(t, firstOpenEventCounter, 1)
 				case 0:
 					assert.ErrorIs(t, internal.ErrUnhandled, err)
-					assert.Equal(t, firstOpenEventCouter, 0)
+					assert.Equal(t, firstOpenEventCounter, 0)
 				default:
 					assert.Equal(t, test.resp, server.msg.Type)
-					assert.Equal(t, firstOpenEventCouter, 0)
+					assert.Equal(t, firstOpenEventCounter, 0)
 				}
 			})
 		}
@@ -1435,4 +1436,51 @@ func Test_serverGroupIDs_NilGroups_ReturnsEmptySlice(t *testing.T) {
 	got := determineServerGroupIDs(&server)
 
 	assert.Equal(t, 0, len(got))
+}
+
+func TestReconnectOnServerMaintenance(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	rpc := testRPCLocal(t)
+	ctx := context.Background()
+	server := &mockRPCServer{}
+
+	params := serverpicker.ServerParameters{
+		ServerName: "it1",
+	}
+	rpc.RequestedConnParams.Set(pb.ConnectionSource_MANUAL, params)
+	rpc.serversAPI = core_test.NewMockServersAPI()
+
+	// select NordLynx because servers list has 2 servers in Italy
+	rpc.cm.SaveWith(func(c config.Config) config.Config {
+		return config.Config{
+			Technology: config.Technology_NORDLYNX,
+		}
+	})
+
+	// connect to a specific server name, it1
+	failed, err := rpc.connectWithParameters(ctx, &pb.ConnectRequest{ServerTag: "it1"}, server, pb.ConnectionSource_MANUAL, "")
+	assert.False(t, failed)
+	assert.NoError(t, err)
+	assert.Equal(t, "it1.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
+
+	// reconnect will take the server city + country. Server selection finds second server, it2
+	failed, err = rpc.reconnectOnServerMaintenance(ctx, server)
+	assert.False(t, failed)
+	assert.NoError(t, err)
+	assert.Equal(t, "it2.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
+
+	p := rpc.RequestedConnParams.Get()
+	assert.Equal(t, "IT", p.CountryCode)
+	assert.Equal(t, "Rome", p.City)
+
+	// reconnect will use the city + country, and server selection finds first server, it1
+	failed, err = rpc.reconnectOnServerMaintenance(ctx, server)
+	assert.False(t, failed)
+	assert.NoError(t, err)
+	assert.Equal(t, "it1.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
+
+	p = rpc.RequestedConnParams.Get()
+	assert.Equal(t, "IT", p.CountryCode)
+	assert.Equal(t, "Rome", p.City)
 }

--- a/daemon/rpc_countries_test.go
+++ b/daemon/rpc_countries_test.go
@@ -49,6 +49,7 @@ func TestRPCCountries(t *testing.T) {
 				{Name: "Algeria", VirtualLocation: true},
 				{Name: "France", VirtualLocation: false},
 				{Name: "Germany", VirtualLocation: false},
+				{Name: "Italy", VirtualLocation: false},
 				{Name: "Lithuania", VirtualLocation: false},
 			},
 		},
@@ -61,6 +62,7 @@ func TestRPCCountries(t *testing.T) {
 			expected: []*pb.ServerGroup{
 				{Name: "France", VirtualLocation: false},
 				{Name: "Germany", VirtualLocation: false},
+				{Name: "Italy", VirtualLocation: false},
 				{Name: "Lithuania", VirtualLocation: false},
 			},
 		},

--- a/daemon/rpc_recommended_server.go
+++ b/daemon/rpc_recommended_server.go
@@ -18,7 +18,7 @@ func (r *RPC) RecommendedServer(ctx context.Context, in *pb.Empty) (*pb.Recommen
 	}
 	insights := r.dm.GetInsightsData().Insights
 
-	serverSelection, err := selectServer(r, &insights, cfg, "", "")
+	serverSelection, err := selectServer(r, &insights, cfg, "", "", "")
 	if err == nil {
 		country := serverSelection.Server.Country()
 		return &pb.RecommendedServerLocation{

--- a/daemon/rpc_set_autoconnect.go
+++ b/daemon/rpc_set_autoconnect.go
@@ -71,8 +71,7 @@ func (r *RPC) SetAutoConnect(ctx context.Context, in *pb.SetAutoconnectRequest) 
 	serverGroup := in.GetServerGroup()
 	if in.GetEnabled() {
 		insights := r.dm.GetInsightsData().Insights
-
-		serverSelection, err := selectServer(r, &insights, cfg, serverTag, serverGroup)
+		serverSelection, err := selectServer(r, &insights, cfg, serverTag, serverGroup, "")
 		if err != nil {
 			log.Println(internal.ErrorPrefix, "no server found for autoconnect", serverTag, err)
 

--- a/daemon/serverpicker/server_selection.go
+++ b/daemon/serverpicker/server_selection.go
@@ -34,14 +34,16 @@ type ServerSelection struct {
 }
 
 type SearchParams struct {
-	Tag   string
-	Group string
+	Tag            string
+	Group          string
+	ExcludedServer string
 }
 
-func NewSearchParams(tag, group string) SearchParams {
+func NewSearchParams(tag, group string, excludedServer string) SearchParams {
 	return SearchParams{
-		Tag:   tag,
-		Group: group,
+		Tag:            tag,
+		Group:          group,
+		ExcludedServer: excludedServer,
 	}
 }
 
@@ -91,6 +93,7 @@ func PickServer(
 	localSelFn := selectFilterForLocalServers(input.Tag, serverGroup, obfuscated)
 	filterServersFn := func(s core.Server) bool {
 		return MatchesUserSettings(s, cfg) &&
+			s.Hostname != input.ExcludedServer &&
 			// for local servers only, take into account also the server.Keys
 			((len(s.Keys) == 0) || localSelFn(s))
 	}

--- a/daemon/serverpicker/serverpicker_test.go
+++ b/daemon/serverpicker/serverpicker_test.go
@@ -166,43 +166,43 @@ func TestResolveServerGroup(t *testing.T) {
 			err:           nil,
 		},
 		{
-			input:         NewSearchParams("", "p2p"),
+			input:         NewSearchParams("", "p2p", ""),
 			expectedGroup: config.ServerGroup_P2P,
 			err:           nil,
 		},
 		{
-			input:         NewSearchParams("p2p", ""),
+			input:         NewSearchParams("p2p", "", ""),
 			tagChanged:    true,
 			expectedGroup: config.ServerGroup_P2P,
 			err:           nil,
 		},
 		{
-			input:         NewSearchParams("p2p", "p2p"),
+			input:         NewSearchParams("p2p", "p2p", ""),
 			expectedGroup: config.ServerGroup_UNDEFINED,
 			err:           internal.ErrDoubleGroup,
 		},
 		{
-			input:         NewSearchParams("p2p", "quantum_vpn"),
+			input:         NewSearchParams("p2p", "quantum_vpn", ""),
 			expectedGroup: config.ServerGroup_UNDEFINED,
 			err:           internal.ErrGroupDoesNotExist,
 		},
 		{
-			input:         NewSearchParams("quantum_vpn", "p2p"),
+			input:         NewSearchParams("quantum_vpn", "p2p", ""),
 			expectedGroup: config.ServerGroup_P2P,
 			err:           nil,
 		},
 		{
-			input:         NewSearchParams("quantum_vpn", ""),
+			input:         NewSearchParams("quantum_vpn", "", ""),
 			expectedGroup: config.ServerGroup_UNDEFINED,
 			err:           nil,
 		},
 		{
-			input:         NewSearchParams("p2p us1234", ""),
+			input:         NewSearchParams("p2p us1234", "", ""),
 			expectedGroup: config.ServerGroup_UNDEFINED,
 			err:           nil,
 		},
 		{
-			input:         NewSearchParams("quantum_vpn", "quantum_vpn"),
+			input:         NewSearchParams("quantum_vpn", "quantum_vpn", ""),
 			expectedGroup: config.ServerGroup_UNDEFINED,
 			err:           internal.ErrGroupDoesNotExist,
 		},
@@ -593,6 +593,7 @@ func TestPickServer(t *testing.T) {
 		tag                  string
 		groupFlag            string
 		onlyPhysicServers    bool
+		excludedServer       string
 		expectedServerName   string
 		expectedRemoteServer bool
 		expectedError        error
@@ -660,6 +661,15 @@ func TestPickServer(t *testing.T) {
 			tech:          config.Technology_NORDLYNX,
 			expectedError: internal.ErrServerIsUnavailable,
 		},
+		{
+			name:           "exclude server de3.nordvpn.com",
+			api:            core_test.NewMockFailingServersAPI(errors.New("500")),
+			servers:        core_test.ServersList(),
+			tech:           config.Technology_NORDLYNX,
+			tag:            "de berlin",
+			excludedServer: "de3.nordvpn.com",
+			expectedError:  internal.ErrServerIsUnavailable,
+		},
 	}
 
 	for _, test := range tests {
@@ -684,7 +694,7 @@ func TestPickServer(t *testing.T) {
 					Latitude:  test.latitude,
 				},
 				cfg,
-				NewSearchParams(test.tag, test.groupFlag),
+				NewSearchParams(test.tag, test.groupFlag, test.excludedServer),
 			)
 
 			assert.Equal(t, test.expectedError, err)

--- a/daemon/servers.go
+++ b/daemon/servers.go
@@ -18,9 +18,10 @@ func selectServer(
 	cfg config.Config,
 	tag string,
 	groupFlag string,
+	excludedServer string,
 ) (serverpicker.ServerSelection, error) {
 	serversList := r.dm.GetServersData().Servers
-	searchParams := serverpicker.NewSearchParams(tag, groupFlag)
+	searchParams := serverpicker.NewSearchParams(tag, groupFlag, excludedServer)
 	selection, err := serverpicker.PickServer(
 		r.serversAPI,
 		serversList,

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -661,7 +661,7 @@ func (l *Libtelio) Refresh(c mesh.MachineMap) error {
 		return fmt.Errorf("failed to deserialize meshnet config: %w", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if err = l.lib.SetMeshnet(config); err == nil {
 			break
 		}
@@ -825,12 +825,13 @@ func (l *Libtelio) GetConnectionParameters() (vpn.ServerData, bool) {
 func isConnected(ctx context.Context,
 	stateCh <-chan state,
 	connParams connParameters,
-	eventsPublisher *vpn.Events) <-chan interface{} {
+	eventsPublisher *vpn.Events,
+) <-chan any {
 	// we need waitgroup just to make sure goroutine has started
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	connectedCh := make(chan interface{})
+	connectedCh := make(chan any)
 	go func() {
 		wg.Done() // signal that goroutine has started
 		monitorConnectionState(ctx, stateCh, connectedCh, connParams, eventsPublisher)
@@ -852,9 +853,10 @@ type connParameters struct {
 func monitorConnectionState(
 	ctx context.Context,
 	states <-chan state,
-	isConnected chan<- interface{},
+	isConnected chan<- any,
 	connParameters connParameters,
-	eventsPublisher *vpn.Events) {
+	eventsPublisher *vpn.Events,
+) {
 	type notifyState int
 	const (
 		disconnected notifyState = iota
@@ -920,7 +922,7 @@ func startConnectionErrorMonitor(
 
 	go func() {
 		wg.Done()
-		monitorConnectionErrors(ctx, errorsChan, eventsPublisher)
+		monitorConnectionErrors(ctx, errorsChan, eventsPublisher, serverPublicKey)
 	}()
 
 	wg.Wait()

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -415,7 +415,7 @@ func (l *Libtelio) connect(
 		l.eventsPublisher)
 
 	// Start monitoring ENS connection errors before connecting so no early error is missed.
-	startConnectionErrorMonitor(ctx, l.vpnErrorEvents, l.eventsPublisher)
+	startConnectionErrorMonitor(ctx, l.vpnErrorEvents, l.eventsPublisher, serverPublicKey)
 
 	var err error
 	port := "51820"
@@ -913,6 +913,7 @@ func startConnectionErrorMonitor(
 	ctx context.Context,
 	errorsChan <-chan teliogo.VpnConnectionError,
 	eventsPublisher *vpn.Events,
+	serverPublicKey string,
 ) {
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -931,12 +932,14 @@ func monitorConnectionErrors(
 	ctx context.Context,
 	errorsChan <-chan teliogo.VpnConnectionError,
 	eventsPublisher *vpn.Events,
+	serverPublicKey string,
 ) {
 	for {
 		select {
 		case connErr := <-errorsChan:
 			eventsPublisher.ConnectionError.Publish(events.VPNConnectionErrorEvent{
-				Code: toVPNConnectionError(connErr),
+				Code:            toVPNConnectionError(connErr),
+				ServerPublicKey: serverPublicKey,
 			})
 		case <-ctx.Done():
 			return

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -793,16 +793,16 @@ func TestMonitorConnectionErrors_PublishesMappedEvent(t *testing.T) {
 	})
 
 	errorsChan := make(chan teliogo.VpnConnectionError, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
-	go monitorConnectionErrors(ctx, errorsChan, pub)
+	const serverPublicKey = "test-server-key"
+	go monitorConnectionErrors(t.Context(), errorsChan, pub, serverPublicKey)
 
 	errorsChan <- teliogo.VpnConnectionErrorSuperseded
 
 	select {
 	case got := <-received:
 		assert.Equal(t, events.VPNConnectionErrorSuperseded, got.Code)
+		assert.Equal(t, serverPublicKey, got.ServerPublicKey)
 	case <-time.After(time.Second):
 		assert.Fail(t, "ConnectionError event was not published")
 	}

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -40,8 +40,10 @@ type mockLib struct{}
 func (mockLib) ConnectToExitNode(teliogo.PublicKey, *[]teliogo.IpNet, *teliogo.SocketAddr) error {
 	return nil
 }
+
 func (mockLib) ConnectToExitNodePostquantum(
-	*string, teliogo.PublicKey, *[]teliogo.IpNet, teliogo.SocketAddr) error {
+	*string, teliogo.PublicKey, *[]teliogo.IpNet, teliogo.SocketAddr,
+) error {
 	return nil
 }
 func (mockLib) DisconnectFromExitNodes() error                                       { return nil }
@@ -105,11 +107,9 @@ func TestIsConnected(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ch := make(chan state, 1)
 			var connectionEstablishedWG sync.WaitGroup
-			connectionEstablishedWG.Add(1)
-			go func() {
+			connectionEstablishedWG.Go(func() {
 				ch <- test.state
-				connectionEstablishedWG.Done()
-			}()
+			})
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 			defer cancel()
@@ -160,7 +160,7 @@ func Test_TelioDefaultConfig(t *testing.T) {
 	} else {
 		fmt.Println(string(jsn))
 	}
-	var intf interface{}
+	var intf any
 	err = json.Unmarshal(jsn, &intf)
 
 	assert.NoError(t, err)
@@ -555,7 +555,7 @@ func TestLibtelio_connect(t *testing.T) {
 			assert.Equal(t, tt.active, libtelio.active)
 
 			if tt.events > 0 {
-				eventsReceivedChan := make(chan interface{})
+				eventsReceivedChan := make(chan any)
 				go func() {
 					eventsReceivedWG.Wait()
 					close(eventsReceivedChan)
@@ -681,9 +681,7 @@ func TestHandleEvent_ForwardsVPNConnectionError(t *testing.T) {
 	vpnErrorsChan := make(chan teliogo.VpnConnectionError, 1)
 	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	callbackHandler.setConnectionMonitoringContext(ctx)
+	callbackHandler.setConnectionMonitoringContext(t.Context())
 
 	connErr := teliogo.VpnConnectionErrorServerMaintenance
 	callbackHandler.handleEvent(teliogo.EventNode{
@@ -715,9 +713,7 @@ func TestHandleEvent_NoVPNConnectionError_DoesNotForwardError(t *testing.T) {
 	vpnErrorsChan := make(chan teliogo.VpnConnectionError, 1)
 	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	callbackHandler.setConnectionMonitoringContext(ctx)
+	callbackHandler.setConnectionMonitoringContext(t.Context())
 
 	callbackHandler.handleEvent(teliogo.EventNode{
 		Body: teliogo.TelioNode{
@@ -746,9 +742,7 @@ func TestHandleEvent_DropsVPNConnectionError_WhenMonitorBusy(t *testing.T) {
 	vpnErrorsChan := make(chan teliogo.VpnConnectionError, 1)
 	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	callbackHandler.setConnectionMonitoringContext(ctx)
+	callbackHandler.setConnectionMonitoringContext(t.Context())
 
 	buffered := teliogo.VpnConnectionErrorUnauthenticated
 	vpnErrorsChan <- buffered

--- a/events/events.go
+++ b/events/events.go
@@ -96,7 +96,8 @@ func (e VPNConnectionError) String() string {
 
 // VPNConnectionErrorEvent is sent on the internal VPN event bus when a VPN connection error happens.
 type VPNConnectionErrorEvent struct {
-	Code VPNConnectionError
+	Code            VPNConnectionError
+	ServerPublicKey string
 }
 
 type TypeLoginType int

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -196,14 +196,30 @@ func (netw *Combined) Start(
 	nameservers config.DNS,
 	enableLocalTraffic bool,
 	disconnectCallback events.DisconnectCallback,
-) (err error) {
+) error {
 	netw.mu.Lock()
 	defer netw.mu.Unlock()
 
 	netw.allowlist = allowlist
 	netw.enableLocalTraffic = enableLocalTraffic
 	if netw.isConnectedToVPN() {
-		return netw.restart(ctx, creds, serverData, nameservers, disconnectCallback)
+		tempKSEnabled := false
+		if netw.KillSwitchState != enabledByUser {
+			if err := netw.internallyEnabledKillSwitch(); err == nil {
+				tempKSEnabled = true
+			} else {
+				log.Warn("failed to activate temporary KS", err)
+			}
+		}
+
+		err := netw.restart(ctx, creds, serverData, nameservers, disconnectCallback)
+		if err == nil && tempKSEnabled {
+			if err := netw.unsetKillSwitch(); err != nil {
+				log.Error("failed to disable temporary KS", err)
+			}
+		}
+
+		return err
 	}
 	return netw.start(ctx, creds, serverData, allowlist, nameservers)
 }

--- a/test/helpers/channels.go
+++ b/test/helpers/channels.go
@@ -1,0 +1,17 @@
+package helpers
+
+import (
+	"testing"
+	"time"
+)
+
+func WaitWithTimeout[T any](t *testing.T, ch <-chan T, d time.Duration) T {
+	t.Helper()
+
+	var v T
+	select {
+	case v = <-ch:
+	case <-time.After(d):
+	}
+	return v
+}

--- a/test/mock/core/mock_data.go
+++ b/test/mock/core/mock_data.go
@@ -53,6 +53,14 @@ func CountriesList() core.Countries {
 				{Name: "Algiers"},
 			},
 		},
+		{
+			Name: "Italy",
+			Code: "IT",
+			ID:   150,
+			Cities: []core.City{
+				{ID: 1, Name: "Rome"},
+			},
+		},
 	}
 }
 
@@ -330,6 +338,46 @@ func ServersList() core.Servers {
 				},
 			},
 			Groups: obfuscatedGroups,
+		},
+		core.Server{
+			ID:           12,
+			Name:         "Italy #1",
+			Hostname:     "it1.nordvpn.com",
+			Status:       core.Online,
+			Technologies: technologies,
+			CreatedAt:    "2006-01-02 15:04:05",
+			Station:      "127.0.0.1",
+			Locations: core.Locations{
+				core.Location{
+					Country: core.Country{
+						Name: "Italy",
+						Code: "IT",
+						ID:   150,
+						City: core.City{ID: 1, Name: "Rome"},
+					},
+				},
+			},
+			Groups: standardGroups,
+		},
+		core.Server{
+			ID:           13,
+			Name:         "Italy #2",
+			Hostname:     "it2.nordvpn.com",
+			Status:       core.Online,
+			Technologies: technologies,
+			CreatedAt:    "2006-01-02 15:04:05",
+			Station:      "127.0.0.1",
+			Locations: core.Locations{
+				core.Location{
+					Country: core.Country{
+						Name: "Italy",
+						Code: "IT",
+						ID:   150,
+						City: core.City{ID: 1, Name: "Rome"},
+					},
+				},
+			},
+			Groups: standardGroups,
 		},
 	}
 

--- a/test/mock/networker/networker.go
+++ b/test/mock/networker/networker.go
@@ -29,8 +29,12 @@ type Mock struct {
 
 	// ProvidedCredentials contain vpn.Credentials provided to the networker in the last Start call
 	ProvidedCredentials vpn.Credentials
-	// ProvidedCredentials contains vpn.ServerData provided to the networker in the last Start call
+	// ProvidedServerData contains vpn.ServerData provided to the networker in the last Start call
 	ProvidedServerData vpn.ServerData
+
+	// ActiveServerData and ActiveServerDataPresent control the return value of GetConnectionParameters.
+	ActiveServerData        vpn.ServerData
+	ActiveServerDataPresent bool
 }
 
 func (m *Mock) Start(
@@ -113,7 +117,9 @@ func (m *Mock) SetLanDiscovery(enabled bool) {
 
 func (*Mock) UnsetFirewall() error { return nil }
 
-func (*Mock) GetConnectionParameters() (vpn.ServerData, bool) { return vpn.ServerData{}, false }
+func (m *Mock) GetConnectionParameters() (vpn.ServerData, bool) {
+	return m.ActiveServerData, m.ActiveServerDataPresent
+}
 
 func (*Mock) SetARPIgnore(bool) error { return nil }
 

--- a/test/mock/networker/networker.go
+++ b/test/mock/networker/networker.go
@@ -50,6 +50,7 @@ func (m *Mock) Start(
 	m.ProvidedServerData = serverData
 	return nil
 }
+
 func (m *Mock) Stop() error {
 	if m.StopErr != nil {
 		return m.StopErr


### PR DESCRIPTION
Context:
- `ServerMaintenance` event reconnects user to a different server
- if the event is duplicated, we should not react to it

Changes:
- ENS monitoring reconnects the server only if the event is targeting currently connected server, comparison is based on server public key passed when starting monitoring, then reconnection starts monitoring for this new server again
- tests
- code cleanup