### PR TITLE
allow group access to norduserd socket

### DIFF
--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -299,12 +299,24 @@ func start() {
 	if err := os.Remove(connURL); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Error("Failed to remove old socket file:", err)
 	}
-	listenerFunction := internal.ManualListener(connURL, internal.PermUserRWX)
+	listenerFunction := internal.ManualListener(connURL, internal.PermUserRWGroupRW)
 
 	listener, err := listenerFunction()
 	if err != nil {
 		log.Fatalf("Error on listening to UNIX domain socket: %s", err)
 	}
+
+	nordvpnGID, err := internal.GetNordvpnGid()
+	if err != nil {
+		log.Error("Unable to retrieve nordvpn gid:", err)
+		os.Exit(int(childprocess.CodeFailedToEnable))
+	}
+	log.Infof("changing group of socket %s to gid=%d", connURL, nordvpnGID)
+	if err := os.Chown(connURL, -1, nordvpnGID); err != nil {
+		log.Error("Failed to set socket group:", err)
+		os.Exit(int(childprocess.CodeFailedToEnable))
+	}
+
 	listener = netutil.LimitListener(listener, 100)
 
 	usr, err := user.Current()


### PR DESCRIPTION
[NixOS nordvpn service](https://github.com/NixOS/nixpkgs/blob/1681e76bd69a4fd0be27552e93b1abdec67392d5/nixos/modules/services/networking/nordvpn.nix#L7) presently runs **nordvpnd** as a *non-root user* via a systemd service.
In order for that unpriviledged **nordvpnd** to launch **nordfileshare**, it must talk to **norduserd** over its socket.
Since they may not share the same user, the natural solution involves changing the socket group to `internal/constants.NordvpnGroup`, which would correspond to the group of **nordvpnd** as well, thereby allowing it to communicate.

Some logs:
```
2026/08/02 08:54:36.260166 logger.go:85: [Info] setting log level to debug
2026/08/02 08:54:36.260247 log_level_watcher.go:19: [Info] trying to set log level watcher on path /run/nordvpn/loglevel
2026/08/02 08:54:36.261671 main.go:314: [Info] changing group of socket /tmp/1000-norduserd.sock to gid=995
2026/08/02 08:54:36.299067 main.go:352: [Info] Norduser daemon has started
```