### PR TITLE
downgrade NordWhisper disabled log to Info

### DIFF
--- a/cmd/daemon/vpn_factory.go
+++ b/cmd/daemon/vpn_factory.go
@@ -39,7 +39,7 @@ func getVpnFactory(
 
 	nordWhisperVPN, nordWhisperErr := getNordWhisperVPN(fwmark, envIsDev, eventsPublisher, libquenchCfg)
 	if nordWhisperErr != nil {
-		log.Error("getting NordWhisper vpn:", nordWhisperErr)
+		log.Info("getting NordWhisper vpn:", nordWhisperErr)
 	}
 
 	return func(tech config.Technology) (vpn.VPN, error) {


### PR DESCRIPTION
Change `log.Error` to `log.Info` in `getVpnFactory` when **NordWhisper** vpn cannot be built.

Example log:

```
Jul 29 06:06:57 nixos nordvpnd[671]: 2026/07/29 06:06:57.509268 vpn_factory.go:42: [Info] getting NordWhisper vpn: NordWhisper technology was disabled in compile time
```