### PR TITLE
LVPN-10890: bump flutter to 3.44.7

### DIFF
--- a/.github/workflows/actions/install-flutter/action.yml
+++ b/.github/workflows/actions/install-flutter/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Download flutter
       run: |
-        curl -fSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.38.1-stable.tar.xz -o flutter.tar.xz
+        curl -fSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.44.7-stable.tar.xz -o flutter.tar.xz
         tar xf flutter.tar.xz -C $HOME
         echo "$HOME/flutter/bin" >> $GITHUB_PATH
         export PATH="$PATH:$HOME/flutter/bin"

--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -18,5 +18,4 @@ jobs:
       project-id: ${{ secrets.PROJECT_ID }}
     with:
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      #TODO: fix before delivery
-      triggered-ref: skubiak/LVPN-10890_bump_flutter_image_ver
+      triggered-ref: v1.8.0

--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -18,4 +18,5 @@ jobs:
       project-id: ${{ secrets.PROJECT_ID }}
     with:
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v1.7.9
+      #TODO: fix before delivery
+      triggered-ref: skubiak/LVPN-10890_bump_flutter_image_ver

--- a/ci/docker/protochecker/docker-compose.yml
+++ b/ci/docker/protochecker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   # Generates Dart protobuf files for the GUI
   # Note: The generation script removes gui/lib/pb, so we backup before generation
   gui-protobuf-gen:
-    image: ghcr.io/nordsecurity/nordvpn-linux/protobuf_dart-3.10.0:1.0.0
+    image: ghcr.io/nordsecurity/nordvpn-linux/protobuf_dart-3.12.2:1.0.0
     environment:
       <<: *common-variables
     volumes:

--- a/gui/docker/flutter/Dockerfile
+++ b/gui/docker/flutter/Dockerfile
@@ -1,8 +1,8 @@
 # Used to create the image for building a Flutter application
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
-LABEL org.opencontainers.image.source="https://github.com/NordSecurity/nordvpn-linux/blob/main/gui/docker/flutter/Dockerfile"
-LABEL org.opencontainers.image.description="Builds the GUI. Must be build for arm64 and amd64. e.g. ./docker/generate_docker_image.sh ghcr.io/nordsecurity/nordvpn-linux/flutter-3.38.1 1.0.0 linux/amd64,linux/arm64 docker/flutter"
+LABEL org.opencontainers.image.source=https://github.com/NordSecurity/nordvpn-linux
+LABEL org.opencontainers.image.description="Builds the GUI. Must be build for arm64 and amd64. e.g. ./docker/generate_docker_image.sh ghcr.io/nordsecurity/nordvpn-linux/flutter-3.44.7 1.0.0 linux/amd64,linux/arm64 docker/flutter"
 
 # this is needed for dpkg not to be interactive
 ARG DEBIAN_FRONTEND=noninteractive
@@ -32,9 +32,13 @@ ARG USER_ID=1000
 ARG GROUP_ID=1000
 ARG USER_NAME=flutter_user
 ARG HOME=/home/${USER_NAME}
-ARG FLUTTER_VERSION=3.38.1
+ARG FLUTTER_VERSION=3.44.7
 
-RUN groupadd -g ${GROUP_ID} ${USER_NAME} && useradd -l -m -u ${USER_ID} -g ${USER_NAME} ${USER_NAME}
+# Ubuntu 24.04 is shipped with pre-defined user and group, both using ID 1000.
+# Recreate the user and group with the desired name and ID to avoid conflicts.
+RUN userdel -r ubuntu 2>/dev/null || true && \
+    groupdel -f ubuntu 2>/dev/null || true && \
+    groupadd -g ${GROUP_ID} ${USER_NAME} && useradd -l -m -u ${USER_ID} -g ${USER_NAME} ${USER_NAME}
 USER ${USER_NAME}
 WORKDIR ${HOME}
 

--- a/gui/docker/protobuf/Dockerfile
+++ b/gui/docker/protobuf/Dockerfile
@@ -1,9 +1,9 @@
 # Build image to convert protobufs to dart code
 # Update this when flutter builder is updated or find a way to keep in sync
-FROM dart:3.10.0
+FROM dart:3.12.2
 
-LABEL org.opencontainers.image.source="https://github.com/NordSecurity/nordvpn-linux/blob/main/gui/docker/protobuf/Dockerfile"
-LABEL org.opencontainers.image.description="Generates the protobuf to dart code, e.g. ./docker/generate_docker_image.sh ghcr.io/nordsecurity/nordvpn-linux/protobuf_dart-3.10.0 1.0.0 linux/amd64 docker/protobuf/"
+LABEL org.opencontainers.image.source=https://github.com/NordSecurity/nordvpn-linux
+LABEL org.opencontainers.image.description="Generates the protobuf to dart code, e.g. ./docker/generate_docker_image.sh ghcr.io/nordsecurity/nordvpn-linux/protobuf_dart-3.12.2 1.0.0 linux/amd64 docker/protobuf/"
 
 WORKDIR /code/app
 

--- a/gui/lib/daemon/error_screen.dart
+++ b/gui/lib/daemon/error_screen.dart
@@ -212,14 +212,17 @@ List<String> extractMissingConnections(Object? error) {
 
   if (error.details != null) {
     for (var detail in error.details!) {
-      if (detail is Any && detail.typeUrl.endsWith('ErrMissingConnections')) {
-        try {
-          return ErrMissingConnections.fromBuffer(
-            detail.value,
-          ).missingConnections;
-        } catch (e) {
-          logger.e('Failed to parse ErrMissingConnections: $e');
-          return const [];
+      if (detail.info_.qualifiedMessageName == 'google.protobuf.Any') {
+        final any = Any.fromBuffer(detail.writeToBuffer());
+        if (any.typeUrl.endsWith('ErrMissingConnections')) {
+          try {
+            return ErrMissingConnections.fromBuffer(
+              any.value,
+            ).missingConnections;
+          } catch (e) {
+            logger.e('Failed to parse ErrMissingConnections: $e');
+            return const [];
+          }
         }
       }
     }

--- a/gui/lib/daemon/error_screen.dart
+++ b/gui/lib/daemon/error_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:grpc/grpc.dart';
+import 'package:protobuf/well_known_types/google/protobuf/any.pb.dart';
 import 'package:nordvpn/data/models/application_error.dart';
 import 'package:nordvpn/data/providers/account_controller.dart';
 import 'package:nordvpn/data/providers/consent_status_provider.dart';
@@ -211,14 +212,17 @@ List<String> extractMissingConnections(Object? error) {
 
   if (error.details != null) {
     for (var detail in error.details!) {
-      if (detail is Any && detail.typeUrl.endsWith('ErrMissingConnections')) {
-        try {
-          return ErrMissingConnections.fromBuffer(
-            detail.value,
-          ).missingConnections;
-        } catch (e) {
-          logger.e('Failed to parse ErrMissingConnections: $e');
-          return const [];
+      if (detail.info_.qualifiedMessageName == 'google.protobuf.Any') {
+        final any = Any.fromBuffer(detail.writeToBuffer());
+        if (any.typeUrl.endsWith('ErrMissingConnections')) {
+          try {
+            return ErrMissingConnections.fromBuffer(
+              any.value,
+            ).missingConnections;
+          } catch (e) {
+            logger.e('Failed to parse ErrMissingConnections: $e');
+            return const [];
+          }
         }
       }
     }

--- a/gui/lib/daemon/error_screen.dart
+++ b/gui/lib/daemon/error_screen.dart
@@ -212,17 +212,14 @@ List<String> extractMissingConnections(Object? error) {
 
   if (error.details != null) {
     for (var detail in error.details!) {
-      if (detail.info_.qualifiedMessageName == 'google.protobuf.Any') {
-        final any = Any.fromBuffer(detail.writeToBuffer());
-        if (any.typeUrl.endsWith('ErrMissingConnections')) {
-          try {
-            return ErrMissingConnections.fromBuffer(
-              any.value,
-            ).missingConnections;
-          } catch (e) {
-            logger.e('Failed to parse ErrMissingConnections: $e');
-            return const [];
-          }
+      if (detail is Any && detail.typeUrl.endsWith('ErrMissingConnections')) {
+        try {
+          return ErrMissingConnections.fromBuffer(
+            detail.value,
+          ).missingConnections;
+        } catch (e) {
+          logger.e('Failed to parse ErrMissingConnections: $e');
+          return const [];
         }
       }
     }

--- a/gui/lib/pb/daemon/account.pb.dart
+++ b/gui/lib/pb/daemon/account.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/account.pbenum.dart
+++ b/gui/lib/pb/daemon/account.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/account.pbjson.dart
+++ b/gui/lib/pb/daemon/account.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/cities.pb.dart
+++ b/gui/lib/pb/daemon/cities.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/cities.pbenum.dart
+++ b/gui/lib/pb/daemon/cities.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/cities.pbjson.dart
+++ b/gui/lib/pb/daemon/cities.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/common.pb.dart
+++ b/gui/lib/pb/daemon/common.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/common.pbenum.dart
+++ b/gui/lib/pb/daemon/common.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/common.pbjson.dart
+++ b/gui/lib/pb/daemon/common.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/config/analytics_consent.pb.dart
+++ b/gui/lib/pb/daemon/config/analytics_consent.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/analytics_consent.pbenum.dart
+++ b/gui/lib/pb/daemon/config/analytics_consent.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/analytics_consent.pbjson.dart
+++ b/gui/lib/pb/daemon/config/analytics_consent.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/config/group.pb.dart
+++ b/gui/lib/pb/daemon/config/group.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/group.pbenum.dart
+++ b/gui/lib/pb/daemon/config/group.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/group.pbjson.dart
+++ b/gui/lib/pb/daemon/config/group.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/config/protocol.pb.dart
+++ b/gui/lib/pb/daemon/config/protocol.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/protocol.pbenum.dart
+++ b/gui/lib/pb/daemon/config/protocol.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/protocol.pbjson.dart
+++ b/gui/lib/pb/daemon/config/protocol.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/config/technology.pb.dart
+++ b/gui/lib/pb/daemon/config/technology.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/technology.pbenum.dart
+++ b/gui/lib/pb/daemon/config/technology.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/config/technology.pbjson.dart
+++ b/gui/lib/pb/daemon/config/technology.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/connect.pb.dart
+++ b/gui/lib/pb/daemon/connect.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/connect.pbenum.dart
+++ b/gui/lib/pb/daemon/connect.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/connect.pbjson.dart
+++ b/gui/lib/pb/daemon/connect.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/countries.pb.dart
+++ b/gui/lib/pb/daemon/countries.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/countries.pbenum.dart
+++ b/gui/lib/pb/daemon/countries.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/countries.pbjson.dart
+++ b/gui/lib/pb/daemon/countries.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/defaults.pb.dart
+++ b/gui/lib/pb/daemon/defaults.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/defaults.pbenum.dart
+++ b/gui/lib/pb/daemon/defaults.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/defaults.pbjson.dart
+++ b/gui/lib/pb/daemon/defaults.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/features.pb.dart
+++ b/gui/lib/pb/daemon/features.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/features.pbenum.dart
+++ b/gui/lib/pb/daemon/features.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/features.pbjson.dart
+++ b/gui/lib/pb/daemon/features.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/login.pb.dart
+++ b/gui/lib/pb/daemon/login.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/login.pbenum.dart
+++ b/gui/lib/pb/daemon/login.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/login.pbjson.dart
+++ b/gui/lib/pb/daemon/login.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/login_with_token.pb.dart
+++ b/gui/lib/pb/daemon/login_with_token.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/login_with_token.pbenum.dart
+++ b/gui/lib/pb/daemon/login_with_token.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/login_with_token.pbjson.dart
+++ b/gui/lib/pb/daemon/login_with_token.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/logout.pb.dart
+++ b/gui/lib/pb/daemon/logout.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/logout.pbenum.dart
+++ b/gui/lib/pb/daemon/logout.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/logout.pbjson.dart
+++ b/gui/lib/pb/daemon/logout.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/pause.pb.dart
+++ b/gui/lib/pb/daemon/pause.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/pause.pbenum.dart
+++ b/gui/lib/pb/daemon/pause.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/pause.pbjson.dart
+++ b/gui/lib/pb/daemon/pause.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/ping.pb.dart
+++ b/gui/lib/pb/daemon/ping.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/ping.pbenum.dart
+++ b/gui/lib/pb/daemon/ping.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/ping.pbjson.dart
+++ b/gui/lib/pb/daemon/ping.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/purchase.pb.dart
+++ b/gui/lib/pb/daemon/purchase.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/purchase.pbenum.dart
+++ b/gui/lib/pb/daemon/purchase.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/purchase.pbjson.dart
+++ b/gui/lib/pb/daemon/purchase.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/rate.pb.dart
+++ b/gui/lib/pb/daemon/rate.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/rate.pbenum.dart
+++ b/gui/lib/pb/daemon/rate.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/rate.pbjson.dart
+++ b/gui/lib/pb/daemon/rate.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/recent_connections.pb.dart
+++ b/gui/lib/pb/daemon/recent_connections.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/recent_connections.pbenum.dart
+++ b/gui/lib/pb/daemon/recent_connections.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/recent_connections.pbjson.dart
+++ b/gui/lib/pb/daemon/recent_connections.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/server_selection_rule.pb.dart
+++ b/gui/lib/pb/daemon/server_selection_rule.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/server_selection_rule.pbenum.dart
+++ b/gui/lib/pb/daemon/server_selection_rule.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/server_selection_rule.pbjson.dart
+++ b/gui/lib/pb/daemon/server_selection_rule.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/servers.pb.dart
+++ b/gui/lib/pb/daemon/servers.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/servers.pbenum.dart
+++ b/gui/lib/pb/daemon/servers.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/servers.pbjson.dart
+++ b/gui/lib/pb/daemon/servers.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/service.pb.dart
+++ b/gui/lib/pb/daemon/service.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/service.pbenum.dart
+++ b/gui/lib/pb/daemon/service.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/service.pbgrpc.dart
+++ b/gui/lib/pb/daemon/service.pbgrpc.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/service.pbjson.dart
+++ b/gui/lib/pb/daemon/service.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/set.pb.dart
+++ b/gui/lib/pb/daemon/set.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/set.pbenum.dart
+++ b/gui/lib/pb/daemon/set.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/set.pbjson.dart
+++ b/gui/lib/pb/daemon/set.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/settings.pb.dart
+++ b/gui/lib/pb/daemon/settings.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/settings.pbenum.dart
+++ b/gui/lib/pb/daemon/settings.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/settings.pbjson.dart
+++ b/gui/lib/pb/daemon/settings.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/state.pb.dart
+++ b/gui/lib/pb/daemon/state.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/state.pbenum.dart
+++ b/gui/lib/pb/daemon/state.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/state.pbjson.dart
+++ b/gui/lib/pb/daemon/state.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/status.pb.dart
+++ b/gui/lib/pb/daemon/status.pb.dart
@@ -8,17 +8,18 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
+import 'package:protobuf/well_known_types/google/protobuf/timestamp.pb.dart'
+    as $0;
 
 import 'config/group.pbenum.dart' as $1;
 import 'config/protocol.pbenum.dart' as $3;
 import 'config/technology.pbenum.dart' as $2;
-import 'google/protobuf/timestamp.pb.dart' as $0;
 import 'status.pbenum.dart';
 
 export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;

--- a/gui/lib/pb/daemon/status.pbenum.dart
+++ b/gui/lib/pb/daemon/status.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/status.pbjson.dart
+++ b/gui/lib/pb/daemon/status.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/telemetry/v1/fields.pb.dart
+++ b/gui/lib/pb/daemon/telemetry/v1/fields.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/telemetry/v1/fields.pbenum.dart
+++ b/gui/lib/pb/daemon/telemetry/v1/fields.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/telemetry/v1/fields.pbjson.dart
+++ b/gui/lib/pb/daemon/telemetry/v1/fields.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/token.pb.dart
+++ b/gui/lib/pb/daemon/token.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/token.pbenum.dart
+++ b/gui/lib/pb/daemon/token.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/daemon/token.pbjson.dart
+++ b/gui/lib/pb/daemon/token.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/daemon/uievent.pb.dart
+++ b/gui/lib/pb/daemon/uievent.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/uievent.pbenum.dart
+++ b/gui/lib/pb/daemon/uievent.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/daemon/uievent.pbjson.dart
+++ b/gui/lib/pb/daemon/uievent.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/fileshare/fileshare.pb.dart
+++ b/gui/lib/pb/fileshare/fileshare.pb.dart
@@ -8,14 +8,15 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+import 'package:protobuf/well_known_types/google/protobuf/timestamp.pb.dart'
+    as $1;
 
 import 'fileshare.pbenum.dart';
-import 'google/protobuf/timestamp.pb.dart' as $1;
 import 'transfer.pb.dart' as $0;
 
 export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;

--- a/gui/lib/pb/fileshare/fileshare.pbenum.dart
+++ b/gui/lib/pb/fileshare/fileshare.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/fileshare/fileshare.pbjson.dart
+++ b/gui/lib/pb/fileshare/fileshare.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/fileshare/service.pb.dart
+++ b/gui/lib/pb/fileshare/service.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/fileshare/service.pbenum.dart
+++ b/gui/lib/pb/fileshare/service.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/fileshare/service.pbgrpc.dart
+++ b/gui/lib/pb/fileshare/service.pbgrpc.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/gui/lib/pb/fileshare/service.pbjson.dart
+++ b/gui/lib/pb/fileshare/service.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/fileshare/transfer.pb.dart
+++ b/gui/lib/pb/fileshare/transfer.pb.dart
@@ -8,14 +8,15 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
+import 'package:protobuf/well_known_types/google/protobuf/timestamp.pb.dart'
+    as $0;
 
-import 'google/protobuf/timestamp.pb.dart' as $0;
 import 'transfer.pbenum.dart';
 
 export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;

--- a/gui/lib/pb/fileshare/transfer.pbenum.dart
+++ b/gui/lib/pb/fileshare/transfer.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/fileshare/transfer.pbjson.dart
+++ b/gui/lib/pb/fileshare/transfer.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/google/protobuf/timestamp.pb.dart
+++ b/gui/lib/pb/google/protobuf/timestamp.pb.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package
 // ignore_for_file: implementation_imports, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/google/protobuf/timestamp.pbenum.dart
+++ b/gui/lib/pb/google/protobuf/timestamp.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/google/protobuf/timestamp.pbjson.dart
+++ b/gui/lib/pb/google/protobuf/timestamp.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/meshnet/empty.pb.dart
+++ b/gui/lib/pb/meshnet/empty.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/empty.pbenum.dart
+++ b/gui/lib/pb/meshnet/empty.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/meshnet/empty.pbjson.dart
+++ b/gui/lib/pb/meshnet/empty.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/meshnet/fsnotify.pb.dart
+++ b/gui/lib/pb/meshnet/fsnotify.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/fsnotify.pbenum.dart
+++ b/gui/lib/pb/meshnet/fsnotify.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/meshnet/fsnotify.pbjson.dart
+++ b/gui/lib/pb/meshnet/fsnotify.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/meshnet/invite.pb.dart
+++ b/gui/lib/pb/meshnet/invite.pb.dart
@@ -8,14 +8,15 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+import 'package:protobuf/well_known_types/google/protobuf/timestamp.pb.dart'
+    as $0;
 
 import 'empty.pb.dart' as $1;
-import 'google/protobuf/timestamp.pb.dart' as $0;
 import 'invite.pbenum.dart';
 import 'service_response.pbenum.dart' as $2;
 

--- a/gui/lib/pb/meshnet/invite.pbenum.dart
+++ b/gui/lib/pb/meshnet/invite.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/invite.pbjson.dart
+++ b/gui/lib/pb/meshnet/invite.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/meshnet/peer.pb.dart
+++ b/gui/lib/pb/meshnet/peer.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/peer.pbenum.dart
+++ b/gui/lib/pb/meshnet/peer.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/peer.pbjson.dart
+++ b/gui/lib/pb/meshnet/peer.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/meshnet/service.pb.dart
+++ b/gui/lib/pb/meshnet/service.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/service.pbenum.dart
+++ b/gui/lib/pb/meshnet/service.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/meshnet/service.pbgrpc.dart
+++ b/gui/lib/pb/meshnet/service.pbgrpc.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;

--- a/gui/lib/pb/meshnet/service.pbjson.dart
+++ b/gui/lib/pb/meshnet/service.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/meshnet/service_response.pb.dart
+++ b/gui/lib/pb/meshnet/service_response.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/service_response.pbenum.dart
+++ b/gui/lib/pb/meshnet/service_response.pbenum.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/meshnet/service_response.pbjson.dart
+++ b/gui/lib/pb/meshnet/service_response.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/lib/pb/snapconf/snapconf.pb.dart
+++ b/gui/lib/pb/snapconf/snapconf.pb.dart
@@ -8,7 +8,7 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 

--- a/gui/lib/pb/snapconf/snapconf.pbenum.dart
+++ b/gui/lib/pb/snapconf/snapconf.pbenum.dart
@@ -8,4 +8,4 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/gui/lib/pb/snapconf/snapconf.pbjson.dart
+++ b/gui/lib/pb/snapconf/snapconf.pbjson.dart
@@ -8,7 +8,8 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures
 // ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
-// ignore_for_file: non_constant_identifier_names, unused_import
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
 
 import 'dart:convert' as $convert;
 import 'dart:core' as $core;

--- a/gui/pubspec.lock
+++ b/gui/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -411,10 +411,10 @@ packages:
     dependency: "direct main"
     description:
       name: grpc
-      sha256: "807a4da90fc1ba94dccc3a44653d3ff7bcf26818f030259d6a8f9fab405cb880"
+      sha256: "86be3a7d39ad865b214a7370021ac80e68939238b507730de6d97fc662cb2723"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "5.1.0"
   hotreloader:
     dependency: transitive
     description:
@@ -544,26 +544,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -688,10 +688,10 @@ packages:
     dependency: "direct main"
     description:
       name: protobuf
-      sha256: "2fcc8a202ca7ec17dab7c97d6b6d91cf03aa07fe6f65f8afbb6dfa52cc5bd902"
+      sha256: "75ec242d22e950bdcc79ee38dd520ce4ee0bc491d7fadc4ea47694604d22bf06"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "6.0.0"
   pub_semver:
     dependency: transitive
     description:
@@ -981,10 +981,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   theme_tailor:
     dependency: "direct dev"
     description:
@@ -1210,5 +1210,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <3.10.1"
+  dart: ">=3.12.0 <3.12.3"
   flutter: ">=3.38.0"

--- a/gui/pubspec.yaml
+++ b/gui/pubspec.yaml
@@ -10,8 +10,8 @@ version: 0.0.1
 
 
 environment:
-  sdk: ">=3.10.0 <3.10.1"
-  # flutter 3.38.1
+  sdk: ">=3.12.0 <3.12.3"
+  # flutter 3.44.7
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -30,8 +30,8 @@ dependencies:
   flutter_riverpod: ^2.6.1
   riverpod_annotation: ^2.6.1
   riverpod: ^2.6.1
-  protobuf: ^5.1.0
-  grpc: ^4.3.0
+  protobuf: ^6.0.0
+  grpc: ^5.1.0
   slang: ^4.7.3
   slang_flutter: ^4.7.0
   searchable_listview: ^2.19.3

--- a/gui/rps.yaml
+++ b/gui/rps.yaml
@@ -68,7 +68,7 @@ scripts:
       protobuf:
         $description: Regenerate protobufs using docker image
         $script: |
-          docker run -v `pwd`/../:/code/app ghcr.io/nordsecurity/nordvpn-linux/protobuf_dart-3.10.0:1.0.0 ./gui/scripts/generate_protobuf.sh
+          docker run -v `pwd`/../:/code/app ghcr.io/nordsecurity/nordvpn-linux/protobuf_dart-3.12.2:1.0.0 ./gui/scripts/generate_protobuf.sh
 
     build:
       package:
@@ -98,7 +98,7 @@ scripts:
               --platform ${PLATFORM} \
               --env WORKDIR=/code/app/ \
               --env ARCH=amd64 \
-              --workdir ${APP_DIR} ghcr.io/nordsecurity/nordvpn-linux/flutter-3.38.1:1.0.1 scripts/build_application.sh ${1}
+              --workdir ${APP_DIR} ghcr.io/nordsecurity/nordvpn-linux/flutter-3.44.7:1.0.0 scripts/build_application.sh ${1}
             # Generate package
             docker run -v `pwd`/../:/code/app \
                     --workdir ${APP_DIR} \

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -22,7 +22,7 @@ import (
 const (
 	registryPrefix         = "ghcr.io/nordsecurity/nordvpn-linux/"
 	imageBuilder           = registryPrefix + "builder:1.4.7"
-	imageGUIFlutter        = registryPrefix + "flutter-3.38.1:1.0.2"
+	imageGUIFlutter        = registryPrefix + "flutter-3.44.7:1.0.0"
 	imagePackager          = registryPrefix + "packager:1.3.6"
 	imageDepender          = registryPrefix + "depender:1.3.5"
 	imageSnapPackager      = registryPrefix + "snaper:1.2.2"

--- a/protobuf/snapconf/snapconf.proto
+++ b/protobuf/snapconf/snapconf.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 package snappb;
-
 option go_package = "github.com/NordSecurity/nordvpn-linux/snapconf/pb";
 
 // ErrMissingConnections defines that some of the snap interfaces that are required for the gRPC


### PR DESCRIPTION
This PR introduces flutter bump to the latest (3.44.7) version.

Another changes under this PR:
- bump flutter and dart gui/docker images
  - gui/flutter image is now based on Ubuntu 24.04
  - gui/dart image is now based on dart 3.12.2
- bumped gui dependencies of `protobuf`(to 6.0.0) and `grpc` (to 5.1.0)