### PR TITLE
Clear GUI logs on package purge.

### DIFF
--- a/gui/scripts/build_package.sh
+++ b/gui/scripts/build_package.sh
@@ -134,13 +134,13 @@ envsubst <templates/nordvpn-gui_template.desktop >"${APP_BUNDLE_DIR}/${NAME}.des
 
 # create install scripts
 mkdir -p "${APP_BUNDLE_DIR}"/scriptlets/{deb,rpm}
-envsubst <templates/scriptlets/deb/postinst_template >"${APP_BUNDLE_DIR}"/scriptlets/deb/postinst
-envsubst <templates/scriptlets/deb/prerm_template >"${APP_BUNDLE_DIR}"/scriptlets/deb/prerm
-envsubst <templates/scriptlets/deb/postrm_template >"${APP_BUNDLE_DIR}"/scriptlets/deb/postrm
+envsubst '${INSTALL_SCRIPT} ${SUCCESS_INSTALL_MESSAGE}' <templates/scriptlets/deb/postinst_template >"${APP_BUNDLE_DIR}"/scriptlets/deb/postinst
+envsubst '' <templates/scriptlets/deb/prerm_template >"${APP_BUNDLE_DIR}"/scriptlets/deb/prerm
+envsubst '${UNINSTALL_SCRIPT}' <templates/scriptlets/deb/postrm_template >"${APP_BUNDLE_DIR}"/scriptlets/deb/postrm
 
-envsubst <templates/scriptlets/rpm/post_template >"${APP_BUNDLE_DIR}"/scriptlets/rpm/post
-envsubst <templates/scriptlets/rpm/preun_template >"${APP_BUNDLE_DIR}"/scriptlets/rpm/preun
-envsubst <templates/scriptlets/rpm/postun_template >"${APP_BUNDLE_DIR}"/scriptlets/rpm/postun
+envsubst '${INSTALL_SCRIPT} ${SUCCESS_INSTALL_MESSAGE}' <templates/scriptlets/rpm/post_template >"${APP_BUNDLE_DIR}"/scriptlets/rpm/post
+envsubst '' <templates/scriptlets/rpm/preun_template >"${APP_BUNDLE_DIR}"/scriptlets/rpm/preun
+envsubst '${UNINSTALL_SCRIPT}' <templates/scriptlets/rpm/postun_template >"${APP_BUNDLE_DIR}"/scriptlets/rpm/postun
 
 # value expected by `nfpm` template and must be given from outside, break here if not set
 echo "${VERSION_DATE}"

--- a/gui/templates/scriptlets/deb/postrm_template
+++ b/gui/templates/scriptlets/deb/postrm_template
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
 
 case "$1" in
-    purge|remove)
-    ${UNINSTALL_SCRIPT}
-    
+    purge)
+        usrInfo=$(
+        while IFS=: read -r user pass uid gid gecos home shell; do
+            if [ "$uid" -ge 1000 ] && [ "$uid" -le 2000 ]; then
+                echo "$home"
+            fi
+        done < /etc/passwd
+        )
+        (
+            IFS=$'\n'
+            for usrLine in $usrInfo; do
+                # for each user remove gui logs
+                rm -f $usrLine/.cache/nordvpn/nordvpn-gui.log
+            done
+        )
+    ;&  # fallthrough
+    remove)
+        ${UNINSTALL_SCRIPT}
     ;;
     disappear|upgrade|failed-upgrade|abort-install|abort-upgrade)
     ;;


### PR DESCRIPTION
## Issue

I noticed that on Debian systems, purging the `nordvpn-gui` package leaves behind GUI log dumps in the users' home directories, which should not be the case.

## Solution

Updated Debian  `postrm_template` script to distinguish and separate `remove` and `purge` actions. 

During a `purge` action, the script now ensures that all GUI-side log dumps are cleared from users' home directories  without affecting the main `nordvpn` package data. The existing `remove` action behavior remains unchanged.

The same behavior is noticeable for RPM packages, but the `postun_template` script was left unchanged, since RPM does not provide any equivalent purge action (dumps are left in users' directories).

Additionally, updated the `build_package.sh` script to call `envsubst` with an explicit variable list (or an empty list where appropriate). This ensures that only intended variables are substituted, while preserving  shell variables used in the generated template scripts.