### PR TITLE
add --no-edit-hosts daemon flag

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -131,6 +131,7 @@ func initializeStaticConfig(machineID uuid.UUID) config.StaticConfigManager {
 func main() {
 	appStartTime := time.Now()
 	ksMode := flag.Bool("killswitch-mode", false, "sets killswitch rules and stops")
+	hostsReadOnly := flag.Bool("hosts-readonly", false, "treat /etc/hosts as read-only")
 	flag.Parse()
 	if *ksMode {
 		log.Info("Daemon running in killswitch mode")
@@ -321,7 +322,7 @@ func main() {
 	gwret := netlinkrouter.Retriever{}
 
 	dnsSetter := dns.NewDNSServiceSetter(daemonEvents.Debugger.DebuggerEvents)
-	dnsHostSetter := dns.NewHostsFileSetter(dns.HostsFilePath)
+	dnsHostSetter := dns.NewHostnameSetter(*hostsReadOnly, dns.HostsFilePath)
 
 	eventsDbPath := filepath.Join(internal.DatFilesPathCommon, "moose.db")
 	if err := assignMooseDBPermissions(eventsDbPath); err != nil {

--- a/daemon/dns/hosts.go
+++ b/daemon/dns/hosts.go
@@ -41,6 +41,22 @@ func NewHostsFileSetter(filePath string) *HostsFileSetter {
 	}
 }
 
+// NoopHostsSetter is a HostnameSetter that never touches the filesystem.
+// Use it when /etc/hosts is managed externally (e.g. NixOS).
+type NoopHostsSetter struct{}
+
+func (NoopHostsSetter) SetHosts(Hosts) error { return nil }
+func (NoopHostsSetter) UnsetHosts() error    { return nil }
+
+// NewHostnameSetter picks the HostnameSetter implementation based on
+// hostsReadOnly: true means /etc/hosts is never modified.
+func NewHostnameSetter(hostsReadOnly bool, path string) HostnameSetter {
+	if hostsReadOnly {
+		return NoopHostsSetter{}
+	}
+	return NewHostsFileSetter(path)
+}
+
 func (h Host) String() string {
 	return fmt.Sprintf("%s\t%s\t%s\t%s", h.IP, h.FQDN, strings.Join(h.DomainNames, "\t"), mark)
 }

--- a/daemon/dns/hosts_test.go
+++ b/daemon/dns/hosts_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/test/category"
@@ -246,4 +247,33 @@ func TestHostFileSetter_UnsetHosts(t *testing.T) {
 			assert.Equal(t, test.after, string(actual))
 		})
 	}
+}
+
+func TestNoopHostsSetter(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	filename := filepath.Join(t.TempDir(), "hosts")
+	original := "127.0.0.1\tlocalhost\n"
+	require.NoError(t, os.WriteFile(filename, []byte(original), 0644))
+	before, err := os.Stat(filename)
+	require.NoError(t, err)
+
+	setter := NoopHostsSetter{}
+	assert.NoError(t, setter.SetHosts(Hosts{{FQDN: "peer.nord"}}))
+	assert.NoError(t, setter.UnsetHosts())
+
+	after, err := os.Stat(filename)
+	require.NoError(t, err)
+	content, err := os.ReadFile(filename)
+	require.NoError(t, err)
+
+	assert.Equal(t, original, string(content))         // bytes untouched
+	assert.Equal(t, before.ModTime(), after.ModTime()) // never opened
+}
+
+func TestNewHostnameSetter(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	assert.IsType(t, NoopHostsSetter{}, NewHostnameSetter(true, HostsFilePath))
+	assert.IsType(t, &HostsFileSetter{}, NewHostnameSetter(false, HostsFilePath))
 }


### PR DESCRIPTION
- add dns.NoopHostsSetter, a HostnameSetter that never touches the filesystem
- add dns.NewHostnameSetter to pick between it and HostsFileSetter based on the flag
- wire --no-edit-hosts in cmd/daemon/main.go
- add tests for NoopHostsSetter and NewHostnameSetter

to let /etc/hosts be managed externally (e.g. in a NixOS configuration)