### PR TITLE
LVPN-10582: Handle duplicated maintenance event

### DIFF
--- a/daemon/ens/ens_monitoring.go
+++ b/daemon/ens/ens_monitoring.go
@@ -15,7 +15,7 @@ const (
 	evChSize  = 2
 )
 
-type ConnectCallback func() error
+type ConnectCallback func(serverPublicKey string) error
 
 type Monitor struct {
 	eventsCh    chan events.VPNConnectionErrorEvent
@@ -78,8 +78,15 @@ func (m *Monitor) run() {
 				log.Debug(logPrefix, "ignoring because VPN is not connected", e)
 				continue
 			}
-			// TODO: check if current server == event.server and check r.RequestedConnParams
-			if err := m.reconnectFn(); err != nil {
+
+			currServer, _ := m.netw.GetConnectionParameters()
+			eventIsForDifferentServer := currServer.NordLynxPublicKey != e.ServerPublicKey
+			if eventIsForDifferentServer {
+				log.Debug(logPrefix, "ignoring ENS event for non-current server", e)
+				continue
+			}
+
+			if err := m.reconnectFn(e.ServerPublicKey); err != nil {
 				log.Error(logPrefix, "failed to reconnect", err)
 			}
 

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config/remote"
+	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
 	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/NordSecurity/nordvpn-linux/test/helpers"
@@ -18,82 +19,134 @@ import (
 func TestENSMonitoring(t *testing.T) {
 	category.Set(t, category.Unit)
 
+	const serverKey = "current-server-key"
+
 	ctx, cancelFn := context.WithCancel(context.Background())
 	netw := &networker.Mock{
-		VpnActive: true,
+		VpnActive:        true,
+		ActiveServerData: &vpn.ServerData{NordLynxPublicKey: serverKey},
 	}
 	rc := mock.NewRemoteConfigMock()
 	rc.FeatureToggles[remote.FeatureENS] = true
 
 	callbackCount := atomic.Int32{}
 	ch := make(chan any)
-	monitor := NewMonitor(
-		ctx,
-		netw,
-		rc,
-		func() error {
-			callbackCount.Add(1)
-			ch <- 1
-			return nil
-		},
-	)
-
+	monitor := NewMonitor(ctx, netw, rc, func(_ string) error {
+		callbackCount.Add(1)
+		ch <- 1
+		return nil
+	})
 	monitor.Start()
 
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
-
+	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
+		Code:            events.VPNConnectionErrorServerMaintenance,
+		ServerPublicKey: serverKey,
+	}))
 	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
 	assert.Equal(t, 1, int(callbackCount.Load()))
 
-	// events except VPNConnectionErrorServerMaintenance are ignored
-	for _, ev := range []events.VPNConnectionError{
-		events.VPNConnectionErrorSuperseded,
-		events.VPNConnectionErrorUnknown,
-		events.VPNConnectionErrorConnectionLimitReached,
-		events.VPNConnectionErrorUnauthenticated,
-		events.VPNConnectionErrorSuperseded,
-	} {
-		monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: ev})
-		helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
-		assert.Equal(t, 1, int(callbackCount.Load()))
-	}
-
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
+		Code:            events.VPNConnectionErrorServerMaintenance,
+		ServerPublicKey: serverKey,
+	}))
 	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
 	assert.Equal(t, 2, int(callbackCount.Load()))
 
 	cancelFn()
 
 	// after stopping the monitoring, events are ignored
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
+	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
+		Code:            events.VPNConnectionErrorServerMaintenance,
+		ServerPublicKey: serverKey,
+	}))
 	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
 	assert.Equal(t, 2, int(callbackCount.Load()))
 }
 
-func TestENSMonitoringWhenENSIsDisabledFromRC(t *testing.T) {
+func TestENSMonitoringEventFiltering(t *testing.T) {
 	category.Set(t, category.Unit)
 
-	netw := &networker.Mock{
-		VpnActive: true,
-	}
-	rc := mock.NewRemoteConfigMock()
-	rc.FeatureToggles[remote.FeatureENS] = false
-	callbackCount := atomic.Int32{}
-	ch := make(chan any)
-	monitor := NewMonitor(
-		context.Background(),
-		netw,
-		rc,
-		func() error {
-			callbackCount.Add(1)
-			ch <- 1
-			return nil
+	const serverKey = "server-key"
+
+	tests := []struct {
+		name            string
+		ensEnabled      bool
+		serverKey       string
+		event           events.VPNConnectionErrorEvent
+		expectReconnect bool
+	}{
+		{
+			name:            "maintenance event for current server triggers reconnect",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance, ServerPublicKey: serverKey},
+			expectReconnect: true,
 		},
-	)
+		{
+			name:            "maintenance event with stale server key is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance, ServerPublicKey: "stale-key"},
+			expectReconnect: false,
+		},
+		{
+			name:            "ENS feature disabled ignores maintenance event",
+			ensEnabled:      false,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "superseded error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorSuperseded, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "unknown error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorUnknown, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "connection limit error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorConnectionLimitReached, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+		{
+			name:            "unauthenticated error is ignored",
+			ensEnabled:      true,
+			serverKey:       serverKey,
+			event:           events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorUnauthenticated, ServerPublicKey: serverKey},
+			expectReconnect: false,
+		},
+	}
 
-	monitor.Start()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			netw := &networker.Mock{
+				VpnActive:        true,
+				ActiveServerData: &vpn.ServerData{NordLynxPublicKey: tt.serverKey},
+			}
+			rc := mock.NewRemoteConfigMock()
+			rc.FeatureToggles[remote.FeatureENS] = tt.ensEnabled
 
-	monitor.HandleENSNotification(events.VPNConnectionErrorEvent{Code: events.VPNConnectionErrorServerMaintenance})
-	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
-	assert.Equal(t, 0, int(callbackCount.Load()))
+			callbackCalled := atomic.Bool{}
+			ch := make(chan any, 1)
+			monitor := NewMonitor(t.Context(), netw, rc, func(_ string) error {
+				callbackCalled.Store(true)
+				ch <- 1
+				return nil
+			})
+			monitor.Start()
+
+			assert.NilError(t, monitor.HandleENSNotification(tt.event))
+			helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
+			assert.Equal(t, tt.expectReconnect, callbackCalled.Load())
+		})
+	}
 }

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -45,7 +45,7 @@ func (r *RPC) ConnectFromLastSelection(srv pb.Daemon_ConnectServer,
 	})
 }
 
-func (r *RPC) ReconnectOnServerMaintenanceEvent() (exitErr error) {
+func (r *RPC) ReconnectOnServerMaintenanceEvent(serverPublicKey string) (exitErr error) {
 	srv := &connectServer{}
 	defer func() {
 		if exitErr != nil || srv.err != nil {
@@ -54,7 +54,7 @@ func (r *RPC) ReconnectOnServerMaintenanceEvent() (exitErr error) {
 	}()
 
 	return r.executeConnect(srv, func(ctx context.Context) (bool, error) {
-		return r.reconnectOnServerMaintenance(ctx, srv)
+		return r.reconnectOnServerMaintenance(ctx, srv, serverPublicKey)
 	})
 }
 
@@ -88,7 +88,15 @@ func (r *RPC) executeConnect(srv pb.Daemon_ConnectServer, fn func(context.Contex
 func (r *RPC) reconnectOnServerMaintenance(
 	ctx context.Context,
 	srv pb.Daemon_ConnectServer,
+	serverPublicKey string,
 ) (bool, error) {
+	currConn, isCurrConnActive := r.netw.GetConnectionParameters()
+	eventIsForDifferentServer := currConn.NordLynxPublicKey != serverPublicKey
+	if !isCurrConnActive || eventIsForDifferentServer {
+		log.Debug("ignoring maintenance event, connection has changed since ENS check")
+		return false, nil
+	}
+
 	reqParams := r.RequestedConnParams.Get()
 	currentServer := r.lastServerSelection.Server
 	log.Debug("[ens]", reqParams, currentServer)

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -186,6 +186,7 @@ func (c *workingLoginChecker) GetDedicatedIPServices() ([]auth.DedicatedIPServic
 
 	return c.dedicatedIPService, nil
 }
+
 func (c *workingLoginChecker) GetDedicatedServerService() (auth.DedicatedServerService, error) {
 	return auth.DedicatedServerService{Active: !c.isDedicatedServersExpired}, c.dedicatedServerErr
 }
@@ -1448,7 +1449,13 @@ func TestReconnectOnServerMaintenance(t *testing.T) {
 	params := serverpicker.ServerParameters{
 		ServerName: "it1",
 	}
+	const activeKey = "nordlynx-server-key"
+
 	rpc.RequestedConnParams.Set(pb.ConnectionSource_MANUAL, params)
+	rpc.netw = &testnetworker.Mock{
+		VpnActive:        true,
+		ActiveServerData: &vpn.ServerData{NordLynxPublicKey: activeKey},
+	}
 	rpc.serversAPI = core_test.NewMockServersAPI()
 
 	// select NordLynx because servers list has 2 servers in Italy
@@ -1465,7 +1472,7 @@ func TestReconnectOnServerMaintenance(t *testing.T) {
 	assert.Equal(t, "it1.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
 
 	// reconnect will take the server city + country. Server selection finds second server, it2
-	failed, err = rpc.reconnectOnServerMaintenance(ctx, server)
+	failed, err = rpc.reconnectOnServerMaintenance(ctx, server, activeKey)
 	assert.False(t, failed)
 	assert.NoError(t, err)
 	assert.Equal(t, "it2.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
@@ -1475,7 +1482,7 @@ func TestReconnectOnServerMaintenance(t *testing.T) {
 	assert.Equal(t, "Rome", p.City)
 
 	// reconnect will use the city + country, and server selection finds first server, it1
-	failed, err = rpc.reconnectOnServerMaintenance(ctx, server)
+	failed, err = rpc.reconnectOnServerMaintenance(ctx, server, activeKey)
 	assert.False(t, failed)
 	assert.NoError(t, err)
 	assert.Equal(t, "it1.nordvpn.com", rpc.lastServerSelection.Server.Hostname)
@@ -1483,4 +1490,63 @@ func TestReconnectOnServerMaintenance(t *testing.T) {
 	p = rpc.RequestedConnParams.Get()
 	assert.Equal(t, "IT", p.CountryCode)
 	assert.Equal(t, "Rome", p.City)
+}
+
+func TestReconnectOnServerMaintenance_ConnectionGuard(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	const activeKey = "current-nordlynx-key"
+
+	tests := []struct {
+		name          string
+		eventKey      string
+		connParams    *vpn.ServerData
+		expectSkipped bool
+	}{
+		{
+			name:          "skips reconnect when connected server changed since ENS check",
+			eventKey:      "stale-key",
+			connParams:    &vpn.ServerData{NordLynxPublicKey: activeKey},
+			expectSkipped: true,
+		},
+		{
+			name:          "skips reconnect when connection is not active anymore",
+			eventKey:      activeKey,
+			expectSkipped: true,
+		},
+		{
+			name:          "proceeds with reconnect when server key still matches and connection is active",
+			eventKey:      activeKey,
+			connParams:    &vpn.ServerData{NordLynxPublicKey: activeKey},
+			expectSkipped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rpc := testRPCLocal(t)
+			rpc.serversAPI = core_test.NewMockServersAPI()
+			rpc.netw = &testnetworker.Mock{
+				VpnActive:        true,
+				ActiveServerData: tt.connParams,
+			}
+			rpc.cm.SaveWith(func(c config.Config) config.Config {
+				return config.Config{Technology: config.Technology_NORDLYNX}
+			})
+			rpc.RequestedConnParams.Set(pb.ConnectionSource_AUTO, serverpicker.ServerParameters{
+				CountryCode: "IT",
+				City:        "Rome",
+			})
+
+			failed, err := rpc.reconnectOnServerMaintenance(context.Background(), &mockRPCServer{}, tt.eventKey)
+
+			assert.False(t, failed)
+			assert.NoError(t, err)
+			if tt.expectSkipped {
+				assert.Nil(t, rpc.lastServerSelection.Server)
+			} else {
+				assert.NotNil(t, rpc.lastServerSelection.Server)
+			}
+		})
+	}
 }

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -869,7 +869,8 @@ func (l *Libtelio) InjectVPNConnectionError(code int32, publicKey string) error 
 func isConnected(ctx context.Context,
 	stateCh <-chan state,
 	connParams connParameters,
-	eventsPublisher *vpn.Events) <-chan interface{} {
+	eventsPublisher *vpn.Events,
+) <-chan interface{} {
 	// we need waitgroup just to make sure goroutine has started
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -898,7 +899,8 @@ func monitorConnectionState(
 	states <-chan state,
 	isConnected chan<- interface{},
 	connParameters connParameters,
-	eventsPublisher *vpn.Events) {
+	eventsPublisher *vpn.Events,
+) {
 	type notifyState int
 	const (
 		disconnected notifyState = iota

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -681,7 +681,7 @@ func (l *Libtelio) Refresh(c mesh.MachineMap) error {
 		return fmt.Errorf("failed to deserialize meshnet config: %w", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if err = l.lib.SetMeshnet(config); err == nil {
 			break
 		}
@@ -870,12 +870,12 @@ func isConnected(ctx context.Context,
 	stateCh <-chan state,
 	connParams connParameters,
 	eventsPublisher *vpn.Events,
-) <-chan interface{} {
+) <-chan any {
 	// we need waitgroup just to make sure goroutine has started
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	connectedCh := make(chan interface{})
+	connectedCh := make(chan any)
 	go func() {
 		wg.Done() // signal that goroutine has started
 		monitorConnectionState(ctx, stateCh, connectedCh, connParams, eventsPublisher)
@@ -897,7 +897,7 @@ type connParameters struct {
 func monitorConnectionState(
 	ctx context.Context,
 	states <-chan state,
-	isConnected chan<- interface{},
+	isConnected chan<- any,
 	connParameters connParameters,
 	eventsPublisher *vpn.Events,
 ) {

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -953,7 +953,7 @@ func monitorConnectionState(
 	}
 }
 
-// startConnectionErrorMonitor starts connection error monitoring in a goroutine and returns only
+// startConnectionErrorMonitor starts connection error monitoring in a goroutine and returns
 // once goroutine started
 func (l *Libtelio) startConnectionErrorMonitor(ctx context.Context) {
 	var wg sync.WaitGroup

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -435,7 +435,7 @@ func (l *Libtelio) connect(
 		l.eventsPublisher)
 
 	// Start monitoring ENS connection errors before connecting so no early error is missed.
-	startConnectionErrorMonitor(ctx, l.vpnErrorEvents, l.injectedErrors, l.eventsPublisher)
+	l.startConnectionErrorMonitor(ctx)
 
 	var err error
 	port := "51820"
@@ -954,19 +954,14 @@ func monitorConnectionState(
 }
 
 // startConnectionErrorMonitor starts connection error monitoring in a goroutine and returns only
-// once it is running
-func startConnectionErrorMonitor(
-	ctx context.Context,
-	errorsChan <-chan vpnConnError,
-	injectedChan <-chan vpnConnError,
-	eventsPublisher *vpn.Events,
-) {
+// once goroutine started
+func (l *Libtelio) startConnectionErrorMonitor(ctx context.Context) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	go func() {
 		wg.Done()
-		monitorConnectionErrors(ctx, errorsChan, injectedChan, eventsPublisher)
+		l.monitorConnectionErrors(ctx)
 	}()
 
 	wg.Wait()
@@ -974,21 +969,16 @@ func startConnectionErrorMonitor(
 
 // monitorConnectionErrors awaits ENS connection errors extracted from telio node events,
 // maps them to the protocol-agnostic events and publishes them on the internal VPN event bus.
-func monitorConnectionErrors(
-	ctx context.Context,
-	errorsChan <-chan vpnConnError,
-	injectedChan <-chan vpnConnError,
-	eventsPublisher *vpn.Events,
-) {
+func (l *Libtelio) monitorConnectionErrors(ctx context.Context) {
 	for {
 		select {
-		case connErr := <-errorsChan:
-			publishConnError(eventsPublisher, connErr)
+		case connErr := <-l.vpnErrorEvents:
+			publishConnError(l.eventsPublisher, connErr)
 
 		// DEV only: a simulated ENS error injected via the gRPC tool. It's nil in production.
-		case injErr := <-injectedChan:
+		case injErr := <-l.injectedErrors:
 			log.Println(internal.InfoPrefix, "[DEV] injecting simulated ENS connection error:", injErr.code)
-			publishConnError(eventsPublisher, injErr)
+			publishConnError(l.eventsPublisher, injErr)
 
 		case <-ctx.Done():
 			return

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -788,8 +788,14 @@ func TestMonitorConnectionErrors_PublishesMappedEvent(t *testing.T) {
 	})
 
 	errorsChan := make(chan vpnConnError, 1)
+	l := &Libtelio{
+		eventsPublisher: pub,
+		vpnErrorEvents:  errorsChan,
+		active:          true,
+		currentServer:   vpn.ServerData{NordLynxPublicKey: "lel"},
+	}
 
-	go monitorConnectionErrors(t.Context(), errorsChan, nil, pub)
+	go l.monitorConnectionErrors(t.Context())
 
 	errorsChan <- vpnConnError{code: teliogo.VpnConnectionErrorSuperseded, publicKey: "srv-key"}
 
@@ -873,13 +879,14 @@ func TestInjectVPNConnectionError_DeliversThroughMonitor(t *testing.T) {
 			})
 
 			injectedChan := make(chan vpnConnError)
-			go monitorConnectionErrors(t.Context(), nil, injectedChan, pub)
-
 			l := &Libtelio{
-				injectedErrors: injectedChan,
-				active:         true,
-				currentServer:  vpn.ServerData{NordLynxPublicKey: tt.connectedKey},
+				eventsPublisher: pub,
+				injectedErrors:  injectedChan,
+				active:          true,
+				currentServer:   vpn.ServerData{NordLynxPublicKey: tt.connectedKey},
 			}
+
+			go l.monitorConnectionErrors(t.Context())
 
 			injected := assert.Eventually(t, func() bool {
 				return l.InjectVPNConnectionError(tt.code, tt.inputKey) == nil

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -40,8 +40,10 @@ type mockLib struct{}
 func (mockLib) ConnectToExitNode(teliogo.PublicKey, *[]teliogo.IpNet, *teliogo.SocketAddr) error {
 	return nil
 }
+
 func (mockLib) ConnectToExitNodePostquantum(
-	*string, teliogo.PublicKey, *[]teliogo.IpNet, teliogo.SocketAddr) error {
+	*string, teliogo.PublicKey, *[]teliogo.IpNet, teliogo.SocketAddr,
+) error {
 	return nil
 }
 func (mockLib) DisconnectFromExitNodes() error                                       { return nil }
@@ -794,10 +796,8 @@ func TestMonitorConnectionErrors_PublishesMappedEvent(t *testing.T) {
 	})
 
 	errorsChan := make(chan vpnConnError, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
-	go monitorConnectionErrors(ctx, errorsChan, nil, pub)
+	go monitorConnectionErrors(t.Context(), errorsChan, nil, pub)
 
 	errorsChan <- vpnConnError{code: teliogo.VpnConnectionErrorSuperseded, publicKey: "srv-key"}
 

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -107,11 +107,9 @@ func TestIsConnected(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ch := make(chan state, 1)
 			var connectionEstablishedWG sync.WaitGroup
-			connectionEstablishedWG.Add(1)
-			go func() {
+			connectionEstablishedWG.Go(func() {
 				ch <- test.state
-				connectionEstablishedWG.Done()
-			}()
+			})
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 			defer cancel()
@@ -162,7 +160,7 @@ func Test_TelioDefaultConfig(t *testing.T) {
 	} else {
 		fmt.Println(string(jsn))
 	}
-	var intf interface{}
+	var intf any
 	err = json.Unmarshal(jsn, &intf)
 
 	assert.NoError(t, err)
@@ -557,7 +555,7 @@ func TestLibtelio_connect(t *testing.T) {
 			assert.Equal(t, tt.active, libtelio.active)
 
 			if tt.events > 0 {
-				eventsReceivedChan := make(chan interface{})
+				eventsReceivedChan := make(chan any)
 				go func() {
 					eventsReceivedWG.Wait()
 					close(eventsReceivedChan)
@@ -683,9 +681,7 @@ func TestHandleEvent_ForwardsVPNConnectionError(t *testing.T) {
 	vpnErrorsChan := make(chan vpnConnError, 1)
 	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	callbackHandler.setConnectionMonitoringContext(ctx)
+	callbackHandler.setConnectionMonitoringContext(t.Context())
 
 	connErr := teliogo.VpnConnectionErrorServerMaintenance
 	callbackHandler.handleEvent(teliogo.EventNode{
@@ -718,9 +714,7 @@ func TestHandleEvent_NoVPNConnectionError_DoesNotForwardError(t *testing.T) {
 	vpnErrorsChan := make(chan vpnConnError, 1)
 	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	callbackHandler.setConnectionMonitoringContext(ctx)
+	callbackHandler.setConnectionMonitoringContext(t.Context())
 
 	callbackHandler.handleEvent(teliogo.EventNode{
 		Body: teliogo.TelioNode{
@@ -749,9 +743,7 @@ func TestHandleEvent_DropsVPNConnectionError_WhenMonitorBusy(t *testing.T) {
 	vpnErrorsChan := make(chan vpnConnError, 1)
 	callbackHandler := newTelioCallbackHandler(stateChan, vpnErrorsChan)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	callbackHandler.setConnectionMonitoringContext(ctx)
+	callbackHandler.setConnectionMonitoringContext(t.Context())
 
 	buffered := vpnConnError{code: teliogo.VpnConnectionErrorUnauthenticated}
 	vpnErrorsChan <- buffered
@@ -881,9 +873,7 @@ func TestInjectVPNConnectionError_DeliversThroughMonitor(t *testing.T) {
 			})
 
 			injectedChan := make(chan vpnConnError)
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			go monitorConnectionErrors(ctx, nil, injectedChan, pub)
+			go monitorConnectionErrors(t.Context(), nil, injectedChan, pub)
 
 			l := &Libtelio{
 				injectedErrors: injectedChan,

--- a/test/mock/networker/networker.go
+++ b/test/mock/networker/networker.go
@@ -29,8 +29,9 @@ type Mock struct {
 
 	// ProvidedCredentials contain vpn.Credentials provided to the networker in the last Start call
 	ProvidedCredentials vpn.Credentials
-	// ProvidedCredentials contains vpn.ServerData provided to the networker in the last Start call
+	// ProvidedServerData contains vpn.ServerData provided to the networker in the last Start call
 	ProvidedServerData vpn.ServerData
+	ActiveServerData   *vpn.ServerData
 }
 
 func (m *Mock) Start(
@@ -113,7 +114,12 @@ func (m *Mock) SetLanDiscovery(enabled bool) {
 
 func (*Mock) UnsetFirewall() error { return nil }
 
-func (*Mock) GetConnectionParameters() (vpn.ServerData, bool) { return vpn.ServerData{}, false }
+func (m *Mock) GetConnectionParameters() (vpn.ServerData, bool) {
+	if m.ActiveServerData == nil {
+		return vpn.ServerData{}, false
+	}
+	return *m.ActiveServerData, true
+}
 
 func (*Mock) SetARPIgnore(bool) error { return nil }
 

--- a/test/mock/networker/networker.go
+++ b/test/mock/networker/networker.go
@@ -47,6 +47,7 @@ func (m *Mock) Start(
 	m.ProvidedServerData = serverData
 	return nil
 }
+
 func (m *Mock) Stop() error {
 	if m.StopErr != nil {
 		return m.StopErr


### PR DESCRIPTION
Context:\n\n- ServerMaintenance event reconnects user to a different server\n- if the event is duplicated, we should not react to it\n\nChanges:\n\n- ENS monitoring reconnects the server only if the event is targeting currently connected server, comparison is based on server public key\n- tests\n- code cleanup