### PR TITLE
LVPN-10608: Refactor fileshare process monitoring test

### DIFF
--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -474,9 +474,9 @@ def is_process_running() -> bool:
     return result.returncode == 0
 
 
-def restart_mesh() -> None:
-    sh.nordvpn.set.meshnet.off()
+def restart_mesh(ssh_client: ssh.Ssh) -> None:
+    exec_command = CommandExecutor(ssh_client) if ssh_client else CommandExecutor()
+    exec_command("nordvpn set meshnet off")
     time.sleep(2)
-    sh.nordvpn.set.meshnet.on()
+    exec_command("nordvpn set meshnet on")
     time.sleep(5)
-

--- a/test/qa/lib/fileshare.py
+++ b/test/qa/lib/fileshare.py
@@ -10,9 +10,8 @@ from threading import Thread
 import pytest
 import sh
 import socket
-import os
 
-from . import FILE_HASH_UTILITY, CommandExecutor, logging, ssh
+from . import firewall, FILE_HASH_UTILITY, CommandExecutor, logging, ssh
 
 class FileSize:
     """
@@ -437,25 +436,25 @@ def bind_port() -> socket.socket | None:
     return None
 
 
-def check_fileshare_port_status(is_allowed: bool, peer_address: str) -> bool:
+def check_fileshare_port_status(is_allowed: bool, peer_address: str, port: int = 49111) -> bool:
+    """
+    Poll port accessibility status over 3 attempts with 1-second delays.
+
+    Returns True if actual accessibility matches expected state, False otherwise.
+    """
     for _ in range(3):
-        if is_port_allowed(peer_address) == is_allowed:
+        if firewall.is_port_accessible_TCP(0, peer_address, port, True) == is_allowed:
             return True
         time.sleep(1)
     return False
 
 
-def port_is_allowed(peer_address: str) -> bool:
-    return check_fileshare_port_status(True, peer_address)
+def port_is_allowed(peer_address: str, port: int = 49111) -> bool:
+    return check_fileshare_port_status(True, peer_address, port)
 
 
-def is_port_allowed(peer_address: str) -> bool:
-    rules = os.popen("sudo iptables -S").read()
-    return f"49111 -m comment --comment nordvpn-meshnet -m comment --comment \"-allow-fileshare-rule-{peer_address}\" -j ACCEPT" in rules
-
-
-def port_is_blocked(peer_address: str) -> bool:
-    return check_fileshare_port_status(False, peer_address)
+def port_is_blocked(peer_address: str, port: int = 49111) -> bool:
+    return check_fileshare_port_status(False, peer_address, port)
 
 
 def ensure_mesh_is_on() -> None:

--- a/test/qa/lib/firewall.py
+++ b/test/qa/lib/firewall.py
@@ -105,18 +105,18 @@ def is_source_port_reachable(ports: list[Port]) -> bool:
 def process_port(port: Port) -> bool:
     if port.protocol == Protocol.TCP:
         print("process tcp")
-        return is_port_accessible_TCP(int(port.value))
+        return is_port_accessible_TCP(src_port=int(port.value), dst_ip=IP, dst_port=TCP_DST_PORT)
     if port.protocol == Protocol.UDP:
         print("process udp")
         return is_port_accessible_UDP(int(port.value))
     print("process both, tcp")
-    tcp_retval = is_port_accessible_TCP(int(port.value))
+    tcp_retval = is_port_accessible_TCP(src_port=int(port.value), dst_ip=IP, dst_port=TCP_DST_PORT)
     print("process both, udp")
     udp_retval = is_port_accessible_UDP(int(port.value))
     return tcp_retval and udp_retval
 
 
-def is_port_accessible_TCP(src_port : int) -> bool :
+def is_port_accessible_TCP(src_port: int, dst_ip: str, dst_port: int, check_connection_only: bool = False) -> bool:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
@@ -128,14 +128,16 @@ def is_port_accessible_TCP(src_port : int) -> bool :
     )
     s.settimeout(SOCK_TIMEOUT)
     try:
-        s.connect((IP, TCP_DST_PORT))
+        s.connect((dst_ip, dst_port))
+        if check_connection_only:
+            return True
         s.send(b"ping")
         print("TCP data sent")
         data = s.recv(4096)
         print("data received: ", data)
         retval = True
     except TimeoutError:
-        print(f"timeout of {SOCK_TIMEOUT} hit with TCP, source port {src_port}, dst port : {TCP_DST_PORT}",)
+        print(f"timeout of {SOCK_TIMEOUT} hit with TCP, source port {src_port}, dst port : {dst_port}",)
         retval = False
     # `OSError: [Errno 99] Cannot assign requested address` handling
     except OSError as e:

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1478,7 +1478,7 @@ def test_fileshare_process_monitoring_manages_fileshare_rules_on_process_state_c
         # port is open when fileshare is running
         assert fileshare.port_is_allowed(peer_address), "Port should be allowed when fileshare is running"
 
-        sh.pkill("-SIGKILL", "nordfileshare")
+        ssh_client.exec_command("sudo pkill -SIGKILL nordfileshare")
         # at the time of writing, the monitoring job is executed periodically every second,
         # wait for 2 seconds to be sure the job executed
         time.sleep(2)
@@ -1487,7 +1487,7 @@ def test_fileshare_process_monitoring_manages_fileshare_rules_on_process_state_c
         assert fileshare.port_is_blocked(peer_address), "Port should be blocked when fileshare is down"
 
         # restart meshet to get fileshare back up
-        fileshare.restart_mesh()
+        fileshare.restart_mesh(ssh_client)
 
         # port is allowed again when fileshare process is up
         assert fileshare.port_is_allowed(peer_address), "Port should be allowed when fileshare is restarted"

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -100,6 +100,8 @@ def teardown_module(module):  # noqa: ARG001
 def setup_function(function):  # noqa: ARG001
     logging.log()
     peer_list = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list())
+    sh_no_tty.nordvpn.mesh.peer.refresh()
+    ssh_client.exec_command("nordvpn mesh peer refresh")
     assert meshnet.is_peer_reachable(peer_list.get_internal_peer()), "Internal peer should be reachable"
     assert meshnet.is_peer_reachable(peer_list.get_this_device(), ssh_client=ssh_client), "This device should be reachable from peer"
 

--- a/test/qa/test_firewall.py
+++ b/test/qa/test_firewall.py
@@ -349,11 +349,11 @@ def test_firewall_dns_tcp_53_to_lan_resolver_dropped(tech, proto, obfuscated):
     with lib.Defer(sh.nordvpn.disconnect):
         sh.nordvpn.connect()
 
-        assert not firewall.is_port_accessible_TCP(src_port=53), (
+        assert not firewall.is_port_accessible_TCP(src_port=53, dst_ip=firewall.IP, dst_port=firewall.TCP_DST_PORT), (
             "TCP port 53 must be blocked by the firewall when VPN is connected"
         )
 
-    assert firewall.is_port_accessible_TCP(src_port=53), (
+    assert firewall.is_port_accessible_TCP(src_port=53, dst_ip=firewall.IP, dst_port=firewall.TCP_DST_PORT), (
         "TCP port 53 must be reachable again after disconnecting from VPN"
     )
 


### PR DESCRIPTION
Instead of checking rules, to understand if fileshare port is open or closed, try to access port.