### PR TITLE
LVPN-10744: Use post for token exchange

### DIFF
--- a/core/authentication.go
+++ b/core/authentication.go
@@ -101,13 +101,16 @@ func (o *OAuth2) Token(exchangeToken string) (*LoginResponse, error) {
 		return nil, err
 	}
 
-	query := url.Values{}
-	query.Add("attempt", o.attempt)
-	query.Add("verifier", o.verifier)
-	query.Add("exchange_token", exchangeToken)
-	path.RawQuery = query.Encode()
+	jsonBody, err := json.Marshal(tokenBody{
+		Attempt:       o.attempt,
+		Verifier:      o.verifier,
+		ExchangeToken: exchangeToken,
+	})
+	if err != nil {
+		return nil, err
+	}
 
-	req, err := http.NewRequest(http.MethodGet, path.String(), nil)
+	req, err := http.NewRequest(http.MethodPost, path.String(), bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, err
 	}
@@ -176,4 +179,10 @@ type loginBody struct {
 	Challenge     string `json:"challenge"`
 	PreferredFlow string `json:"preferred_flow"`
 	RedirectFlow  string `json:"redirect_flow"`
+}
+
+type tokenBody struct {
+	Attempt       string `json:"attempt"`
+	Verifier      string `json:"verifier"`
+	ExchangeToken string `json:"exchange_token"`
 }

--- a/core/authentication_test.go
+++ b/core/authentication_test.go
@@ -267,9 +267,11 @@ func TestOAuth2_Token(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusOK),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, http.MethodPost, r.Method)
 				assert.Equal(t, r.URL.Path, urlOAuth2Token)
-				assert.Equal(t, "exchange", r.URL.Query().Get("exchange_token"))
+				var body tokenBody
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, "exchange", body.ExchangeToken)
 				data, err := os.ReadFile("testdata/token_200.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)
@@ -282,9 +284,11 @@ func TestOAuth2_Token(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusBadRequest),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, http.MethodPost, r.Method)
 				assert.Equal(t, r.URL.Path, urlOAuth2Token)
-				assert.Equal(t, "exchange", r.URL.Query().Get("exchange_token"))
+				var body tokenBody
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, "exchange", body.ExchangeToken)
 				data, err := os.ReadFile("testdata/token_400.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)
@@ -298,9 +302,11 @@ func TestOAuth2_Token(t *testing.T) {
 		{
 			name: http.StatusText(http.StatusNotFound),
 			handler: func(rw http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, http.MethodPost, r.Method)
 				assert.Equal(t, r.URL.Path, urlOAuth2Token)
-				assert.Equal(t, "exchange", r.URL.Query().Get("exchange_token"))
+				var body tokenBody
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, "exchange", body.ExchangeToken)
 				data, err := os.ReadFile("testdata/token_404.json")
 				if err != nil {
 					rw.WriteHeader(http.StatusInternalServerError)

--- a/events/logger/logger.go
+++ b/events/logger/logger.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/netip"
-	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -18,10 +17,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/log"
 )
 
-var (
-	sensitiveHeaders = [...]string{"Authorization"}
-	sensitiveParams  = [...]string{"attempt", "verifier", "exchange_token"}
-)
+var sensitiveHeaders = [...]string{"Authorization"}
 
 // Subscriber is a subscriber for logging debug messages, info messages
 // and error messages
@@ -131,11 +127,10 @@ func dataRequestAPIToString(
 		if !isRequestBinary(data.Request) {
 			tmpBody = string(reqBody)
 		}
-		reqURL := processQueryParams(hideSensitiveValues, data.Request.URL)
 		fmt.Fprintf(&b, "Request: %s %s %s %s %s\n",
 			data.Request.Proto,
 			data.Request.Method,
-			reqURL,
+			data.Request.URL,
 			headers,
 			tmpBody)
 	}
@@ -169,21 +164,6 @@ func processHeaders(hide bool, headers http.Header) http.Header {
 		}
 	}
 	return headers
-}
-
-func processQueryParams(hide bool, u *url.URL) *url.URL {
-	if !hide || u == nil {
-		return u
-	}
-	clone := *u
-	query := clone.Query()
-	for _, param := range sensitiveParams {
-		if query.Get(param) != "" {
-			query.Set(param, "hidden")
-		}
-	}
-	clone.RawQuery = query.Encode()
-	return &clone
 }
 
 func getSystemInfo() string {

--- a/events/logger/logger_test.go
+++ b/events/logger/logger_test.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"net/http"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -168,98 +167,4 @@ func Test_processHeaders(t *testing.T) {
 			assert.Equal(t, original, tt.input)
 		})
 	}
-}
-
-func Test_processQueryParams(t *testing.T) {
-	category.Set(t, category.Unit)
-
-	tests := []struct {
-		name          string
-		hide          bool
-		input         *url.URL
-		expectedQuery url.Values
-	}{
-		{
-			name:          "hide=false returns URL unchanged",
-			hide:          false,
-			input:         mustParse(t, "https://example.com?exchange_token=secret&attempt=abc&verifier=lel"),
-			expectedQuery: url.Values{"exchange_token": []string{"secret"}, "attempt": []string{"abc"}, "verifier": []string{"lel"}},
-		},
-		{
-			name:          "nil URL is returned as-is",
-			hide:          true,
-			input:         nil,
-			expectedQuery: nil,
-		},
-		{
-			name:          "hides attempt",
-			hide:          true,
-			input:         mustParse(t, "https://example.com?attempt=lel"),
-			expectedQuery: url.Values{"attempt": []string{"hidden"}},
-		},
-		{
-			name:          "hides verifier",
-			hide:          true,
-			input:         mustParse(t, "https://example.com?verifier=xyz"),
-			expectedQuery: url.Values{"verifier": []string{"hidden"}},
-		},
-		{
-			name:          "hides exchange_token",
-			hide:          true,
-			input:         mustParse(t, "https://example.com?exchange_token=secret"),
-			expectedQuery: url.Values{"exchange_token": []string{"hidden"}},
-		},
-		{
-			name:          "hides all sensitive params",
-			hide:          true,
-			input:         mustParse(t, "https://example.com?attempt=abc&verifier=xyz&exchange_token=secret"),
-			expectedQuery: url.Values{"attempt": []string{"hidden"}, "verifier": []string{"hidden"}, "exchange_token": []string{"hidden"}},
-		},
-		{
-			name:          "non-sensitive params are not modified",
-			hide:          true,
-			input:         mustParse(t, "https://example.com?attempt=abc&foo=bar"),
-			expectedQuery: url.Values{"attempt": []string{"hidden"}, "foo": []string{"bar"}},
-		},
-		{
-			name:          "does not modify original URL",
-			hide:          true,
-			input:         mustParse(t, "https://example.com?exchange_token=secret"),
-			expectedQuery: url.Values{"exchange_token": []string{"hidden"}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var originalRaw string
-			if tt.input != nil {
-				originalRaw = tt.input.RawQuery
-			}
-
-			result := processQueryParams(tt.hide, tt.input)
-
-			if tt.input == nil {
-				assert.Nil(t, result)
-				return
-			}
-
-			assert.Equal(t, originalRaw, tt.input.RawQuery)
-
-			if tt.hide {
-				assert.Equal(t, tt.expectedQuery, result.Query())
-			} else {
-				assert.Equal(t, tt.input, result)
-				assert.Equal(t, tt.expectedQuery, result.Query())
-			}
-		})
-	}
-}
-
-func mustParse(t *testing.T, raw string) *url.URL {
-	t.Helper()
-	u, err := url.Parse(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return u
 }


### PR DESCRIPTION
Context:

- follow up of this one: https://github.com/NordSecurity/nordvpn-linux/pull/1596

Changes:

- token exchange endpoint now uses `POST` instead of `GET`
- removal of query params cleanup as it's a dead code now