### PR TITLE
use NorduserSocketFork on permission denied

### DIFF
--- a/norduser/process/norduser_process_manager.go
+++ b/norduser/process/norduser_process_manager.go
@@ -29,7 +29,7 @@ func GetNorduserClientConnection(uid int) (*grpc.ClientConn, error) {
 	socket := internal.GetNorduserdSocket(uid)
 	if snapconf.IsUnderSnap() {
 		socket = internal.GetNorduserSocketSnap(uid)
-	} else if _, err := os.Stat(socket); os.IsNotExist(err) {
+	} else if _, err := os.Stat(socket); os.IsNotExist(err) || os.IsPermission(err) {
 		socket = internal.GetNorduserSocketFork(uid)
 	}
 


### PR DESCRIPTION
For when **nordvpnd** does not have access to **/run/user/** path, such as when `ProtectHome = "yes";` within a **nordvpnd.service** systemd service file.