### PR TITLE
LVPN-10738: Don't log sensitive values when logging in

### DIFF
--- a/core/authentication.go
+++ b/core/authentication.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -11,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/response"
-	"github.com/NordSecurity/nordvpn-linux/log"
 )
 
 // Authentication is responsible for verifying user's identity.
@@ -55,18 +55,23 @@ func (o *OAuth2) Login(regularLogin bool) (string, error) {
 		return "", err
 	}
 
-	query := url.Values{}
-	query.Add("challenge", o.challenge)
+	preferredFlow := "registration"
 	if regularLogin {
-		query.Add("preferred_flow", "login")
-	} else {
-		query.Add("preferred_flow", "registration")
+		preferredFlow = "login"
 	}
-	query.Add("redirect_flow", "default")
-	path.RawQuery = query.Encode()
-	log.Info("oauth2 login url", path.String())
 
-	req, err := http.NewRequest(http.MethodPost, path.String(), nil)
+	jsonBody, err := json.Marshal(loginBody{
+		Challenge:     o.challenge,
+		PreferredFlow: preferredFlow,
+		RedirectFlow:  "default",
+	})
+	if err != nil {
+		return "", err
+	}
+
+	reqBody := bytes.NewReader(jsonBody)
+
+	req, err := http.NewRequest(http.MethodPost, path.String(), reqBody)
 	if err != nil {
 		return "", err
 	}
@@ -122,7 +127,9 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 }
 
 func (o *OAuth2) doValidatedRequest(req *http.Request, errContext string) ([]byte, error) {
-	req.Header.Set("Content-Type", "application/json")
+	if req.Method != http.MethodGet {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := o.client.Do(req)
 	if err != nil {
@@ -163,4 +170,10 @@ func newProofKeyPair(length int) (string, string, error) {
 
 	challenge := hex.EncodeToString(hasher.Sum(nil))
 	return verifier, challenge, nil
+}
+
+type loginBody struct {
+	Challenge     string `json:"challenge"`
+	PreferredFlow string `json:"preferred_flow"`
+	RedirectFlow  string `json:"redirect_flow"`
 }

--- a/core/authentication_test.go
+++ b/core/authentication_test.go
@@ -1,10 +1,10 @@
 package core
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -29,10 +29,13 @@ func TestOAuth2_Login(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusOK),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				url, err := url.Parse(r.URL.String())
-				assert.NoError(t, err)
-				assert.Equal(t, url.Path, urlOAuth2Login)
-				assert.True(t, url.Query().Get("preferred_flow") == "login")
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, r.URL.Path, urlOAuth2Login)
+				var body loginBody
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.NotEmpty(t, body.Challenge)
+				assert.Equal(t, "login", body.PreferredFlow)
+				assert.Equal(t, "default", body.RedirectFlow)
 				data, err := os.ReadFile("testdata/login_200.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)
@@ -47,10 +50,13 @@ func TestOAuth2_Login(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusBadRequest),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				url, err := url.Parse(r.URL.String())
-				assert.NoError(t, err)
-				assert.Equal(t, url.Path, urlOAuth2Login)
-				assert.True(t, url.Query().Get("preferred_flow") == "login")
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, r.URL.Path, urlOAuth2Login)
+				var body loginBody
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.NotEmpty(t, body.Challenge)
+				assert.Equal(t, "login", body.PreferredFlow)
+				assert.Equal(t, "default", body.RedirectFlow)
 				data, err := os.ReadFile("testdata/login_400.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)
@@ -65,10 +71,13 @@ func TestOAuth2_Login(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusOK),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				url, err := url.Parse(r.URL.String())
-				assert.NoError(t, err)
-				assert.Equal(t, url.Path, urlOAuth2Login)
-				assert.True(t, url.Query().Get("preferred_flow") == "registration")
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, r.URL.Path, urlOAuth2Login)
+				var body loginBody
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.NotEmpty(t, body.Challenge)
+				assert.Equal(t, "registration", body.PreferredFlow)
+				assert.Equal(t, "default", body.RedirectFlow)
 				data, err := os.ReadFile("testdata/login_200.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)
@@ -258,7 +267,9 @@ func TestOAuth2_Token(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusOK),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				assert.True(t, strings.HasPrefix(r.URL.String(), urlOAuth2Token))
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, r.URL.Path, urlOAuth2Token)
+				assert.Equal(t, "exchange", r.URL.Query().Get("exchange_token"))
 				data, err := os.ReadFile("testdata/token_200.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)
@@ -271,7 +282,9 @@ func TestOAuth2_Token(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusBadRequest),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				assert.True(t, strings.HasPrefix(r.URL.String(), urlOAuth2Token))
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, r.URL.Path, urlOAuth2Token)
+				assert.Equal(t, "exchange", r.URL.Query().Get("exchange_token"))
 				data, err := os.ReadFile("testdata/token_400.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)
@@ -285,7 +298,9 @@ func TestOAuth2_Token(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusNotFound),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				assert.True(t, strings.HasPrefix(r.URL.String(), urlOAuth2Token))
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, r.URL.Path, urlOAuth2Token)
+				assert.Equal(t, "exchange", r.URL.Query().Get("exchange_token"))
 				data, err := os.ReadFile("testdata/token_404.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)

--- a/events/logger/logger.go
+++ b/events/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -15,6 +16,11 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
+)
+
+var (
+	sensitiveHeaders = [...]string{"Authorization"}
+	sensitiveParams  = [...]string{"attempt", "verifier", "exchange_token"}
 )
 
 // Subscriber is a subscriber for logging debug messages, info messages
@@ -115,20 +121,21 @@ func dataRequestAPIToString(
 	data events.DataRequestAPI,
 	reqBody []byte,
 	respBody []byte,
-	hideSensitiveHeaders bool,
+	hideSensitiveValues bool,
 ) string {
 	b := strings.Builder{}
-	headers := processHeaders(hideSensitiveHeaders, data.Request.Header)
 	fmt.Fprintf(&b, "Duration: %s\n", data.Duration)
 	if data.Request != nil {
+		headers := processHeaders(hideSensitiveValues, data.Request.Header)
 		tmpBody := "(binary data)"
 		if !isRequestBinary(data.Request) {
 			tmpBody = string(reqBody)
 		}
+		reqURL := processQueryParams(hideSensitiveValues, data.Request.URL)
 		fmt.Fprintf(&b, "Request: %s %s %s %s %s\n",
 			data.Request.Proto,
 			data.Request.Method,
-			data.Request.URL,
+			reqURL,
 			headers,
 			tmpBody)
 	}
@@ -156,15 +163,27 @@ func processHeaders(hide bool, headers http.Header) http.Header {
 		return headers
 	}
 	headers = headers.Clone()
-	sensitiveHeaders := []string{
-		"Authorization",
-	}
 	for _, header := range sensitiveHeaders {
 		if headers.Get(header) != "" {
 			headers.Set(header, "hidden")
 		}
 	}
 	return headers
+}
+
+func processQueryParams(hide bool, u *url.URL) *url.URL {
+	if !hide || u == nil {
+		return u
+	}
+	clone := *u
+	query := clone.Query()
+	for _, param := range sensitiveParams {
+		if query.Get(param) != "" {
+			query.Set(param, "hidden")
+		}
+	}
+	clone.RawQuery = query.Encode()
+	return &clone
 }
 
 func getSystemInfo() string {

--- a/events/logger/logger.go
+++ b/events/logger/logger.go
@@ -119,22 +119,21 @@ func dataRequestAPIToString(
 ) string {
 	b := strings.Builder{}
 	headers := processHeaders(hideSensitiveHeaders, data.Request.Header)
-	b.WriteString(fmt.Sprintf("Duration: %s\n", data.Duration))
+	fmt.Fprintf(&b, "Duration: %s\n", data.Duration)
 	if data.Request != nil {
 		tmpBody := "(binary data)"
 		if !isRequestBinary(data.Request) {
 			tmpBody = string(reqBody)
 		}
-		b.WriteString(fmt.Sprintf("Request: %s %s %s %s %s\n",
+		fmt.Fprintf(&b, "Request: %s %s %s %s %s\n",
 			data.Request.Proto,
 			data.Request.Method,
 			data.Request.URL,
 			headers,
-			tmpBody,
-		))
+			tmpBody)
 	}
 	if data.Error != nil {
-		b.WriteString(fmt.Sprintf("Error: %s\n", data.Error))
+		fmt.Fprintf(&b, "Error: %s\n", data.Error)
 	}
 	if data.Response != nil {
 		tmpBody := "(binary data)"
@@ -142,12 +141,11 @@ func dataRequestAPIToString(
 		if !isResponseBinary(data.Response) {
 			tmpBody = string(respBody)
 		}
-		b.WriteString(fmt.Sprintf("Response: %s %d - %s %s\n",
+		fmt.Fprintf(&b, "Response: %s %d - %s %s\n",
 			data.Response.Proto,
 			data.Response.StatusCode,
 			data.Response.Header,
-			tmpBody,
-		))
+			tmpBody)
 	}
 
 	return b.String()

--- a/events/logger/logger_test.go
+++ b/events/logger/logger_test.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -115,4 +116,150 @@ func Test_dataRequestAPIToString(t *testing.T) {
 			assert.True(t, strings.Contains(rc, string(test.responseBody)))
 		}
 	}
+}
+
+func Test_processHeaders(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name     string
+		hide     bool
+		input    http.Header
+		expected http.Header
+	}{
+		{
+			name:     "hide=false returns headers unchanged",
+			hide:     false,
+			input:    http.Header{"Authorization": []string{"Bearer secret"}},
+			expected: http.Header{"Authorization": []string{"Bearer secret"}},
+		},
+		{
+			name:     "hides Authorization header",
+			hide:     true,
+			input:    http.Header{"Authorization": []string{"Bearer secret"}},
+			expected: http.Header{"Authorization": []string{"hidden"}},
+		},
+		{
+			name:     "absent Authorization header is not added",
+			hide:     true,
+			input:    http.Header{"Content-Type": []string{"application/json"}},
+			expected: http.Header{"Content-Type": []string{"application/json"}},
+		},
+		{
+			name:     "non-sensitive headers are not modified",
+			hide:     true,
+			input:    http.Header{"Authorization": []string{"Bearer secret"}, "Content-Type": []string{"application/json"}},
+			expected: http.Header{"Authorization": []string{"hidden"}, "Content-Type": []string{"application/json"}},
+		},
+		{
+			name:  "does not modify original headers",
+			hide:  true,
+			input: http.Header{"Authorization": []string{"Bearer secret"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := tt.input.Clone()
+			result := processHeaders(tt.hide, tt.input)
+			if tt.expected != nil {
+				assert.Equal(t, tt.expected, result)
+			}
+			assert.Equal(t, original, tt.input)
+		})
+	}
+}
+
+func Test_processQueryParams(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name          string
+		hide          bool
+		input         *url.URL
+		expectedQuery url.Values
+	}{
+		{
+			name:          "hide=false returns URL unchanged",
+			hide:          false,
+			input:         mustParse(t, "https://example.com?exchange_token=secret&attempt=abc&verifier=lel"),
+			expectedQuery: url.Values{"exchange_token": []string{"secret"}, "attempt": []string{"abc"}, "verifier": []string{"lel"}},
+		},
+		{
+			name:          "nil URL is returned as-is",
+			hide:          true,
+			input:         nil,
+			expectedQuery: nil,
+		},
+		{
+			name:          "hides attempt",
+			hide:          true,
+			input:         mustParse(t, "https://example.com?attempt=lel"),
+			expectedQuery: url.Values{"attempt": []string{"hidden"}},
+		},
+		{
+			name:          "hides verifier",
+			hide:          true,
+			input:         mustParse(t, "https://example.com?verifier=xyz"),
+			expectedQuery: url.Values{"verifier": []string{"hidden"}},
+		},
+		{
+			name:          "hides exchange_token",
+			hide:          true,
+			input:         mustParse(t, "https://example.com?exchange_token=secret"),
+			expectedQuery: url.Values{"exchange_token": []string{"hidden"}},
+		},
+		{
+			name:          "hides all sensitive params",
+			hide:          true,
+			input:         mustParse(t, "https://example.com?attempt=abc&verifier=xyz&exchange_token=secret"),
+			expectedQuery: url.Values{"attempt": []string{"hidden"}, "verifier": []string{"hidden"}, "exchange_token": []string{"hidden"}},
+		},
+		{
+			name:          "non-sensitive params are not modified",
+			hide:          true,
+			input:         mustParse(t, "https://example.com?attempt=abc&foo=bar"),
+			expectedQuery: url.Values{"attempt": []string{"hidden"}, "foo": []string{"bar"}},
+		},
+		{
+			name:          "does not modify original URL",
+			hide:          true,
+			input:         mustParse(t, "https://example.com?exchange_token=secret"),
+			expectedQuery: url.Values{"exchange_token": []string{"hidden"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var originalRaw string
+			if tt.input != nil {
+				originalRaw = tt.input.RawQuery
+			}
+
+			result := processQueryParams(tt.hide, tt.input)
+
+			if tt.input == nil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.Equal(t, originalRaw, tt.input.RawQuery)
+
+			if tt.hide {
+				assert.Equal(t, tt.expectedQuery, result.Query())
+			} else {
+				assert.Equal(t, tt.input, result)
+				assert.Equal(t, tt.expectedQuery, result.Query())
+			}
+		})
+	}
+}
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
 }

--- a/events/logger/logger_test.go
+++ b/events/logger/logger_test.go
@@ -65,8 +65,8 @@ const (
 )
 
 func setupResponseHeaders(headersStr string) http.Header {
-	result := http.Header{} // map[string]string
-	for _, pair := range strings.Split(headersStr, " ") {
+	result := http.Header{}
+	for pair := range strings.SplitSeq(headersStr, " ") {
 		parts := strings.SplitN(pair, ":", 2)
 		if len(parts) == 2 {
 			key := strings.TrimSpace(parts[0])


### PR DESCRIPTION
Context:

- according to API docs, we should do POST with body instead of GET with params for logging endpoint
- token endpoint does not accept GET, so for this one, values redaction is done

Changes:

- introduce `loginBody` struct to serialize body for logging requests and change method to POST, redact sensitive headers from GET requests, tests adjustments
- cleanup