### PR TITLE
LVPN-10730: Add bindings import change on major bump

### DIFF
--- a/ci/set_bindings_version.sh
+++ b/ci/set_bindings_version.sh
@@ -30,7 +30,7 @@ new_module="${repo_path}/${major_version}"
 if [[ -n "${current_major}" && -n "${major_version}" && "${current_major}" != "${major_version}" ]]; then
   # NOTE: GONOSUMDB allows ignoring module checksum check made by go. This is
   # not needed for regular builds, because we commit changed go.sum which is
-  # trusted by go tooling, but when we are changing module on the fly, go
+  # trusted by go tooling. But when we are changing module on the fly, go
   # needs to recompute checksum database and we don't allow to do this in
   # docker, so this temporary override here allows module change on the fly
   # without compilation errors.

--- a/ci/set_bindings_version.sh
+++ b/ci/set_bindings_version.sh
@@ -2,8 +2,8 @@
 set -euxo pipefail
 
 declare -A LIB_NAME_TO_PACKAGE=(
-    [libtelio]=github.com/NordSecurity/libtelio-go
-    [libdrop]=github.com/NordSecurity/libdrop-go
+  [libtelio]=github.com/NordSecurity/libtelio-go
+  [libdrop]=github.com/NordSecurity/libdrop-go
 )
 
 declare -A LIB_NAME_TO_VERSION
@@ -14,30 +14,26 @@ declare -A LIB_NAME_TO_BINDINGS_VERSION
 [[ -n "${LIBTELIO_BINDINGS_VERSION:-}" ]] && LIB_NAME_TO_BINDINGS_VERSION[libtelio]=${LIBTELIO_BINDINGS_VERSION}
 [[ -n "${LIBDROP_BINDINGS_VERSION:-}" ]] && LIB_NAME_TO_BINDINGS_VERSION[libdrop]=${LIBDROP_BINDINGS_VERSION}
 
-for lib_name in "$@"; do
-  repo_path="${LIB_NAME_TO_PACKAGE[${lib_name}]}"
-  lib_version="${LIB_NAME_TO_VERSION[${lib_name}]:-}"
-  if [[ -z "${lib_version}" ]]; then
-    continue
-  fi
+lib_name=$1
+repo_path="${LIB_NAME_TO_PACKAGE[${lib_name}]}"
+lib_version="${LIB_NAME_TO_VERSION[${lib_name}]:-}"
 
-  bindings_version="${LIB_NAME_TO_BINDINGS_VERSION[${lib_name}]:-}"
+bindings_version="${LIB_NAME_TO_BINDINGS_VERSION[${lib_name}]:-}"
 
-  new_version="${bindings_version:-${lib_version}}"
-  major_version=$(echo "${new_version}" | cut -d'.' -f1)
+new_version="${bindings_version:-${lib_version}}"
+major_version=$(echo "${new_version}" | cut -d'.' -f1)
 
-  current_version=$(grep "^\s*${repo_path}/" go.mod | awk '{print $2}' | head -1) || true
-  current_major=$(echo "${current_version}" | cut -d'.' -f1)
-  new_module="${repo_path}/${major_version}"
+current_version=$(grep "^\s*${repo_path}/" go.mod | awk '{print $2}' | head -1) || true
+current_major=$(echo "${current_version}" | cut -d'.' -f1)
+new_module="${repo_path}/${major_version}"
 
-  if [[ -n "${current_major}" && -n "${major_version}" && "${current_major}" != "${major_version}" ]]; then
-    # NOTE: GONOSUMDB allows ignoring module checksum check made by go. This is
-    # not needed for regular builds, because we commit changed go.sum which is
-    # trusted by go tooling, but when we are changing module on the fly, go
-    # needs to recompute checksum database and we don't allow to do this in
-    # docker, so this temporary override here allows module change on the fly
-    # without compilation errors.
-    GONOSUMDB="${repo_path}/*" go get "${new_module}@${new_version}"
-    find . -name "*.go" -exec sed -i "s|\"${repo_path}/${current_major}|\"${repo_path}/${major_version}|g" {} +
-  fi
-done
+if [[ -n "${current_major}" && -n "${major_version}" && "${current_major}" != "${major_version}" ]]; then
+  # NOTE: GONOSUMDB allows ignoring module checksum check made by go. This is
+  # not needed for regular builds, because we commit changed go.sum which is
+  # trusted by go tooling, but when we are changing module on the fly, go
+  # needs to recompute checksum database and we don't allow to do this in
+  # docker, so this temporary override here allows module change on the fly
+  # without compilation errors.
+  GONOSUMDB="${repo_path}/*" go get "${new_module}@${new_version}"
+  find . -name "*.go" -exec sed -i "s|\"${repo_path}/${current_major}|\"${repo_path}/${major_version}|g" {} +
+fi

--- a/ci/set_bindings_version.sh
+++ b/ci/set_bindings_version.sh
@@ -7,27 +7,37 @@ declare -A LIB_NAME_TO_PACKAGE=(
 )
 
 declare -A LIB_NAME_TO_VERSION
-[[ -n "${LIBTELIO_VERSION:-}" ]] && LIB_NAME_TO_VERSION[libtelio]=$LIBTELIO_VERSION
-[[ -n "${LIBDROP_VERSION:-}" ]] && LIB_NAME_TO_VERSION[libdrop]=$LIBDROP_VERSION
+[[ -n "${LIBTELIO_VERSION:-}" ]] && LIB_NAME_TO_VERSION[libtelio]=${LIBTELIO_VERSION}
+[[ -n "${LIBDROP_VERSION:-}" ]] && LIB_NAME_TO_VERSION[libdrop]=${LIBDROP_VERSION}
 
 declare -A LIB_NAME_TO_BINDINGS_VERSION
-[[ -n "${LIBTELIO_BINDINGS_VERSION:-}" ]] && LIB_NAME_TO_BINDINGS_VERSION[libtelio]=$LIBTELIO_BINDINGS_VERSION
-[[ -n "${LIBDROP_BINDINGS_VERSION:-}" ]] && LIB_NAME_TO_BINDINGS_VERSION[libdrop]=$LIBDROP_BINDINGS_VERSION
+[[ -n "${LIBTELIO_BINDINGS_VERSION:-}" ]] && LIB_NAME_TO_BINDINGS_VERSION[libtelio]=${LIBTELIO_BINDINGS_VERSION}
+[[ -n "${LIBDROP_BINDINGS_VERSION:-}" ]] && LIB_NAME_TO_BINDINGS_VERSION[libdrop]=${LIBDROP_BINDINGS_VERSION}
 
-lib_name=$1
-repo_path="${LIB_NAME_TO_PACKAGE[$lib_name]}"
-lib_version="${LIB_NAME_TO_VERSION[$lib_name]:-}"
-if [[ -z "${lib_version}" ]]; then
-  return 0
-fi
+for lib_name in "$@"; do
+  repo_path="${LIB_NAME_TO_PACKAGE[${lib_name}]}"
+  lib_version="${LIB_NAME_TO_VERSION[${lib_name}]:-}"
+  if [[ -z "${lib_version}" ]]; then
+    continue
+  fi
 
-bindings_version="${LIB_NAME_TO_BINDINGS_VERSION[$lib_name]:-}"
+  bindings_version="${LIB_NAME_TO_BINDINGS_VERSION[${lib_name}]:-}"
 
-major_version=$(echo "${lib_version}" | cut -d'.' -f1)
+  new_version="${bindings_version:-${lib_version}}"
+  major_version=$(echo "${new_version}" | cut -d'.' -f1)
 
-full_package_path=$repo_path/$major_version@$lib_version
-if [[ -n "${bindings_version}" ]]; then
-  full_package_path=$repo_path/$major_version@$bindings_version
-fi
+  current_version=$(grep "^\s*${repo_path}/" go.mod | awk '{print $2}' | head -1) || true
+  current_major=$(echo "${current_version}" | cut -d'.' -f1)
+  new_module="${repo_path}/${major_version}"
 
-go get "$full_package_path"
+  if [[ -n "${current_major}" && -n "${major_version}" && "${current_major}" != "${major_version}" ]]; then
+    # NOTE: GONOSUMDB allows ignoring module checksum check made by go. This is
+    # not needed for regular builds, because we commit changed go.sum which is
+    # trusted by go tooling, but when we are changing module on the fly, go
+    # needs to recompute checksum database and we don't allow to do this in
+    # docker, so this temporary override here allows module change on the fly
+    # without compilation errors.
+    GONOSUMDB="${repo_path}/*" go get "${new_module}@${new_version}"
+    find . -name "*.go" -exec sed -i "s|\"${repo_path}/${current_major}|\"${repo_path}/${major_version}|g" {} +
+  fi
+done


### PR DESCRIPTION
Context:
- when our CI pipeline is used to build with libtelio version override and that version is a major version change, compilation will fail because bindings version in import paths is hardcoded
- this PR modifies those import paths on the fly when it detects that the version override is a major version change

Changes:
- `set_bindings_version.sh` additionally checks if there is a major version change and then `sed`s import paths to include this new major version
- this is based on a convention that libtelio `vX` has bindings available under `github.com/NordSecurity/libtelio-go/vX`