### PR TITLE
LVPN-10792: sanitize dedicated server/ip logs

### DIFF
--- a/daemon/state/state.go
+++ b/daemon/state/state.go
@@ -56,7 +56,7 @@ func (s *StatePublisher) OnStateChange(e events.DataConnectChangeNotif) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Infof("notifying about data connect change event: %+v", e)
+	log.Tracef("notifying about data connect change event: %+v", e)
 	s.notify(e)
 	return nil
 }

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -99,7 +99,7 @@ func (t *telioCallbackHandler) handleEvent(e teliogo.Event) error {
 	if err != nil {
 		log.Warnf("can't marshal telio Event %T: %s", e, err)
 	} else {
-		log.Infof("received event %T: %s", e, maskPublicKey(string(eventBytes)))
+		log.Tracef("received event %T: %s", e, maskPublicKey(string(eventBytes)))
 	}
 
 	t.mu.Lock()

--- a/log/log_level_watcher.go
+++ b/log/log_level_watcher.go
@@ -90,6 +90,8 @@ func applyLevelFile(path string) {
 
 	text := strings.TrimSpace(strings.ToLower(string(data)))
 	switch text {
+	case "trace":
+		SetLevel(levelTrace)
 	case "debug":
 		SetLevel(levelDebug)
 	case "info":

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,5 +1,5 @@
 // Package log wraps the standard library logger with level-filtered functions
-// (Debug, Info, Warn, Error). The active level is stored atomically and can
+// (Debug, Info, Warn, Error, Trace). The active level is stored atomically and can
 // be changed at runtime by writing to the file watched by SetupLogger.
 package log
 
@@ -127,7 +127,7 @@ func (l *Logger) Errorf(format string, v ...any) {
 	logAtf(levelError, errorPrefix, l.prefix+" "+format, v)
 }
 func (l *Logger) Trace(v ...any) { logAt(levelTrace, tracePrefix, prepend(l.prefix, v)) }
-func (l *Logger) Traceff(format string, v ...any) {
+func (l *Logger) Tracef(format string, v ...any) {
 	logAtf(levelTrace, tracePrefix, l.prefix+" "+format, v)
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -20,6 +20,7 @@ const showCallerAsSource = 4
 
 const (
 	levelUnknown logLevel = iota
+	levelTrace
 	levelDebug
 	levelInfo
 	levelWarn
@@ -34,10 +35,13 @@ const (
 	warningPrefix = "[Warning]"
 	errorPrefix   = "[Error]"
 	fatalPrefix   = "[Fatal]"
+	tracePrefix   = "[Trace]"
 )
 
 func (l logLevel) String() string {
 	switch l {
+	case levelTrace:
+		return "trace"
 	case levelDebug:
 		return "debug"
 	case levelInfo:
@@ -122,6 +126,10 @@ func (l *Logger) Error(v ...any) { logAt(levelError, errorPrefix, prepend(l.pref
 func (l *Logger) Errorf(format string, v ...any) {
 	logAtf(levelError, errorPrefix, l.prefix+" "+format, v)
 }
+func (l *Logger) Trace(v ...any) { logAt(levelTrace, tracePrefix, prepend(l.prefix, v)) }
+func (l *Logger) Traceff(format string, v ...any) {
+	logAtf(levelTrace, tracePrefix, l.prefix+" "+format, v)
+}
 
 func (l *Logger) Fatal(v ...any) {
 	logAt(levelFatal, fatalPrefix, prepend(l.prefix, v))
@@ -145,6 +153,8 @@ func Warn(v ...any)                  { logAt(levelWarn, warningPrefix, v) }
 func Warnf(format string, v ...any)  { logAtf(levelWarn, warningPrefix, format, v) }
 func Error(v ...any)                 { logAt(levelError, errorPrefix, v) }
 func Errorf(format string, v ...any) { logAtf(levelError, errorPrefix, format, v) }
+func Trace(v ...any)                 { logAt(levelTrace, tracePrefix, v) }
+func Tracef(format string, v ...any) { logAtf(levelTrace, tracePrefix, format, v) }
 
 func Fatal(v ...any) {
 	logAt(levelFatal, fatalPrefix, v)


### PR DESCRIPTION
We want to sanitize the IP address for dedicated server/ip. To achieve that, a new log level(trace) was added, with priority lower than the log level enabled by default(debug).

The undesired logs were switched to trace so that they will not appear by default. For debugging purposes, user can switch the log level.