### PR TITLE
LVPN-10715: make sure no stale fileshare process is left

### DIFF
--- a/child_process/grpc_child_process_manager.go
+++ b/child_process/grpc_child_process_manager.go
@@ -4,11 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"google.golang.org/grpc/status"
 )
+
+const processStopTimeout = 5 * time.Second
 
 type ProcessClient interface {
 	Ping(nowait bool) error
@@ -69,10 +74,36 @@ func (g *GRPCChildProcessManager) StartProcess() (StartupErrorCode, error) {
 func (g *GRPCChildProcessManager) StopProcess(disable bool) error {
 	err := g.processClient.Stop(disable)
 	if err != nil {
-		return fmt.Errorf("stopping process: %w", err)
+		log.Warnf("gRPC stop for %s: %s",
+			filepath.Base(g.processBinaryPath), err)
 	}
 
-	return nil
+	// ensure process is terminated
+	g.confirmProcessDeath()
+
+	return err
+}
+
+func (g *GRPCChildProcessManager) confirmProcessDeath() {
+	binaryName := filepath.Base(g.processBinaryPath)
+
+	if pids := internal.FindProcessPIDsByName(binaryName); len(pids) == 0 {
+		return
+	}
+
+	deadline := time.Now().Add(processStopTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(1 * time.Second)
+		if pids := internal.FindProcessPIDsByName(binaryName); len(pids) == 0 {
+			return
+		}
+	}
+
+	if pids := internal.FindProcessPIDsByName(binaryName); len(pids) > 0 {
+		log.Warnf("%s still running after %s, force killing PIDs: %v",
+			binaryName, processStopTimeout, pids)
+		internal.KillStaleProcesses(binaryName, pids)
+	}
 }
 
 func (g *GRPCChildProcessManager) RestartProcess() error {

--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -73,7 +73,11 @@ func main() {
 		log.Info("Cannot start fileshare daemon, it is already running for another user.")
 		os.Exit(int(childprocess.CodeAlreadyRunningForOtherUser))
 	case childprocess.NotRunning:
-		// Continue with normal startup
+		// try to cleanup, if any stale process is still running from previous run
+		if pids := internal.FindProcessPIDsByName(internal.Fileshare); len(pids) > 0 {
+			log.Warnf("found %d stale %s process(es), killing: %v", len(pids), internal.Fileshare, pids)
+			internal.KillStaleProcesses(internal.Fileshare, pids)
+		}
 	}
 
 	eventsDBPath := filepath.Join(internal.DatFilesPath, "moose.db")

--- a/cmd/fileshare/redirect_to_lumberjack.go
+++ b/cmd/fileshare/redirect_to_lumberjack.go
@@ -44,8 +44,18 @@ func redirectStdOutputToLumberjack(lj *lumberjack.Logger) (cleanup func() error,
 	}()
 
 	cleanup = func() error {
-		_ = w.Close() // EOF for the goroutine
-		<-done        // wait for drain
+		// Dup2 created independent copies of the pipe write end on fd 1
+		// (stdout) and fd 2 (stderr). w.Close() only closes the original
+		// fd from os.Pipe. Redirect fd 1 and fd 2 to /dev/null so ALL
+		// pipe write ends are closed and io.Copy receives EOF.
+		devNull, err := unix.Open(os.DevNull, unix.O_WRONLY, 0)
+		if err == nil {
+			_ = unix.Dup2(devNull, 1)
+			_ = unix.Dup2(devNull, 2)
+			_ = unix.Close(devNull)
+		}
+		_ = w.Close()
+		<-done
 		return lj.Close()
 	}
 	if internal.IsProdEnv(Environment) {

--- a/fileshare/fileshare_startup/startup.go
+++ b/fileshare/fileshare_startup/startup.go
@@ -2,6 +2,7 @@ package fileshare_startup
 
 import (
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
 
@@ -13,6 +14,7 @@ import (
 )
 
 const transferHistoryChunkSize = 10000
+const disableTimeout = 5 * time.Second
 
 type FileshareHandle struct {
 	shutdownChan            <-chan struct{}
@@ -34,9 +36,21 @@ func (f *FileshareHandle) Shutdown() {
 
 	f.grpcServer.Stop()
 
-	if err := f.fileshareImplementation.Disable(); err != nil {
-		log.Error("disabling fileshare:", err)
+	// Disable() is an FFI call into libdrop that can hang
+	done := make(chan error, 1)
+	go func() {
+		done <- f.fileshareImplementation.Disable()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Error("disabling fileshare:", err)
+		}
+	case <-time.After(disableTimeout):
+		log.Error("fileshare Disable() timed out after", disableTimeout)
 	}
+
 	if err := f.grpcConn.Close(); err != nil {
 		log.Error("closing grpc connection:", err)
 	}

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"golang.org/x/sys/unix"
@@ -617,6 +619,88 @@ func isProcessRunning(executablePath string, readdir readdirFunc, readfile readf
 	}
 
 	return false, nil
+}
+
+// FindProcessPIDsByName scans /proc for processes whose binary basename matches
+// binaryName, excluding the calling process. Handles snap revision path changes
+// where the full path differs but the binary name is the same.
+func FindProcessPIDsByName(binaryName string) []int {
+	pids, err := findProcessPIDsByName(binaryName, os.Getpid(), defaultReaddir, defaultReadfile)
+	if err != nil {
+		log.Warn("failed to find processes by name:", err)
+		return nil
+	}
+	return pids
+}
+
+func findProcessPIDsByName(
+	binaryName string,
+	selfPID int,
+	readdir readdirFunc,
+	readfile readfileFunc,
+) ([]int, error) {
+	procDirs, err := readdir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("reading /proc directories: %w", err)
+	}
+
+	var pids []int
+	for _, dir := range procDirs {
+		pid, err := strconv.Atoi(dir.Name())
+		if err != nil {
+			continue
+		}
+		if pid == selfPID {
+			continue
+		}
+
+		cmdline, err := readfile(filepath.Join("/proc", dir.Name(), "cmdline"))
+		if err != nil {
+			continue
+		}
+		args := strings.Split(string(cmdline), "\x00")
+		if len(args) > 0 && filepath.Base(args[0]) == binaryName {
+			pids = append(pids, pid)
+		}
+	}
+
+	return pids, nil
+}
+
+// KillStaleProcesses sends SIGTERM to each PID, waits up to 3 seconds for exit,
+// then sends SIGKILL if the process is still alive.
+func KillStaleProcesses(binaryName string, pids []int) {
+	for _, pid := range pids {
+		killStaleProcess(binaryName, pid)
+	}
+}
+
+func killStaleProcess(binaryName string, pid int) {
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		log.Warnf("failed to send SIGTERM to %s (pid %d): %s", binaryName, pid, err)
+		return
+	}
+	log.Infof("sent SIGTERM to stale %s (pid %d)", binaryName, pid)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		log.Warnf("failed to send SIGKILL to %s (pid %d): %s", binaryName, pid, err)
+		return
+	}
+	log.Warnf("sent SIGKILL to stale %s (pid %d) after SIGTERM timeout", binaryName, pid)
 }
 
 // UserLogOutput opens logFileName in the user's cache directory and returns it.

--- a/internal/filesystem_test.go
+++ b/internal/filesystem_test.go
@@ -621,3 +621,159 @@ func TestIsProcessRunning(t *testing.T) {
 		})
 	}
 }
+
+func TestFindProcessPIDsByName(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	selfPID := 999
+
+	tests := []struct {
+		name      string
+		binary    string
+		selfPID   int
+		readdir   readdirFunc
+		readfile  readfileFunc
+		expected  []int
+		withError bool
+	}{
+		{
+			name:     "empty proc returns empty slice",
+			binary:   "nordfileshare",
+			selfPID:  selfPID,
+			readdir:  func(string) ([]os.DirEntry, error) { return []os.DirEntry{}, nil },
+			readfile: defaultReadfile,
+			expected: nil,
+		},
+		{
+			name:    "single matching process returns its PID",
+			binary:  "nordfileshare",
+			selfPID: selfPID,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return []os.DirEntry{
+					&fs.MockDirEntry{DirName: "42"},
+				}, nil
+			},
+			readfile: func(string) ([]byte, error) {
+				return []byte("/usr/lib/nordvpn/nordfileshare\x00"), nil
+			},
+			expected: []int{42},
+		},
+		{
+			name:    "matches snap path by basename",
+			binary:  "nordfileshare",
+			selfPID: selfPID,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return []os.DirEntry{
+					&fs.MockDirEntry{DirName: "100"},
+				}, nil
+			},
+			readfile: func(string) ([]byte, error) {
+				return []byte("/snap/nordvpn/x1/usr/lib/nordvpn/nordfileshare\x00"), nil
+			},
+			expected: []int{100},
+		},
+		{
+			name:    "matches different snap revisions",
+			binary:  "nordfileshare",
+			selfPID: selfPID,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return []os.DirEntry{
+					&fs.MockDirEntry{DirName: "100"},
+					&fs.MockDirEntry{DirName: "200"},
+				}, nil
+			},
+			readfile: func(name string) ([]byte, error) {
+				if strings.Contains(name, "100") {
+					return []byte("/snap/nordvpn/x1/usr/lib/nordvpn/nordfileshare\x00"), nil
+				}
+				return []byte("/snap/nordvpn/x2/usr/lib/nordvpn/nordfileshare\x00"), nil
+			},
+			expected: []int{100, 200},
+		},
+		{
+			name:    "excludes self PID",
+			binary:  "nordfileshare",
+			selfPID: 42,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return []os.DirEntry{
+					&fs.MockDirEntry{DirName: "42"},
+					&fs.MockDirEntry{DirName: "43"},
+				}, nil
+			},
+			readfile: func(string) ([]byte, error) {
+				return []byte("/usr/lib/nordvpn/nordfileshare\x00"), nil
+			},
+			expected: []int{43},
+		},
+		{
+			name:    "ignores non-matching processes",
+			binary:  "nordfileshare",
+			selfPID: selfPID,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return []os.DirEntry{
+					&fs.MockDirEntry{DirName: "10"},
+					&fs.MockDirEntry{DirName: "20"},
+					&fs.MockDirEntry{DirName: "30"},
+				}, nil
+			},
+			readfile: func(name string) ([]byte, error) {
+				if strings.Contains(name, "20") {
+					return []byte("/usr/lib/nordvpn/nordfileshare\x00"), nil
+				}
+				return []byte("/usr/bin/other-binary\x00"), nil
+			},
+			expected: []int{20},
+		},
+		{
+			name:    "skips non-numeric dirs",
+			binary:  "nordfileshare",
+			selfPID: selfPID,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return []os.DirEntry{
+					&fs.MockDirEntry{DirName: "not-a-pid"},
+					&fs.MockDirEntry{DirName: "self"},
+				}, nil
+			},
+			readfile: func(string) ([]byte, error) {
+				return []byte("/usr/lib/nordvpn/nordfileshare\x00"), nil
+			},
+			expected: nil,
+		},
+		{
+			name:    "skips unreadable cmdline",
+			binary:  "nordfileshare",
+			selfPID: selfPID,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return []os.DirEntry{
+					&fs.MockDirEntry{DirName: "42"},
+				}, nil
+			},
+			readfile:  func(string) ([]byte, error) { return nil, errors.New("permission denied") },
+			expected:  nil,
+			withError: false,
+		},
+		{
+			name:    "readdir error returns error",
+			binary:  "nordfileshare",
+			selfPID: selfPID,
+			readdir: func(string) ([]os.DirEntry, error) {
+				return nil, errors.New("test error")
+			},
+			readfile:  defaultReadfile,
+			expected:  nil,
+			withError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pids, err := findProcessPIDsByName(test.binary, test.selfPID, test.readdir, test.readfile)
+			if test.withError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, test.expected, pids)
+		})
+	}
+}

--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -1,5 +1,6 @@
 import random
 import re
+import subprocess
 import time
 from collections import namedtuple
 from collections.abc import Callable
@@ -463,6 +464,15 @@ def ensure_mesh_is_on() -> None:
     except sh.ErrorReturnCode_1 as e:
         if "Meshnet is already enabled." not in str(e):
             raise e
+
+
+def is_process_running() -> bool:
+    """Check if nordfileshare process exists using pgrep."""
+    result = subprocess.run(
+        ["pgrep", "-x", "nordfileshare"],
+        capture_output=True,
+    )
+    return result.returncode == 0
 
 
 def restart_mesh() -> None:

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1525,6 +1525,28 @@ def test_fileshare_process_monitoring_cuts_the_port_access_even_when_it_was_take
         fileshare.ensure_mesh_is_on()
 
 
+def test_no_stale_fileshare_process_after_mesh_off():
+    """Verify nordfileshare exits when meshnet is disabled."""
+    try:
+        assert fileshare.is_process_running(), \
+            "nordfileshare should be running when meshnet is on"
+
+        sh.nordvpn.set.meshnet.off()
+
+        # Poll for process death. The shutdown sequence needs time:
+        # Stop RPC -> Disable() (up to 5s) -> cleanup() -> confirmProcessDeath (up to 5s).
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if not fileshare.is_process_running():
+                break
+            time.sleep(1)
+
+        assert not fileshare.is_process_running(), \
+            "nordfileshare should not be running after mesh off"
+    finally:
+        fileshare.ensure_mesh_is_on()
+
+
 @pytest.mark.core_meshnet
 @pytest.mark.parametrize("background_accept", [True, False], ids=["accept_bg", "accept_int"])
 @pytest.mark.parametrize("background_send", [True, False], ids=["send_bg", "send_int"])


### PR DESCRIPTION
Fileshare process was left stale after turn mesh off (and more situations).\nThe main culprit was not closing all pipes on cleanup after redirected stdout and stderr to lumberjack.\nImplemented additional measures to make sure fileshare process is not left stale.