### PR TITLE
LVPN-10857: Fix meshnet tests

### DIFF
--- a/meshnet/server.go
+++ b/meshnet/server.go
@@ -2028,7 +2028,7 @@ func MakePeerMaps(peers *pb.PeerList) (map[string]*pb.Peer, map[string]*pb.Peer)
 	return peerPubkeyToPeer, peerNameToPeer
 }
 
-// hasRoutableAddress returns true when at least one IP is globally routable.
+// hasRoutableAddress returns true when at least one IP is globally routable, false otherwise.
 // Link-local (fe80::/10, 169.254.0.0/16) and loopback addresses are excluded:
 // they may be returned by host-local resolvers (e.g. myhostname NSS module or
 // Docker DNS forwarding to the host) and do not conflict with meshnet routing.

--- a/meshnet/server.go
+++ b/meshnet/server.go
@@ -2036,12 +2036,9 @@ func hasRoutableAddress(ips []net.IP, err error) bool {
 	if err != nil {
 		return false
 	}
-	for _, ip := range ips {
-		if !ip.IsLinkLocalUnicast() && !ip.IsLoopback() {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(ips, func(ip net.IP) bool {
+		return !ip.IsLinkLocalUnicast() && !ip.IsLoopback()
+	})
 }
 
 func changeNicknameError(code pb.ChangeNicknameErrorCode) *pb.ChangeNicknameResponse {

--- a/meshnet/server.go
+++ b/meshnet/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -1067,8 +1068,7 @@ func (s *Server) ChangePeerNickname(
 		// resolve the new nickname only if old and new are not case insensitive equal
 		if !strings.EqualFold(peer.Nickname, req.Nickname) {
 			// check that the DNS name is not already used
-			ips, err := s.nameservers.LookupIP(req.Nickname)
-			if err == nil && len(ips) != 0 {
+			if hasRoutableAddress(s.nameservers.LookupIP(req.Nickname)) {
 				return &pb.ChangeNicknameResponse{
 					Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
 						ChangeNicknameErrorCode: pb.ChangeNicknameErrorCode_DOMAIN_NAME_EXISTS,
@@ -1147,11 +1147,11 @@ func (s *Server) ChangeMachineNickname(
 		if cfg.MeshDevice.Nickname == req.Nickname {
 			return changeNicknameError(pb.ChangeNicknameErrorCode_SAME_NICKNAME), nil
 		}
+
 		// resolve the new nickname only if old and new are not case insensitive equal
 		if !strings.EqualFold(cfg.MeshDevice.Nickname, req.Nickname) {
 			// check that the DNS name is not already used
-			ips, err := s.nameservers.LookupIP(req.Nickname)
-			if err == nil && len(ips) != 0 {
+			if hasRoutableAddress(s.nameservers.LookupIP(req.Nickname)) {
 				return changeNicknameError(pb.ChangeNicknameErrorCode_DOMAIN_NAME_EXISTS), nil
 			}
 		}
@@ -1613,7 +1613,6 @@ func (s *Server) DenyFileshare(
 	}, nil
 }
 
-// AllowFileshare requests from the peer
 func (s *Server) EnableAutomaticFileshare(
 	ctx context.Context,
 	req *pb.UpdatePeerRequest,
@@ -1806,9 +1805,7 @@ func (s *Server) Connect(
 	_ context.Context,
 	req *pb.UpdatePeerRequest,
 ) (*pb.ConnectResponse, error) {
-	var (
-		resp *pb.ConnectResponse
-	)
+	var resp *pb.ConnectResponse
 	if !s.connectContext.TryExecuteWith(func(ctx context.Context) {
 		resp = s.connect(ctx, req)
 	}) {
@@ -2030,6 +2027,23 @@ func MakePeerMaps(peers *pb.PeerList) (map[string]*pb.Peer, map[string]*pb.Peer)
 	}
 	return peerPubkeyToPeer, peerNameToPeer
 }
+
+// hasRoutableAddress returns true when at least one IP is globally routable.
+// Link-local (fe80::/10, 169.254.0.0/16) and loopback addresses are excluded:
+// they may be returned by host-local resolvers (e.g. myhostname NSS module or
+// Docker DNS forwarding to the host) and do not conflict with meshnet routing.
+func hasRoutableAddress(ips []net.IP, err error) bool {
+	if err != nil {
+		return false
+	}
+	for _, ip := range ips {
+		if !ip.IsLinkLocalUnicast() && !ip.IsLoopback() {
+			return true
+		}
+	}
+	return false
+}
+
 func changeNicknameError(code pb.ChangeNicknameErrorCode) *pb.ChangeNicknameResponse {
 	return &pb.ChangeNicknameResponse{
 		Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{

--- a/meshnet/server_test.go
+++ b/meshnet/server_test.go
@@ -55,6 +55,7 @@ func (meshRenewChecker) IsVPNExpired() (bool, error) { return false, nil }
 func (meshRenewChecker) GetDedicatedIPServices() ([]auth.DedicatedIPService, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
+
 func (meshRenewChecker) GetDedicatedServerService() (auth.DedicatedServerService, error) {
 	return auth.DedicatedServerService{}, fmt.Errorf("Not implemented")
 }
@@ -1015,6 +1016,46 @@ func TestServer_Peer_Nickname(t *testing.T) {
 			},
 		},
 		{
+			name: "succeeds when nickname resolves only to link-local address",
+			peersList: []mesh.MachinePeer{
+				{
+					ID: uuid.MustParse(exampleUUID1),
+				},
+			},
+			peerId:           exampleUUID1,
+			newNickname:      "peer1",
+			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.ParseIP("fe80::1")}},
+			expectedResponse: changedSuccessfully,
+		},
+		{
+			name: "succeeds when nickname resolves only to loopback address",
+			peersList: []mesh.MachinePeer{
+				{
+					ID: uuid.MustParse(exampleUUID1),
+				},
+			},
+			peerId:           exampleUUID1,
+			newNickname:      "peer1",
+			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.ParseIP("127.0.0.1")}},
+			expectedResponse: changedSuccessfully,
+		},
+		{
+			name: "fails when nickname resolves to routable address alongside link-local",
+			peersList: []mesh.MachinePeer{
+				{
+					ID: uuid.MustParse(exampleUUID1),
+				},
+			},
+			peerId:           exampleUUID1,
+			newNickname:      "peer1",
+			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.ParseIP("fe80::1"), net.ParseIP("1.2.3.4")}},
+			expectedResponse: &pb.ChangeNicknameResponse{
+				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
+					ChangeNicknameErrorCode: pb.ChangeNicknameErrorCode_DOMAIN_NAME_EXISTS,
+				},
+			},
+		},
+		{
 			name: "successful change nickname for same value but different caps",
 			peersList: []mesh.MachinePeer{
 				{
@@ -1197,6 +1238,31 @@ func TestServer_Current_Machine_Nickname(t *testing.T) {
 			newNickname:      "peer1",
 			machine:          mesh.Machine{SupportsRouting: true},
 			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.IPv4bcast}},
+			expectedResponse: &pb.ChangeNicknameResponse{
+				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
+					ChangeNicknameErrorCode: pb.ChangeNicknameErrorCode_DOMAIN_NAME_EXISTS,
+				},
+			},
+		},
+		{
+			name:             "succeeds when nickname resolves only to link-local address",
+			newNickname:      "peer1",
+			machine:          mesh.Machine{SupportsRouting: true},
+			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.ParseIP("fe80::1")}},
+			expectedResponse: changedSuccessfully,
+		},
+		{
+			name:             "succeeds when nickname resolves only to loopback address",
+			newNickname:      "peer1",
+			machine:          mesh.Machine{SupportsRouting: true},
+			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.ParseIP("127.0.0.1")}},
+			expectedResponse: changedSuccessfully,
+		},
+		{
+			name:             "fails when nickname resolves to routable address alongside link-local",
+			newNickname:      "peer1",
+			machine:          mesh.Machine{SupportsRouting: true},
+			reservedDNSNames: mock.RegisteredDomainsList{"peer1": []net.IP{net.ParseIP("fe80::1"), net.ParseIP("1.2.3.4")}},
 			expectedResponse: &pb.ChangeNicknameResponse{
 				Response: &pb.ChangeNicknameResponse_ChangeNicknameErrorCode{
 					ChangeNicknameErrorCode: pb.ChangeNicknameErrorCode_DOMAIN_NAME_EXISTS,

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -331,6 +331,8 @@ def test_direct_connection_rtt_and_loss():
 def test_incoming_connections():
     """Manual TC: LVPN-1259"""
 
+    meshnet.are_peers_connected(ssh_client)
+
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname
     peer_hostname = peer_list.get_external_peer().hostname


### PR DESCRIPTION
Context:

- on nightly, `test_connect_meshnet` is failing with nickname conflict
- on daily `test_incoming_connections` fails peer not reachable error

Changes:

-  for nickname conflict check, exclude non-routable addresses as those do not conflict with meshnet, so in case where IP lookup happens to return the host with the same name as peer nickname, it will not conflict if IP is non-routable
- for peer not reachable added check waiting for peers to report that they are connected and only then proceed with tests