### PR TITLE
LVPN-10400: add shadow to connection card, recent servers and settings menu

### DIFF
--- a/gui/lib/settings/settings_wrapper_widget.dart
+++ b/gui/lib/settings/settings_wrapper_widget.dart
@@ -30,8 +30,10 @@ final class SettingsWrapperWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appTheme = context.appTheme;
+    final settingsTheme = context.settingsTheme;
 
     return RoundContainer(
+      shadow: settingsTheme.cardShadow,
       padding: EdgeInsets.zero,
       child: Column(
         children: [

--- a/gui/lib/theme/aurora_design.dart
+++ b/gui/lib/theme/aurora_design.dart
@@ -964,7 +964,9 @@ final class AppBoxShadows {
     BoxShadow(
       offset: Offset(0, 0.5),
       blurRadius: 0,
-      spreadRadius: 0,
+      // Setting a shadow creates a slight halo effect around the Widged which is visible in dark mode. Setting spread
+      // radius to -2 prevents this.
+      spreadRadius: -2,
       color: Color.fromRGBO(255, 255, 255, 0.16),
     ),
   ];

--- a/gui/lib/theme/connection_card_theme.dart
+++ b/gui/lib/theme/connection_card_theme.dart
@@ -144,6 +144,9 @@ final class ConnectionCardTheme extends ThemeExtension<ConnectionCardTheme>
   @override
   final ConnectionCardButtonTheme buttonTheme;
 
+  @override
+  final List<BoxShadow> cardShadow;
+
   ConnectionCardTheme({
     required this.primaryFont,
     required this.mapPadding,
@@ -156,5 +159,6 @@ final class ConnectionCardTheme extends ThemeExtension<ConnectionCardTheme>
     required this.labelTheme,
     required this.iconTheme,
     required this.buttonTheme,
+    required this.cardShadow
   });
 }

--- a/gui/lib/theme/connection_card_theme.tailor.dart
+++ b/gui/lib/theme/connection_card_theme.tailor.dart
@@ -332,6 +332,7 @@ mixin _$ConnectionCardThemeTailorMixin on ThemeExtension<ConnectionCardTheme> {
   ConnectionCardLabelTheme get labelTheme;
   ConnectionCardIconTheme get iconTheme;
   ConnectionCardButtonTheme get buttonTheme;
+  List<BoxShadow> get cardShadow;
 
   @override
   ConnectionCardTheme copyWith({
@@ -346,6 +347,7 @@ mixin _$ConnectionCardThemeTailorMixin on ThemeExtension<ConnectionCardTheme> {
     ConnectionCardLabelTheme? labelTheme,
     ConnectionCardIconTheme? iconTheme,
     ConnectionCardButtonTheme? buttonTheme,
+    List<BoxShadow>? cardShadow,
   }) {
     return ConnectionCardTheme(
       primaryFont: primaryFont ?? this.primaryFont,
@@ -360,6 +362,7 @@ mixin _$ConnectionCardThemeTailorMixin on ThemeExtension<ConnectionCardTheme> {
       labelTheme: labelTheme ?? this.labelTheme,
       iconTheme: iconTheme ?? this.iconTheme,
       buttonTheme: buttonTheme ?? this.buttonTheme,
+      cardShadow: cardShadow ?? this.cardShadow,
     );
   }
 
@@ -383,6 +386,7 @@ mixin _$ConnectionCardThemeTailorMixin on ThemeExtension<ConnectionCardTheme> {
       labelTheme: labelTheme.lerp(other.labelTheme, t),
       iconTheme: iconTheme.lerp(other.iconTheme, t),
       buttonTheme: buttonTheme.lerp(other.buttonTheme, t),
+      cardShadow: t < 0.5 ? cardShadow : other.cardShadow,
     );
   }
 
@@ -425,6 +429,10 @@ mixin _$ConnectionCardThemeTailorMixin on ThemeExtension<ConnectionCardTheme> {
             const DeepCollectionEquality().equals(
               buttonTheme,
               other.buttonTheme,
+            ) &&
+            const DeepCollectionEquality().equals(
+              cardShadow,
+              other.cardShadow,
             ));
   }
 
@@ -443,6 +451,7 @@ mixin _$ConnectionCardThemeTailorMixin on ThemeExtension<ConnectionCardTheme> {
       const DeepCollectionEquality().hash(labelTheme),
       const DeepCollectionEquality().hash(iconTheme),
       const DeepCollectionEquality().hash(buttonTheme),
+      const DeepCollectionEquality().hash(cardShadow),
     );
   }
 }
@@ -462,4 +471,5 @@ extension ConnectionCardThemeBuildContextProps on BuildContext {
   ConnectionCardLabelTheme get labelTheme => connectionCardTheme.labelTheme;
   ConnectionCardIconTheme get iconTheme => connectionCardTheme.iconTheme;
   ConnectionCardButtonTheme get buttonTheme => connectionCardTheme.buttonTheme;
+  List<BoxShadow> get cardShadow => connectionCardTheme.cardShadow;
 }

--- a/gui/lib/theme/servers_list_theme.dart
+++ b/gui/lib/theme/servers_list_theme.dart
@@ -33,6 +33,9 @@ final class ServersListTheme extends ThemeExtension<ServersListTheme>
   @override
   final Color obfuscatedItemBackgroundColor;
 
+  @override
+  final List<BoxShadow> cardShadow;
+
   ServersListTheme({
     required this.flagSize,
     required this.loaderSize,
@@ -43,5 +46,6 @@ final class ServersListTheme extends ThemeExtension<ServersListTheme>
     required this.searchErrorStyle,
     required this.obfuscationSearchWarningStyle,
     required this.obfuscatedItemBackgroundColor,
+    required this.cardShadow,
   });
 }

--- a/gui/lib/theme/servers_list_theme.tailor.dart
+++ b/gui/lib/theme/servers_list_theme.tailor.dart
@@ -19,6 +19,7 @@ mixin _$ServersListThemeTailorMixin on ThemeExtension<ServersListTheme> {
   TextStyle get obfuscationSearchWarningStyle;
   TextStyle get searchErrorStyle;
   Color get obfuscatedItemBackgroundColor;
+  List<BoxShadow> get cardShadow;
 
   @override
   ServersListTheme copyWith({
@@ -31,6 +32,7 @@ mixin _$ServersListThemeTailorMixin on ThemeExtension<ServersListTheme> {
     TextStyle? obfuscationSearchWarningStyle,
     TextStyle? searchErrorStyle,
     Color? obfuscatedItemBackgroundColor,
+    List<BoxShadow>? cardShadow,
   }) {
     return ServersListTheme(
       flagSize: flagSize ?? this.flagSize,
@@ -45,6 +47,7 @@ mixin _$ServersListThemeTailorMixin on ThemeExtension<ServersListTheme> {
       searchErrorStyle: searchErrorStyle ?? this.searchErrorStyle,
       obfuscatedItemBackgroundColor:
           obfuscatedItemBackgroundColor ?? this.obfuscatedItemBackgroundColor,
+      cardShadow: cardShadow ?? this.cardShadow,
     );
   }
 
@@ -82,6 +85,7 @@ mixin _$ServersListThemeTailorMixin on ThemeExtension<ServersListTheme> {
         other.obfuscatedItemBackgroundColor,
         t,
       )!,
+      cardShadow: t < 0.5 ? cardShadow : other.cardShadow,
     );
   }
 
@@ -122,6 +126,10 @@ mixin _$ServersListThemeTailorMixin on ThemeExtension<ServersListTheme> {
             const DeepCollectionEquality().equals(
               obfuscatedItemBackgroundColor,
               other.obfuscatedItemBackgroundColor,
+            ) &&
+            const DeepCollectionEquality().equals(
+              cardShadow,
+              other.cardShadow,
             ));
   }
 
@@ -138,6 +146,7 @@ mixin _$ServersListThemeTailorMixin on ThemeExtension<ServersListTheme> {
       const DeepCollectionEquality().hash(obfuscationSearchWarningStyle),
       const DeepCollectionEquality().hash(searchErrorStyle),
       const DeepCollectionEquality().hash(obfuscatedItemBackgroundColor),
+      const DeepCollectionEquality().hash(cardShadow),
     );
   }
 }
@@ -157,4 +166,5 @@ extension ServersListThemeBuildContextProps on BuildContext {
   TextStyle get searchErrorStyle => serversListTheme.searchErrorStyle;
   Color get obfuscatedItemBackgroundColor =>
       serversListTheme.obfuscatedItemBackgroundColor;
+  List<BoxShadow> get cardShadow => serversListTheme.cardShadow;
 }

--- a/gui/lib/theme/settings_theme.dart
+++ b/gui/lib/theme/settings_theme.dart
@@ -28,6 +28,8 @@ final class SettingsTheme extends ThemeExtension<SettingsTheme>
   // default padding for settings items
   @override
   final EdgeInsets itemPadding;
+  @override
+  final List<BoxShadow> cardShadow;
 
   SettingsTheme({
     required this.itemTitleStyle,
@@ -40,5 +42,6 @@ final class SettingsTheme extends ThemeExtension<SettingsTheme>
     required this.otherProductsSubtitle,
     required this.fwMarkInputSize,
     required this.itemPadding,
+    required this.cardShadow,
   });
 }

--- a/gui/lib/theme/settings_theme.tailor.dart
+++ b/gui/lib/theme/settings_theme.tailor.dart
@@ -20,6 +20,7 @@ mixin _$SettingsThemeTailorMixin on ThemeExtension<SettingsTheme> {
   TextStyle get otherProductsSubtitle;
   double get fwMarkInputSize;
   EdgeInsets get itemPadding;
+  List<BoxShadow> get cardShadow;
 
   @override
   SettingsTheme copyWith({
@@ -33,6 +34,7 @@ mixin _$SettingsThemeTailorMixin on ThemeExtension<SettingsTheme> {
     TextStyle? otherProductsSubtitle,
     double? fwMarkInputSize,
     EdgeInsets? itemPadding,
+    List<BoxShadow>? cardShadow,
   }) {
     return SettingsTheme(
       currentPageNameStyle: currentPageNameStyle ?? this.currentPageNameStyle,
@@ -46,6 +48,7 @@ mixin _$SettingsThemeTailorMixin on ThemeExtension<SettingsTheme> {
           otherProductsSubtitle ?? this.otherProductsSubtitle,
       fwMarkInputSize: fwMarkInputSize ?? this.fwMarkInputSize,
       itemPadding: itemPadding ?? this.itemPadding,
+      cardShadow: cardShadow ?? this.cardShadow,
     );
   }
 
@@ -83,6 +86,7 @@ mixin _$SettingsThemeTailorMixin on ThemeExtension<SettingsTheme> {
       )!,
       fwMarkInputSize: t < 0.5 ? fwMarkInputSize : other.fwMarkInputSize,
       itemPadding: t < 0.5 ? itemPadding : other.itemPadding,
+      cardShadow: t < 0.5 ? cardShadow : other.cardShadow,
     );
   }
 
@@ -130,6 +134,10 @@ mixin _$SettingsThemeTailorMixin on ThemeExtension<SettingsTheme> {
             const DeepCollectionEquality().equals(
               itemPadding,
               other.itemPadding,
+            ) &&
+            const DeepCollectionEquality().equals(
+              cardShadow,
+              other.cardShadow,
             ));
   }
 
@@ -147,6 +155,7 @@ mixin _$SettingsThemeTailorMixin on ThemeExtension<SettingsTheme> {
       const DeepCollectionEquality().hash(otherProductsSubtitle),
       const DeepCollectionEquality().hash(fwMarkInputSize),
       const DeepCollectionEquality().hash(itemPadding),
+      const DeepCollectionEquality().hash(cardShadow),
     );
   }
 }
@@ -163,4 +172,5 @@ extension SettingsThemeBuildContextProps on BuildContext {
   TextStyle get otherProductsSubtitle => settingsTheme.otherProductsSubtitle;
   double get fwMarkInputSize => settingsTheme.fwMarkInputSize;
   EdgeInsets get itemPadding => settingsTheme.itemPadding;
+  List<BoxShadow> get cardShadow => settingsTheme.cardShadow;
 }

--- a/gui/lib/theme/theme.dart
+++ b/gui/lib/theme/theme.dart
@@ -347,6 +347,7 @@ final class NordVpnTheme {
 
   ConnectionCardTheme _connectionCardThemeExt(ThemeMode mode) {
     return ConnectionCardTheme(
+      cardShadow: mode == ThemeMode.light ? AppBoxShadows.lightBevel : AppBoxShadows.darkBevel,
       primaryFont: design.typography.heading.copyWith(
         color: design.semanticColors.textPrimary,
       ),
@@ -513,6 +514,7 @@ final class NordVpnTheme {
         color: design.semanticColors.textSecondary,
       ),
       obfuscatedItemBackgroundColor: design.semanticColors.bgSecondaryActive,
+      cardShadow: mode == ThemeMode.light ? AppBoxShadows.lightBevel : AppBoxShadows.darkBevel,
     );
   }
 
@@ -542,6 +544,7 @@ final class NordVpnTheme {
       ),
       fwMarkInputSize: 250,
       itemPadding: EdgeInsets.symmetric(horizontal: 4, vertical: 16),
+      cardShadow: mode == ThemeMode.light ? AppBoxShadows.lightBevel : AppBoxShadows.darkBevel,
     );
   }
 

--- a/gui/lib/vpn/connection_card.dart
+++ b/gui/lib/vpn/connection_card.dart
@@ -19,6 +19,7 @@ final class ConnectionCard extends StatelessWidget {
     final connectionCardTheme = context.connectionCardTheme;
 
     return RoundContainer(
+      shadow: connectionCardTheme.cardShadow,
       radius: connectionCardTheme.borderRadius,
       padding: connectionCardTheme.mapPadding,
       margin: connectionCardTheme.margin,

--- a/gui/lib/vpn/vpn.dart
+++ b/gui/lib/vpn/vpn.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nordvpn/data/models/connect_arguments.dart';
 import 'package:nordvpn/data/providers/vpn_status_controller.dart';
 import 'package:nordvpn/theme/app_theme.dart';
+import 'package:nordvpn/theme/servers_list_theme.dart';
 import 'package:nordvpn/vpn/servers_list_card.dart';
 import 'package:nordvpn/vpn/connection_card.dart';
 import 'package:nordvpn/widgets/round_container.dart';
@@ -17,6 +18,7 @@ final class VpnWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = context.appTheme;
+    final serversListThme = context.serversListTheme;
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       spacing: theme.bigMargin,
@@ -24,6 +26,7 @@ final class VpnWidget extends ConsumerWidget {
         ConnectionCard(key: VpnWidget.connectionCardKey),
         Expanded(
           child: RoundContainer(
+            shadow: serversListThme.cardShadow,
             margin: EdgeInsets.only(
               top: 0,
               bottom: theme.margin,

--- a/gui/lib/widgets/round_container.dart
+++ b/gui/lib/widgets/round_container.dart
@@ -14,6 +14,7 @@ final class RoundContainer extends StatelessWidget {
   final EdgeInsetsGeometry? margin;
   final BorderRadius? radius;
   final Color? color;
+  final List<BoxShadow>? shadow;
 
   const RoundContainer({
     super.key,
@@ -27,6 +28,7 @@ final class RoundContainer extends StatelessWidget {
     this.margin,
     this.radius,
     this.color,
+    this.shadow,
   });
 
   @override
@@ -46,6 +48,7 @@ final class RoundContainer extends StatelessWidget {
       decoration: BoxDecoration(
         color: color ?? theme.colorScheme.surface,
         borderRadius: radius ?? appTheme.borderRadiusMedium,
+        boxShadow: shadow,
       ),
       margin: margin ?? EdgeInsets.all(appTheme.margin),
       child: child,


### PR DESCRIPTION
Connection card/recent servers and settings menu are all rounded container, which cannot be decorated. In order to add a shadow, a decorated container parent was added for each of them.