### PR TITLE
LVPN-10915: Fix flaky ens test

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -645,12 +645,12 @@ func main() {
 	)
 
 	ensMonitor := ens.NewMonitor(
-		httpGlobalCtx,
 		netw,
 		rcConfig,
 		rpc.ReconnectOnServerMaintenanceEvent,
 		daemonEvents.Debugger.DebuggerEvents,
 	)
+	defer ensMonitor.Stop()
 	internalVpnEvents.ConnectionError.Subscribe(ensMonitor.HandleENSNotification)
 	ensMonitor.Start()
 

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -650,7 +650,6 @@ func main() {
 		rpc.ReconnectOnServerMaintenanceEvent,
 		daemonEvents.Debugger.DebuggerEvents,
 	)
-	defer ensMonitor.Stop()
 	internalVpnEvents.ConnectionError.Subscribe(ensMonitor.HandleENSNotification)
 	ensMonitor.Start()
 
@@ -801,6 +800,7 @@ func main() {
 	signals := internal.GetSignalChan()
 	sig := <-signals
 	log.Info("Received signal:", sig)
+	ensMonitor.Stop()
 	s.Stop()
 	norduserService.StopAll()
 

--- a/daemon/ens/ens_monitoring.go
+++ b/daemon/ens/ens_monitoring.go
@@ -2,6 +2,7 @@ package ens
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/config/remote"
@@ -17,6 +18,8 @@ type ConnectCallback func(serverEndpoint string) error
 type Monitor struct {
 	eventsCh       chan events.VPNConnectionErrorEvent
 	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
 	netw           networker.Networker
 	reconnectFn    ConnectCallback
 	debuggerEvents events.Publisher[events.DebuggerEvent]
@@ -24,7 +27,6 @@ type Monitor struct {
 }
 
 func NewMonitor(
-	ctx context.Context,
 	netw networker.Networker,
 	rc remote.ConfigGetter,
 	connectCallback ConnectCallback,
@@ -36,9 +38,13 @@ func NewMonitor(
 	if debuggerEvents == nil {
 		log.ENS.Warn("debugger events publisher is nil")
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
 	return &Monitor{
 		eventsCh:       make(chan events.VPNConnectionErrorEvent, evChSize),
 		ctx:            ctx,
+		cancel:         cancel,
 		netw:           netw,
 		rc:             rc,
 		reconnectFn:    connectCallback,
@@ -58,7 +64,7 @@ func (m *Monitor) HandleENSNotification(e events.VPNConnectionErrorEvent) error 
 }
 
 func (m *Monitor) Start() {
-	go m.run()
+	m.wg.Go(m.run)
 }
 
 func (m *Monitor) run() {
@@ -107,4 +113,12 @@ func (m *Monitor) run() {
 			return
 		}
 	}
+}
+
+func (m *Monitor) Stop() {
+	log.ENS.Info("stopping ENS monitoring")
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.wg.Wait()
 }

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -1,7 +1,6 @@
 package ens
 
 import (
-	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,7 +21,6 @@ func TestENSMonitoring(t *testing.T) {
 
 	const serverEndpoint = "192.168.1.1:51820"
 
-	ctx, cancelFn := context.WithCancel(context.Background())
 	netw := &networker.Mock{
 		VpnActive:        true,
 		ActiveServerData: &vpn.ServerData{Endpoint: serverEndpoint},
@@ -32,7 +30,7 @@ func TestENSMonitoring(t *testing.T) {
 
 	callbackCount := atomic.Int32{}
 	ch := make(chan any)
-	monitor := NewMonitor(ctx, netw, rc, func(_ string) error {
+	monitor := NewMonitor(netw, rc, func(_ string) error {
 		callbackCount.Add(1)
 		ch <- 1
 		return nil
@@ -53,7 +51,7 @@ func TestENSMonitoring(t *testing.T) {
 	helpers.WaitWithTimeout(t, ch, time.Millisecond*10)
 	assert.Equal(t, 2, int(callbackCount.Load()))
 
-	cancelFn()
+	monitor.Stop()
 
 	// after stopping the monitoring, events are ignored
 	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
@@ -151,7 +149,7 @@ func TestENSMonitoringEventHandling(t *testing.T) {
 				return nil
 			})
 			reconnected := make(chan bool, 1)
-			monitor := NewMonitor(t.Context(), netw, rc,
+			monitor := NewMonitor(netw, rc,
 				func(_ string) error {
 					reconnected <- true
 					return nil
@@ -159,6 +157,7 @@ func TestENSMonitoringEventHandling(t *testing.T) {
 				debuggerEvents,
 			)
 			monitor.Start()
+			defer monitor.Stop()
 
 			assert.NilError(t, monitor.HandleENSNotification(tt.event))
 			assert.Equal(t, tt.expectReport, helpers.WaitWithTimeout(t, reported, time.Millisecond*50))


### PR DESCRIPTION
Changes:

- instead of using external context for cancellation, introduce `Stop()`
- it waits until goroutine exits so there is no race between asynchronous stopping of the monitor and sending event immediately after sending signal to stop the monitor