### PR TITLE
LVPN-10858: make cli case insensitive

### DIFF
--- a/cli/normalize.go
+++ b/cli/normalize.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// NormalizeCommandCase canonicalizes the case of command and subcommand name
+// tokens in args so that commands can be invoked case-insensitively, e.g.
+// "SET MESH on" and "Set Mesh On" both resolve to "set meshnet on".
+//
+// Only tokens that name a command/subcommand (matched case-insensitively against
+// the command tree, including aliases) are rewritten to their canonical name.
+// Every other token — flags, flag values, server tags, hostnames, file paths,
+// on/off values — is left byte-for-byte untouched, so case-sensitive argument
+// values are never corrupted.
+//
+// commands is the top-level command list (app.Commands); args is the full
+// argument vector including the program name at index 0.
+func NormalizeCommandCase(commands []*cli.Command, args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+
+	out := make([]string, 0, len(args))
+	out = append(out, args[0]) // program name, verbatim
+
+	level := commands
+	matching := true
+	for _, arg := range args[1:] {
+		if !matching {
+			out = append(out, arg)
+			continue
+		}
+
+		// Flags may precede a subcommand; pass them through without treating
+		// them as a command boundary or descending the tree.
+		if strings.HasPrefix(arg, "-") {
+			out = append(out, arg)
+			continue
+		}
+
+		if cmd := findCommandFold(level, arg); cmd != nil {
+			out = append(out, cmd.Name)
+			level = cmd.Subcommands
+			continue
+		}
+
+		// First token that isn't a command: it and everything after it are
+		// arguments/values and must be preserved verbatim.
+		out = append(out, arg)
+		matching = false
+	}
+
+	return out
+}
+
+// findCommandFold returns the command in commands whose canonical name or any of
+// its aliases matches name case-insensitively, or nil if none match.
+func findCommandFold(commands []*cli.Command, name string) *cli.Command {
+	for _, cmd := range commands {
+		if strings.EqualFold(cmd.Name, name) {
+			return cmd
+		}
+		for _, alias := range cmd.Aliases {
+			if strings.EqualFold(alias, name) {
+				return cmd
+			}
+		}
+	}
+	return nil
+}

--- a/cli/normalize.go
+++ b/cli/normalize.go
@@ -6,6 +6,13 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// Names of the implicit help command that urfave/cli injects at runtime; it is
+// not present in the static command tree, so normalization handles it by name.
+const (
+	helpName  = "help"
+	helpAlias = "h"
+)
+
 // NormalizeCommandCase canonicalizes the case of command and subcommand name
 // tokens in args so that commands can be invoked case-insensitively, e.g.
 // "SET MESH on" and "Set Mesh On" both resolve to "set meshnet on".
@@ -44,6 +51,17 @@ func NormalizeCommandCase(commands []*cli.Command, args []string) []string {
 		if cmd := findCommandFold(level, arg); cmd != nil {
 			out = append(out, cmd.Name)
 			level = cmd.Subcommands
+			continue
+		}
+
+		// urfave/cli injects an implicit "help" command (alias "h") into the app
+		// and into every command group that has subcommands. That injection
+		// happens inside Run (after this normalization), so the help command is
+		// never present in the tree above. Recognize it explicitly, mirroring
+		// urfave's rule that help exists wherever the current level has commands.
+		// help's argument is a sibling command name, so keep the current level.
+		if len(level) > 0 && (strings.EqualFold(arg, helpName) || strings.EqualFold(arg, helpAlias)) {
+			out = append(out, helpName)
 			continue
 		}
 

--- a/cli/normalize_test.go
+++ b/cli/normalize_test.go
@@ -116,6 +116,41 @@ func TestNormalizeCommandCase(t *testing.T) {
 			input:    []string{"nordvpn", "SET", "autoconnect", "ON", "set"},
 			expected: []string{"nordvpn", "set", "autoconnect", "ON", "set"},
 		},
+		{
+			name:     "help as trailing subcommand uppercase",
+			input:    []string{"nordvpn", "mesh", "HELP"},
+			expected: []string{"nordvpn", "meshnet", "help"},
+		},
+		{
+			name:     "help mixed case on command group",
+			input:    []string{"nordvpn", "MESH", "Help"},
+			expected: []string{"nordvpn", "meshnet", "help"},
+		},
+		{
+			name:     "help alias h canonicalized",
+			input:    []string{"nordvpn", "meshnet", "H"},
+			expected: []string{"nordvpn", "meshnet", "help"},
+		},
+		{
+			name:     "top-level help uppercase",
+			input:    []string{"nordvpn", "HELP"},
+			expected: []string{"nordvpn", "help"},
+		},
+		{
+			name:     "help followed by sibling command is canonicalized",
+			input:    []string{"nordvpn", "HELP", "MESH"},
+			expected: []string{"nordvpn", "help", "meshnet"},
+		},
+		{
+			name:     "help on nested group canonicalizes following subcommand",
+			input:    []string{"nordvpn", "MESH", "HELP", "PEER"},
+			expected: []string{"nordvpn", "meshnet", "help", "peer"},
+		},
+		{
+			name:     "help not recognized on leaf command without subcommands",
+			input:    []string{"nordvpn", "LOGIN", "HELP"},
+			expected: []string{"nordvpn", "login", "HELP"},
+		},
 	}
 
 	tree := testCommandTree()

--- a/cli/normalize_test.go
+++ b/cli/normalize_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func testCommandTree() []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:    "connect",
+			Aliases: []string{"c"},
+		},
+		{
+			Name:    "set",
+			Aliases: []string{"s"},
+			Subcommands: []*cli.Command{
+				{Name: "killswitch"},
+				{Name: "autoconnect"},
+			},
+		},
+		{
+			Name:    "meshnet",
+			Aliases: []string{"mesh"},
+			Subcommands: []*cli.Command{
+				{
+					Name: "peer",
+					Subcommands: []*cli.Command{
+						{Name: "list"},
+						{Name: "remove"},
+					},
+				},
+				{Name: "set"},
+			},
+		},
+		{
+			Name: "login",
+		},
+	}
+}
+
+func TestNormalizeCommandCase(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "already lowercase",
+			input:    []string{"nordvpn", "set", "killswitch", "on"},
+			expected: []string{"nordvpn", "set", "killswitch", "on"},
+		},
+		{
+			name:     "all uppercase commands",
+			input:    []string{"nordvpn", "SET", "KILLSWITCH", "on"},
+			expected: []string{"nordvpn", "set", "killswitch", "on"},
+		},
+		{
+			name:     "mixed case commands",
+			input:    []string{"nordvpn", "Set", "Killswitch", "On"},
+			expected: []string{"nordvpn", "set", "killswitch", "On"},
+		},
+		{
+			name:     "alias canonicalization",
+			input:    []string{"nordvpn", "S", "killswitch", "on"},
+			expected: []string{"nordvpn", "set", "killswitch", "on"},
+		},
+		{
+			name:     "meshnet alias case-insensitive",
+			input:    []string{"nordvpn", "MESH", "peer", "LIST"},
+			expected: []string{"nordvpn", "meshnet", "peer", "list"},
+		},
+		{
+			name:     "deep nesting",
+			input:    []string{"nordvpn", "Mesh", "Peer", "Remove", "MyPeer-Host"},
+			expected: []string{"nordvpn", "meshnet", "peer", "remove", "MyPeer-Host"},
+		},
+		{
+			name:     "value case preserved after command stops matching",
+			input:    []string{"nordvpn", "CONNECT", "United_States"},
+			expected: []string{"nordvpn", "connect", "United_States"},
+		},
+		{
+			name:     "flag before value on command without subcommands",
+			input:    []string{"nordvpn", "Connect", "--group", "Double_VPN", "United_States"},
+			expected: []string{"nordvpn", "connect", "--group", "Double_VPN", "United_States"},
+		},
+		{
+			name:     "login token stays case-sensitive",
+			input:    []string{"nordvpn", "LOGIN", "--token", "AbCdEf123XYZ"},
+			expected: []string{"nordvpn", "login", "--token", "AbCdEf123XYZ"},
+		},
+		{
+			name:     "unknown command left untouched",
+			input:    []string{"nordvpn", "Foobar", "Baz"},
+			expected: []string{"nordvpn", "Foobar", "Baz"},
+		},
+		{
+			name:     "only program name",
+			input:    []string{"nordvpn"},
+			expected: []string{"nordvpn"},
+		},
+		{
+			name:     "empty args",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "argument matching a nested command name is not descended past a value",
+			input:    []string{"nordvpn", "SET", "autoconnect", "ON", "set"},
+			expected: []string{"nordvpn", "set", "autoconnect", "ON", "set"},
+		},
+	}
+
+	tree := testCommandTree()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeCommandCase(tree, tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -114,7 +114,7 @@ func main() {
 	}
 
 	// Canonicalize command/subcommand name case so commands can be invoked
-	// case-insensitively (e.g. "SET MESH on" == "set meshnet on").
+	// case-insensitively (e.g. "SET MESH on" == "set mesh on").
 	args = cli.NormalizeCommandCase(cmd.Commands, args)
 
 	// nolint:errcheck // we want to suppress errors in the cli app, as starting norduser is not strictly related to the

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -113,6 +113,10 @@ func main() {
 		args = append(args, clearFormatting(arg))
 	}
 
+	// Canonicalize command/subcommand name case so commands can be invoked
+	// case-insensitively (e.g. "SET MESH on" == "set meshnet on").
+	args = cli.NormalizeCommandCase(cmd.Commands, args)
+
 	// nolint:errcheck // we want to suppress errors in the cli app, as starting norduser is not strictly related to the
 	// running command. For startup details norduser logs could be checked.
 	_, _ = getNorduserManager().StartProcess()

--- a/contrib/patches/bash_autocomplete.diff
+++ b/contrib/patches/bash_autocomplete.diff
@@ -1,9 +1,9 @@
 # Generated with git diff --no-index dist/autocomplete/bash_autocomplete dist/autocomplete/bash_autocomplete_nordvpn > contrib/patches/bash_autocomplete
 diff --git a/dist/autocomplete/bash_autocomplete b/dist/autocomplete/bash_autocomplete
-index fea6ee33..22fd802f 100644
+index fea6ee33..a4cf0db3 100644
 --- a/dist/autocomplete/bash_autocomplete
 +++ b/dist/autocomplete/bash_autocomplete
-@@ -26,10 +26,15 @@ _cli_bash_autocomplete() {
+@@ -26,10 +26,21 @@ _cli_bash_autocomplete() {
        requestComp="${words[*]} --generate-bash-completion"
      fi
      opts=$(eval "${requestComp}" 2>/dev/null)
@@ -12,7 +12,13 @@ index fea6ee33..22fd802f 100644
 +    if [[ $opts == "nordvpn_autocomplete_filepaths" ]]; then
 +      compopt -o bashdefault -o default
 +    else
-+      COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
++      # Case-insensitive prefix matching. `compgen -W` matches case-sensitively
++      # and honors neither `nocasematch` nor readline's `completion-ignore-case`,
++      # so awk does the case-folded prefix filter while preserving each
++      # candidate's canonical casing (e.g. "ger" -> "Germany"). IFS is pinned to
++      # newlines so candidates containing spaces stay intact.
++      local IFS=$'\n'
++      COMPREPLY=($(compgen -W "${opts}" | awk -v c="${cur}" 'BEGIN{c=tolower(c)} tolower(substr($0,1,length(c)))==c'))
 +    fi
      return 0
    fi

--- a/contrib/patches/zsh_autocomplete.diff
+++ b/contrib/patches/zsh_autocomplete.diff
@@ -1,6 +1,6 @@
 # Generated with git diff --no-index dist/autocomplete/zsh_autocomplete dist/autocomplete/zsh_autocomplete_nordvpn > contrib/patches/zsh_autocomplete.diff
 diff --git a/dist/autocomplete/zsh_autocomplete b/dist/autocomplete/zsh_autocomplete
-index b519666f..00618811 100644
+index b519666f..9d1cf4ef 100644
 --- a/dist/autocomplete/zsh_autocomplete
 +++ b/dist/autocomplete/zsh_autocomplete
 @@ -1,4 +1,4 @@
@@ -9,7 +9,7 @@ index b519666f..00618811 100644
  
  _cli_zsh_autocomplete() {
    local -a opts
-@@ -10,11 +10,12 @@ _cli_zsh_autocomplete() {
+@@ -10,11 +10,16 @@ _cli_zsh_autocomplete() {
      opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
    fi
  
@@ -20,7 +20,11 @@ index b519666f..00618811 100644
 +      _files
    else
 -    _files
-+    _describe 'values' opts
++    # Case-insensitive prefix matching: fold case both ways so e.g. "ger" or
++    # "GER" both match "Germany". The match spec is passed straight to the
++    # underlying compadd via _describe, so it applies only to this completion
++    # and does not mutate the user's global zstyle configuration.
++    _describe 'values' opts -M 'm:{a-zA-Z}={A-Za-z}'
    fi
  }
  


### PR DESCRIPTION
Make nordvpn invocations behave identically regardless of the letter case used for command and subcommand names, so that all of the following work the same:
- nordvpn set mesh on
- nordvpn SET MESH on
- nordvpn Set Mesh On