### PR TITLE
LVPN-10917: Append " " only if country is set

### DIFF
--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -129,14 +129,17 @@ func (r *RPC) reconnectOnServerMaintenance(
 }
 
 func locationTag(code, city string) string {
-	tag := internal.SnakeCase(code)
-	if city != "" {
-		if tag != "" {
-			tag += " "
-		}
-		tag += internal.SnakeCase(city)
+	codeTag := internal.SnakeCase(code)
+	cityTag := internal.SnakeCase(city)
+
+	if codeTag == "" {
+		return cityTag
 	}
-	return tag
+	if cityTag == "" {
+		return codeTag
+	}
+
+	return codeTag + " " + cityTag
 }
 
 // determineServerSelectionRule determines the server selection rule based on the provided

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -106,15 +106,6 @@ func (r *RPC) reconnectOnServerMaintenance(
 		group = reqParams.Group.String()
 	}
 
-	// builds a "<country>[ <city>]" server tag, omitting the city when it is empty
-	locationTag := func(code, city string) string {
-		tag := internal.SnakeCase(code)
-		if city != "" {
-			tag += " " + internal.SnakeCase(city)
-		}
-		return tag
-	}
-
 	var serverTag string
 	var hostname string
 	if currentServer != nil {
@@ -135,6 +126,17 @@ func (r *RPC) reconnectOnServerMaintenance(
 	}
 
 	return r.connectWithParameters(ctx, &req, srv, pb.ConnectionSource_AUTO, hostname, events.VPNConnectionReasonServerMaintenance)
+}
+
+func locationTag(code, city string) string {
+	tag := internal.SnakeCase(code)
+	if city != "" {
+		if tag != "" {
+			tag += " "
+		}
+		tag += internal.SnakeCase(city)
+	}
+	return tag
 }
 
 // determineServerSelectionRule determines the server selection rule based on the provided

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -1620,6 +1620,12 @@ func TestLocationTag(t *testing.T) {
 			expected: "rome",
 		},
 		{
+			name:     "city only, with leading space",
+			code:     "",
+			city:     " Rome",
+			expected: "rome",
+		},
+		{
 			name:     "both empty",
 			code:     "",
 			city:     "",

--- a/daemon/rpc_connect_test.go
+++ b/daemon/rpc_connect_test.go
@@ -1591,3 +1591,57 @@ func TestReconnectOnServerMaintenance_CountryOnly(t *testing.T) {
 	assert.False(t, failed)
 	assert.NoError(t, err)
 }
+
+func TestLocationTag(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name     string
+		code     string
+		city     string
+		expected string
+	}{
+		{
+			name:     "code and city",
+			code:     "IT",
+			city:     "Rome",
+			expected: "it rome",
+		},
+		{
+			name:     "code only",
+			code:     "IT",
+			city:     "",
+			expected: "it",
+		},
+		{
+			name:     "city only, no leading space",
+			code:     "",
+			city:     "Rome",
+			expected: "rome",
+		},
+		{
+			name:     "both empty",
+			code:     "",
+			city:     "",
+			expected: "",
+		},
+		{
+			name:     "city with multiple words",
+			code:     "US",
+			city:     "New York",
+			expected: "us new_york",
+		},
+		{
+			name:     "lowercase code is preserved as snake case",
+			code:     "US",
+			city:     "Las Vegas",
+			expected: "us las_vegas",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, locationTag(tt.code, tt.city))
+		})
+	}
+}

--- a/daemon/serverpicker/server_selection.go
+++ b/daemon/serverpicker/server_selection.go
@@ -8,6 +8,7 @@ package serverpicker
 import (
 	"errors"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -38,9 +39,9 @@ type SearchParams struct {
 
 func NewSearchParams(tag, group string, excludedServer string) SearchParams {
 	return SearchParams{
-		Tag:            tag,
-		Group:          group,
-		ExcludedServer: excludedServer,
+		Tag:            strings.TrimSpace(tag),
+		Group:          strings.TrimSpace(group),
+		ExcludedServer: strings.TrimSpace(excludedServer),
 	}
 }
 

--- a/daemon/serverpicker/server_selection.go
+++ b/daemon/serverpicker/server_selection.go
@@ -99,7 +99,7 @@ func PickServer(
 	serverTag, err := serverTagFromString(input.Tag, serverGroup, countries, servers)
 
 	if err != nil {
-		log.ServerSel.Debug("unable to detect server tag", err)
+		log.ServerSel.Debug("unable to detect server tag:", err)
 		if errors.Is(err, internal.ErrTagDoesNotExist) {
 			return ServerSelection{}, err
 		}

--- a/daemon/serverpicker/serverpicker_test.go
+++ b/daemon/serverpicker/serverpicker_test.go
@@ -886,3 +886,77 @@ func TestRecommendationUUID_GetServersRemote(t *testing.T) {
 		})
 	}
 }
+
+func TestNewSearchParams(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name           string
+		tag            string
+		group          string
+		excludedServer string
+		expected       SearchParams
+	}{
+		{
+			name:           "plain values are kept as is",
+			tag:            "it rome",
+			group:          "P2P",
+			excludedServer: "it1.nordvpn.com",
+			expected: SearchParams{
+				Tag:            "it rome",
+				Group:          "P2P",
+				ExcludedServer: "it1.nordvpn.com",
+			},
+		},
+		{
+			name:           "leading and trailing whitespace is trimmed from tag and group",
+			tag:            "  it rome  ",
+			group:          "  P2P ",
+			excludedServer: "it1.nordvpn.com",
+			expected: SearchParams{
+				Tag:            "it rome",
+				Group:          "P2P",
+				ExcludedServer: "it1.nordvpn.com",
+			},
+		},
+		{
+			name:           "whitespace-only tag and group become empty",
+			tag:            "   ",
+			group:          "\t\n ",
+			excludedServer: "",
+			expected:       SearchParams{},
+		},
+		{
+			name:           "internal whitespace in tag is preserved",
+			tag:            "it rome",
+			group:          "",
+			excludedServer: "",
+			expected: SearchParams{
+				Tag: "it rome",
+			},
+		},
+		{
+			name:           "excluded server is trimmed",
+			tag:            "it",
+			group:          "",
+			excludedServer: " it1.nordvpn.com ",
+			expected: SearchParams{
+				Tag:            "it",
+				ExcludedServer: "it1.nordvpn.com",
+			},
+		},
+		{
+			name:           "all empty",
+			tag:            "",
+			group:          "",
+			excludedServer: "",
+			expected:       SearchParams{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NewSearchParams(tt.tag, tt.group, tt.excludedServer))
+		})
+	}
+}


### PR DESCRIPTION
Changes:

- fix server tag calculation when ENS Maintenance even requires reconnect
- trim input arguments when creating search params