### PR TITLE
LVPN-10672: KS earlier

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -757,10 +757,10 @@ func main() {
 		}
 	}()
 
+	rpc.StartKillSwitch()
 	rpc.StartJobs(statePublisher, heartBeatSubject)
 	rpc.StartRemoteConfigLoaderJob(rcConfig)
 	meshService.StartJobs()
-	rpc.StartKillSwitch()
 	if internal.IsSystemd() {
 		go rpc.StartSystemShutdownMonitor()
 	}


### PR DESCRIPTION
Currently we would start our killswitch asynchronously after we had already started doing some http requests to the api. This would cause the responses to our requests to get dropped by the firewall as they were not connmarked before leaving the client, causing a dns timeout of 5s to stall every http request. 

This PR fixes this issue by moving the killswitch enabling earlier, before http requests are started