### PR TITLE
LVPN-10354: Temporarily skip failing test

### DIFF
--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -328,6 +328,7 @@ def test_direct_connection_rtt_and_loss():
 
 
 @pytest.mark.core_meshnet
+@pytest.mark.skip("LVPN-10390")
 def test_incoming_connections():
     """Manual TC: LVPN-1259"""
 


### PR DESCRIPTION
Changes:

- temporarily skip `test_incoming_connections` to unblock CI, investigation is in progress