### PR TITLE
LVPN-10939: Modernize go code

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -105,8 +105,8 @@ func NewApp(version, environment, hash, salt string,
 	cli.CommandHelpTemplate = CommandHelpTemplate
 	// Configure line wrapping for command descriptions
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
-		funcMap := map[string]interface{}{"wrapAt": func() int { return width }}
+	cli.HelpPrinter = func(w io.Writer, templ string, data any) {
+		funcMap := map[string]any{"wrapAt": func() int { return width }}
 		cli.HelpPrinterCustom(w, templ, data, funcMap)
 	}
 
@@ -1006,7 +1006,7 @@ type LoaderInterceptor struct {
 	enabled bool
 }
 
-func (i *LoaderInterceptor) UnaryInterceptor(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn,
+func (i *LoaderInterceptor) UnaryInterceptor(ctx context.Context, method string, req any, reply any, cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 ) error {
 	if i.enabled {
@@ -1061,7 +1061,7 @@ type loaderStream struct {
 	loaderEnabled bool
 }
 
-func (s loaderStream) RecvMsg(m interface{}) error {
+func (s loaderStream) RecvMsg(m any) error {
 	if s.loaderEnabled {
 		loader := NewLoader()
 		loader.Start()
@@ -1314,16 +1314,16 @@ func (c *cmd) printServersForAutoComplete(country string, hasGroupFlag bool, gro
 			return
 		}
 
-		output := ""
+		var output strings.Builder
 		for _, server := range resp.Servers {
 			if hasGroupFlag && groupName == server.Name {
 				// if the group is equal to one of the group names then exists don't return anything
 				return
 			}
-			output += server.Name + "\n"
+			output.WriteString(server.Name + "\n")
 		}
 
-		fmt.Print(output)
+		fmt.Print(output.String())
 
 		if hasGroupFlag {
 			// if --group flag exists don't show the countries

--- a/cli/cli_click.go
+++ b/cli/cli_click.go
@@ -17,7 +17,7 @@ import (
 )
 
 func waitForInput(timeout bool) {
-	inputChan := make(chan interface{})
+	inputChan := make(chan any)
 	go func() {
 		_, _ = bufio.NewReader(os.Stdin).ReadBytes('\n')
 		close(inputChan)

--- a/cli/cli_mesh_peers.go
+++ b/cli/cli_mesh_peers.go
@@ -49,36 +49,43 @@ func filterOnline(peers *pb.PeerList) *pb.PeerList {
 	peers.External = internal.Filter(peers.External, func(p *pb.Peer) bool { return p.Status == 1 })
 	return peers
 }
+
 func filterOffline(peers *pb.PeerList) *pb.PeerList {
 	peers.Local = internal.Filter(peers.Local, func(p *pb.Peer) bool { return p.Status == 0 })
 	peers.External = internal.Filter(peers.External, func(p *pb.Peer) bool { return p.Status == 0 })
 	return peers
 }
+
 func filterAllowsIncomingTraffic(peers *pb.PeerList) *pb.PeerList {
 	peers.Local = internal.Filter(peers.Local, func(p *pb.Peer) bool { return p.IsInboundAllowed })
 	peers.External = internal.Filter(peers.External, func(p *pb.Peer) bool { return p.IsInboundAllowed })
 	return peers
 }
+
 func filterAllowsRouting(peers *pb.PeerList) *pb.PeerList {
 	peers.Local = internal.Filter(peers.Local, func(p *pb.Peer) bool { return p.IsRoutable })
 	peers.External = internal.Filter(peers.External, func(p *pb.Peer) bool { return p.IsRoutable })
 	return peers
 }
+
 func filterIncomingTrafficAllowed(peers *pb.PeerList) *pb.PeerList {
 	peers.Local = internal.Filter(peers.Local, func(p *pb.Peer) bool { return p.DoIAllowInbound })
 	peers.External = internal.Filter(peers.External, func(p *pb.Peer) bool { return p.DoIAllowInbound })
 	return peers
 }
+
 func filterRoutingAllowed(peers *pb.PeerList) *pb.PeerList {
 	peers.Local = internal.Filter(peers.Local, func(p *pb.Peer) bool { return p.DoIAllowRouting })
 	peers.External = internal.Filter(peers.External, func(p *pb.Peer) bool { return p.DoIAllowRouting })
 	return peers
 }
+
 func filterSendingFilesAllowed(peers *pb.PeerList) *pb.PeerList {
 	peers.Local = internal.Filter(peers.Local, func(p *pb.Peer) bool { return p.DoIAllowFileshare })
 	peers.External = internal.Filter(peers.External, func(p *pb.Peer) bool { return p.DoIAllowFileshare })
 	return peers
 }
+
 func filterInternalExternal(peers *pb.PeerList) *pb.PeerList {
 	return peers
 }
@@ -111,7 +118,7 @@ func (c *cmd) MeshPeerList(ctx *cli.Context) error {
 	}
 	if ctx.IsSet(flagFilter) {
 		condition := ""
-		for _, value := range strings.Split(ctx.String(flagFilter), ",") {
+		for value := range strings.SplitSeq(ctx.String(flagFilter), ",") {
 			filtersFunc, ok := availableFilters[value]
 			if !ok {
 				return formatError(errors.New(internal.FilterNonExistentErrorMessage))
@@ -223,6 +230,7 @@ func titledKeyvalListToColoredString(
 		"\n" +
 		keyvalListToColoredString(kvs)
 }
+
 func keyvalListToColoredString(kvs []keyval) string {
 	builder := strings.Builder{}
 	for _, kv := range kvs {
@@ -280,7 +288,7 @@ func (c *cmd) MeshPeerDenyRouting(ctx *cli.Context) error {
 		return formatError(err)
 	}
 
-	//TODO - LVPN-9412: reavaulate error handling
+	// TODO - LVPN-9412: reavaulate error handling
 	resp, _ := c.meshClient.DenyRouting(
 		context.Background(),
 		&pb.UpdatePeerRequest{
@@ -414,7 +422,6 @@ func (c *cmd) MeshPeerAllowFileshare(ctx *cli.Context) error {
 			Identifier: peer.Identifier,
 		},
 	)
-
 	if err != nil {
 		return errors.New(AccountInternalError)
 	}
@@ -443,7 +450,6 @@ func (c *cmd) MeshPeerDenyFileshare(ctx *cli.Context) error {
 			Identifier: peer.Identifier,
 		},
 	)
-
 	if err != nil {
 		return errors.New(AccountInternalError)
 	}
@@ -477,7 +483,6 @@ func (c *cmd) MeshPeerEnableAutomaticFileshare(ctx *cli.Context) error {
 			Identifier: peer.Identifier,
 		},
 	)
-
 	if err != nil {
 		return errors.New(AccountInternalError)
 	}
@@ -506,7 +511,6 @@ func (c *cmd) MeshPeerDisableAutomaticFileshare(ctx *cli.Context) error {
 			Identifier: peer.Identifier,
 		},
 	)
-
 	if err != nil {
 		return errors.New(AccountInternalError)
 	}
@@ -649,7 +653,6 @@ func (c *cmd) changeMeshnetPeerNickname(peer *pb.Peer, nickname string) error {
 		Identifier: peer.Identifier,
 		Nickname:   nickname,
 	})
-
 	if err != nil {
 		return formatError(err)
 	}
@@ -680,7 +683,6 @@ func (c *cmd) MeshSetMachineNickname(ctx *cli.Context) error {
 	resp, err := c.meshClient.ChangeMachineNickname(context.Background(), &pb.ChangeMachineNicknameRequest{
 		Nickname: nickname,
 	})
-
 	if err != nil {
 		return formatError(err)
 	}
@@ -703,7 +705,6 @@ func (c *cmd) MeshRemoveMachineNickname(ctx *cli.Context) error {
 	resp, err := c.meshClient.ChangeMachineNickname(context.Background(), &pb.ChangeMachineNicknameRequest{
 		Nickname: "",
 	})
-
 	if err != nil {
 		return formatError(err)
 	}

--- a/cli/terminal.go
+++ b/cli/terminal.go
@@ -237,12 +237,9 @@ func formatTable[T any](
 
 	// Calculate the number of columns that can fit in the terminal width
 	columnWidth := min(width, maxItemWidth+4)
-	columns := width / columnWidth
-
-	if columns < 1 {
+	columns := max(width/columnWidth,
 		// if the width is very small then display everything in one column
-		columns = 1
-	}
+		1)
 
 	var builder strings.Builder
 	for i, item := range data {

--- a/client/int64.go
+++ b/client/int64.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-func InterfaceToInt64(item interface{}) int64 {
+func InterfaceToInt64(item any) int64 {
 	var i int64
 	switch item := item.(type) {
 	case json.Number:

--- a/client/int64_test.go
+++ b/client/int64_test.go
@@ -12,7 +12,7 @@ func TestInterfaceToInt64(t *testing.T) {
 	category.Set(t, category.Unit)
 
 	tests := []struct {
-		info     interface{}
+		info     any
 		expected int64
 	}{
 		{int64(123), 123},

--- a/cmd/daemon/main_test.go
+++ b/cmd/daemon/main_test.go
@@ -97,7 +97,7 @@ func TestBuildTpServersAndResolver(t *testing.T) {
 	assert.True(t, fetched.Load(), "servers were fetched")
 
 	// retry several times, until the internal members are sync
-	for retry := 0; retry < 5; retry++ {
+	for range 5 {
 		if slices.Contains(tp.Get(true), serversList[0]) {
 			break
 		}

--- a/cmd/daemon/transports.go
+++ b/cmd/daemon/transports.go
@@ -203,7 +203,7 @@ func validateHTTPTransportsString(val string) []string {
 	}
 	finalVal := []string{}
 	val = strings.ToLower(val)
-	for _, item := range strings.Split(val, ",") {
+	for item := range strings.SplitSeq(val, ",") {
 		if slices.Contains(validTransportTypes, item) {
 			finalVal = append(finalVal, item)
 		} else {

--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -137,8 +137,8 @@ func shouldEnableFileshare(uid uint32) (bool, error) {
 
 func waitForShutdown(stopChan <-chan norduser.StopRequest,
 	fileshareManagementChan chan<- norduser.FileshareManagementMsg,
-	fileshareShutdownChan <-chan interface{},
-	logoutChan <-chan interface{},
+	fileshareShutdownChan <-chan any,
+	logoutChan <-chan any,
 	grpcServer *grpc.Server,
 	onShutdown func(bool),
 ) {
@@ -187,7 +187,7 @@ func waitForShutdown(stopChan <-chan norduser.StopRequest,
 	}
 }
 
-func startFileshare(uid uint32) (chan<- norduser.FileshareManagementMsg, <-chan interface{}) {
+func startFileshare(uid uint32) (chan<- norduser.FileshareManagementMsg, <-chan any) {
 	fileshareManagementChan, fileshareShutdownChan := norduser.StartFileshareManagementLoop()
 	if enable, err := shouldEnableFileshare(uid); err != nil {
 		log.Error("Failed to determine if fileshare should be enabled on startup:", err)
@@ -234,7 +234,7 @@ func startSnap() {
 		os.Exit(int(childprocess.CodeFailedToEnable))
 	}
 
-	logoutChan := make(chan interface{})
+	logoutChan := make(chan any)
 	go func() {
 		if err := norduser.WaitForLogout(usr.Username, logoutChan); err != nil {
 			log.Error("failed to start logout monitor:", err)
@@ -340,7 +340,7 @@ func start() {
 	log.Info("Norduser daemon has started")
 
 	// logoutChan is not needed in non-snap environment, as startup/shutdown on login/logout is managed by the main daemon
-	waitForShutdown(stopChan, fileshareManagementChan, fileshareShutdownChan, make(<-chan interface{}),
+	waitForShutdown(stopChan, fileshareManagementChan, fileshareShutdownChan, make(<-chan any),
 		grpcServer,
 		func(disable bool) {})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -51,10 +51,10 @@ type Config struct {
 	MachineID       uuid.UUID           `json:"machine_id,omitempty"`
 	LanDiscovery    bool                `json:"lan_discovery"`
 	RemoteConfig    string              `json:"remote_config,omitempty"`
-	RCLastUpdate    time.Time           `json:"rc_last_update,omitempty"`
+	RCLastUpdate    time.Time           `json:"rc_last_update"`
 	// Indicates whether the virtual servers are used. True by default
-	VirtualLocation TrueField `json:"virtual_location,omitempty"`
-	ARPIgnore       TrueField `json:"arp_ignore,omitempty"`
+	VirtualLocation TrueField `json:"virtual_location"`
+	ARPIgnore       TrueField `json:"arp_ignore"`
 	DeviceUUID      uuid.UUID `json:"device_uuid"`
 }
 
@@ -85,7 +85,7 @@ type AutoConnectData struct {
 	ThreatProtectionLite bool      `json:"cybersec,omitempty"`
 	Obfuscate            bool      `json:"obfuscate,omitempty"`
 	DNS                  DNS       `json:"dns,omitempty"`
-	Allowlist            Allowlist `json:"whitelist,omitempty"`
+	Allowlist            Allowlist `json:"whitelist"`
 	PostquantumVpn       bool      `json:"postquantum_vpn"`
 }
 
@@ -105,7 +105,7 @@ type NCData struct {
 	Username       string    `json:"username,omitempty"`
 	Password       string    `json:"password,omitempty"`
 	Endpoint       string    `json:"endpoint,omitempty"`
-	ExpirationDate time.Time `json:"timestamp,omitempty"`
+	ExpirationDate time.Time `json:"timestamp"`
 }
 
 type meshnet struct {

--- a/config/machine_id.go
+++ b/config/machine_id.go
@@ -15,8 +15,10 @@ type MachineIDGetter interface {
 	GetMachineID() uuid.UUID
 }
 
-type FileReader func(fileName string) ([]byte, error)
-type HostNameReader func() (name string, err error)
+type (
+	FileReader     func(fileName string) ([]byte, error)
+	HostNameReader func() (name string, err error)
+)
 
 type generatorFn func() ([]byte, error)
 
@@ -185,7 +187,6 @@ func (getter *MachineID) readCPUSerial() ([]byte, error) {
 	}
 
 	val, err := getValueForKey(string(data), "Serial", ":")
-
 	if err != nil {
 		return nil, fmt.Errorf("no serial number found for CPU %w", err)
 	}
@@ -272,7 +273,7 @@ func (getter *MachineID) fallbackGenerateUUID() uuid.UUID {
 
 func getValueForKey(fileContent string, key string, delim string) (string, error) {
 	trimmedKey := strings.TrimSpace(key)
-	for _, line := range strings.Split(fileContent, "\n") {
+	for line := range strings.SplitSeq(fileContent, "\n") {
 		parts := strings.SplitN(line, delim, 2)
 		if len(parts) != 2 {
 			continue

--- a/config/manager.go
+++ b/config/manager.go
@@ -285,7 +285,7 @@ func generateKey() []byte {
 	source := rand.NewSource(time.Now().UnixNano())
 	// #nosec G404 -- config encryption will go away after OSS
 	r := rand.New(source)
-	for i := 0; i < 32; i++ {
+	for range 32 {
 		character := r.Intn(max-min) + min
 		key = append(key, byte(character))
 	}

--- a/config/remote/analytics_builder_test.go
+++ b/config/remote/analytics_builder_test.go
@@ -120,7 +120,7 @@ func TestDebuggerEventContainsOnlyDesignedFields(t *testing.T) {
 	event := NewDownloadFailureEvent(rolloutGroup, "test-env", FeatureLibtelio, DownloadErrorIntegrity, "Integrity corrupted")
 	debugerEvent := event.ToDebuggerEvent()
 
-	var payload map[string]interface{}
+	var payload map[string]any
 	err := json.Unmarshal([]byte(debugerEvent.JsonData), &payload)
 	require.NoError(t, err, "JSON should be valid")
 

--- a/config/remote/analytics_deduplication_test.go
+++ b/config/remote/analytics_deduplication_test.go
@@ -611,7 +611,7 @@ func TestClearEventFlagsRaceCondition(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-startSignal // Wait for signal to start
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			feature := features[i%len(features)]
 			analytics.EmitPartialRolloutEvent(ClientCli, feature, i%100, true)
 		}
@@ -621,7 +621,7 @@ func TestClearEventFlagsRaceCondition(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-startSignal // Wait for signal to start
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			analytics.ClearEventFlags()
 		}
 	}()
@@ -630,7 +630,7 @@ func TestClearEventFlagsRaceCondition(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-startSignal // Wait for signal to start
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			if i%2 == 0 {
 				analytics.ClearEventFlags()
 			} else {

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -1025,7 +1025,7 @@ func TestHandleIncludeFilesEdgeCases(t *testing.T) {
 				return &mockFileSystem{
 					files: map[string][]byte{
 						"test.json":      []byte(nonJsonInclude),
-						"test-hash.json": []byte(fmt.Sprintf(`{"hash": "%s"}`, nonJsonHash)),
+						"test-hash.json": fmt.Appendf(nil, `{"hash": "%s"}`, nonJsonHash),
 					},
 				}
 			}(),
@@ -1042,7 +1042,7 @@ func TestHandleIncludeFilesEdgeCases(t *testing.T) {
 				return &mockFileSystem{
 					files: map[string][]byte{
 						"test.json":             []byte(mainJson),
-						"test-hash.json":        []byte(fmt.Sprintf(`{"hash": "%s"}`, mainHash)),
+						"test-hash.json":        fmt.Appendf(nil, `{"hash": "%s"}`, mainHash),
 						"include/settings.json": []byte(`{"key": "value"}`),
 						// Missing include/settings-hash.json
 					},
@@ -1061,7 +1061,7 @@ func TestHandleIncludeFilesEdgeCases(t *testing.T) {
 				return &mockFileSystem{
 					files: map[string][]byte{
 						"test.json":                  []byte(mainJson),
-						"test-hash.json":             []byte(fmt.Sprintf(`{"hash": "%s"}`, mainHash)),
+						"test-hash.json":             fmt.Appendf(nil, `{"hash": "%s"}`, mainHash),
 						"include/settings.json":      []byte(`{"key": "value"}`),
 						"include/settings-hash.json": []byte("invalid json"),
 					},
@@ -1080,7 +1080,7 @@ func TestHandleIncludeFilesEdgeCases(t *testing.T) {
 				return &mockFileSystem{
 					files: map[string][]byte{
 						"test.json":                  []byte(mainJson),
-						"test-hash.json":             []byte(fmt.Sprintf(`{"hash": "%s"}`, mainHash)),
+						"test-hash.json":             fmt.Appendf(nil, `{"hash": "%s"}`, mainHash),
 						"include/settings.json":      []byte(`{"key": "value"}`),
 						"include/settings-hash.json": []byte(`{"hash": "wronghash"}`),
 					},

--- a/config/remote/data_test.go
+++ b/config/remote/data_test.go
@@ -50,7 +50,7 @@ func TestFeatureOrderFixed(t *testing.T) {
 	const featureNamePattern = "feature-%d"
 
 	featureMap := NewFeatureMap()
-	for i := 0; i < featureCount; i++ {
+	for i := range featureCount {
 		featureMap.add(fmt.Sprintf(featureNamePattern, i))
 	}
 	assert.Equal(t, featureCount, len(featureMap.keys()))

--- a/config/remote/utils_test.go
+++ b/config/remote/utils_test.go
@@ -31,7 +31,7 @@ func TestGroupDistribution(t *testing.T) {
 	defer uuid.DisableRandPool()
 
 	groups := make([]int, iterations)
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		id := uuid.New()
 		g := GenerateRolloutGroup(id)
 		groups[i] = g

--- a/config/static_config_test.go
+++ b/config/static_config_test.go
@@ -213,7 +213,7 @@ func TestConcurrentAccess(t *testing.T) {
 
 	// Test concurrent reads
 	done := make(chan bool, 10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			rolloutGroup, err := manager.GetRolloutGroup()
 			assert.NilError(t, err)
@@ -223,7 +223,7 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 
 	// Wait for all goroutines to complete
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 }

--- a/config/token.go
+++ b/config/token.go
@@ -15,6 +15,6 @@ type TokenData struct {
 	NordLynxPrivateKey     string     `json:"nordlynx_private_key"`
 	OpenVPNUsername        string     `json:"openvpn_username"`
 	OpenVPNPassword        string     `json:"openvpn_password"`
-	NCData                 NCData     `json:"nc_data,omitempty"`
+	NCData                 NCData     `json:"nc_data"`
 	IdempotencyKey         *uuid.UUID `json:"idempotency_key,omitempty"`
 }

--- a/core/models.go
+++ b/core/models.go
@@ -118,7 +118,7 @@ type ServiceData struct {
 	ID        int64          `json:"ID"`
 	ExpiresAt string         `json:"expires_at"`
 	Service   Service        `json:"service"`
-	Details   ServiceDetails `json:"details,omitempty"`
+	Details   ServiceDetails `json:"details"`
 }
 
 type Service struct {
@@ -150,14 +150,14 @@ type Order struct {
 }
 
 type PaymentResponse struct {
-	Payment Payment `json:"payment,omitempty"`
+	Payment Payment `json:"payment"`
 }
 
 type Payment struct {
-	CreatedAt    time.Time    `json:"created_at,omitempty"`
-	Subscription Subscription `json:"subscription,omitempty"`
+	CreatedAt    time.Time    `json:"created_at"`
+	Subscription Subscription `json:"subscription"`
 	Status       string       `json:"status,omitempty"`
-	Payer        Payer        `json:"payer,omitempty"`
+	Payer        Payer        `json:"payer"`
 	Amount       float32      `json:"amount,omitempty"`
 	Currency     string       `json:"currency,omitempty"`
 	Provider     string       `json:"provider,omitempty"`
@@ -234,8 +234,8 @@ type Technology struct {
 	ID       ServerTechnology `json:"id"`
 	Pivot    Pivot            `json:"pivot"`
 	Metadata []struct {
-		Name  string      `json:"name,omitempty"`
-		Value interface{} `json:"value,omitempty"`
+		Name  string `json:"name,omitempty"`
+		Value any    `json:"value,omitempty"`
 	} `json:"metadata"`
 }
 
@@ -584,7 +584,7 @@ type Country struct {
 	ID     int64  `json:"id"`
 	Name   string `json:"name"`
 	Code   string `json:"code"`
-	City   `json:"city,omitempty"`
+	City   `json:"city"`
 	Cities `json:"cities,omitempty"`
 }
 

--- a/daemon/allowlist/analytics.go
+++ b/daemon/allowlist/analytics.go
@@ -226,10 +226,10 @@ func (e *OperationEvent) ToDebuggerEvent() *events.DebuggerEvent {
 	if err != nil {
 		log.Error("failed to marshal operation-event:", err)
 		// Fallback: provide basic information we know for certain
-		jsonData = []byte(fmt.Sprintf(
+		jsonData = fmt.Appendf(nil,
 			`{"namespace":"%s","subscope":"%s","event":"%s","operation":"%s","result":"%s","error":"marshal_error"}`,
 			e.Namespace, e.Subscope, e.Event, e.Operation, e.Result,
-		))
+		)
 	}
 	return events.NewDebuggerEvent(string(jsonData)).
 		WithKeyBasedContextPaths(
@@ -256,10 +256,10 @@ func (e *SnapshotEvent) ToDebuggerEvent() *events.DebuggerEvent {
 	if err != nil {
 		log.Error("failed to marshal snapshot-event:", err)
 		// Fallback: provide basic information we know for certain
-		jsonData = []byte(fmt.Sprintf(
+		jsonData = fmt.Appendf(nil,
 			`{"namespace":"%s","subscope":"%s","event":"%s","error":"marshal_error"}`,
 			e.Namespace, e.Subscope, e.Event,
-		))
+		)
 	}
 	return events.NewDebuggerEvent(string(jsonData)).
 		WithKeyBasedContextPaths(

--- a/daemon/atomic_login_type_test.go
+++ b/daemon/atomic_login_type_test.go
@@ -66,11 +66,11 @@ func TestAtomicLoginTypeConcurrency(t *testing.T) {
 	iterations := 1000
 
 	// Writers
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < iterations; j++ {
+			for range iterations {
 				if id%2 == 0 {
 					alt.set(pb.LoginType_LoginType_LOGIN)
 				} else {
@@ -81,27 +81,23 @@ func TestAtomicLoginTypeConcurrency(t *testing.T) {
 	}
 
 	// Readers
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := 0; j < iterations; j++ {
+	for range 10 {
+		wg.Go(func() {
+			for range iterations {
 				_ = alt.get()
 				_ = alt.isUnknown()
 				_ = alt.wasStarted()
 			}
-		}()
+		})
 	}
 
 	// Reseters
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 5 {
+		wg.Go(func() {
 			for j := 0; j < iterations/10; j++ {
 				alt.reset()
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/daemon/connect_server.go
+++ b/daemon/connect_server.go
@@ -20,8 +20,8 @@ func (connectServer) SetHeader(metadata.MD) error  { return nil }
 func (connectServer) SendHeader(metadata.MD) error { return nil }
 func (connectServer) SetTrailer(metadata.MD)       {}
 func (connectServer) Context() context.Context     { return nil }
-func (connectServer) SendMsg(m interface{}) error  { return nil }
-func (connectServer) RecvMsg(m interface{}) error  { return nil }
+func (connectServer) SendMsg(m any) error          { return nil }
+func (connectServer) RecvMsg(m any) error          { return nil }
 func (a *connectServer) Send(data *pb.Payload) error {
 	switch data.GetType() {
 	case internal.CodeFailure:

--- a/daemon/dns/hosts.go
+++ b/daemon/dns/hosts.go
@@ -118,7 +118,7 @@ func setHostLines(content []byte, hosts Hosts) []byte {
 func removeHostLinesFrom(content []byte) []byte {
 	lines := [][]byte{}
 	// Remove the .nord lines
-	for _, line := range bytes.Split(content, []byte{'\n'}) {
+	for line := range bytes.SplitSeq(content, []byte{'\n'}) {
 		if !bytes.HasSuffix(line, []byte(mark)) {
 			lines = append(lines, line)
 		}

--- a/daemon/dns/nameservers_test.go
+++ b/daemon/dns/nameservers_test.go
@@ -88,7 +88,7 @@ func TestNameservers(t *testing.T) {
 			wg.Wait()
 
 			// retry several times to fetch the servers, because at first attempt internal members might not be stored
-			for retry := 0; retry < 2; retry++ {
+			for range 2 {
 				if slices.Contains(servers.Get(test.threatProtectionLite), test.expected[0]) {
 					break
 				}

--- a/daemon/ens/analytics.go
+++ b/daemon/ens/analytics.go
@@ -59,10 +59,10 @@ func (e *vpnConnectionErrorEvent) ToDebuggerEvent() *events.DebuggerEvent {
 	jsonData, err := json.Marshal(e)
 	if err != nil {
 		log.Error("failed to marshal ENS connection error event:", err)
-		jsonData = []byte(fmt.Sprintf(
+		jsonData = fmt.Appendf(nil,
 			`{"namespace":"%s","subscope":"%s","event":"%s","code":"%s","error":"marshal_error"}`,
 			e.Namespace, e.Subscope, e.Event, e.Code,
-		))
+		)
 	}
 	return events.NewDebuggerEvent(string(jsonData)).
 		WithKeyBasedContextPaths(

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -19,21 +19,21 @@ func TestNewDaemonSubjects(t *testing.T) {
 // isValid returns true if given val is not nil. In case val is struct,
 // it checks if any of exported fields are not nil
 // Also, returns the minimum number of a private map field elements
-func isValid(val interface{}) (bool, int) {
+func isValid(val any) (bool, int) {
 	return isValidGetMin(val, math.MaxInt32)
 }
 
-func isValidGetMin(val interface{}, min int) (bool, int) {
+func isValidGetMin(val any, min int) (bool, int) {
 	v := reflect.ValueOf(val)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return false, -1
 		}
 		v = reflect.ValueOf(v.Elem().Interface())
 	}
 	if v.Kind() == reflect.Struct {
-		for i := 0; i < v.NumField(); i++ {
-			field := v.Field(i)
+		for _, field := range v.Fields() {
+			field := field
 			subMin := min
 			if !isPrivate(field) {
 				var valid bool

--- a/daemon/firewall/analytics.go
+++ b/daemon/firewall/analytics.go
@@ -102,10 +102,10 @@ func (e *ConfigureEvent) ToDebuggerEvent() *events.DebuggerEvent {
 	if err != nil {
 		log.Error("failed to marshal firewall configure event:", err)
 		// Fallback: provide basic information we know for certain
-		jsonData = []byte(fmt.Sprintf(
+		jsonData = fmt.Appendf(nil,
 			`{"namespace":"%s","subscope":"%s","event":"%s","status":"%s","purpose":[],"error":"marshal_error"}`,
 			e.Namespace, e.Subscope, e.Event, e.Status,
-		))
+		)
 	}
 	return events.NewDebuggerEvent(string(jsonData)).
 		WithKeyBasedContextPaths(
@@ -162,10 +162,10 @@ func (e *MigrationEvent) ToDebuggerEvent() *events.DebuggerEvent {
 	if err != nil {
 		log.Error("failed to marshal migration event:", err)
 		// Fallback: provide basic information we know for certain
-		jsonData = []byte(fmt.Sprintf(
+		jsonData = fmt.Appendf(nil,
 			`{"namespace":"%s","subscope":"%s","event":"%s","status":"%s","error":"marshal_error"}`,
 			e.Namespace, e.Subscope, e.Event, e.Status,
-		))
+		)
 	}
 	return events.NewDebuggerEvent(string(jsonData)).
 		WithKeyBasedContextPaths(

--- a/daemon/firewall/iptables/iptables.go
+++ b/daemon/firewall/iptables/iptables.go
@@ -23,7 +23,7 @@ var (
 func generateFlushRules(rules string, table string) []string {
 	re := regexp.MustCompile(fmt.Sprintf(`--comment\s+%s(?:\s|$)`, regexp.QuoteMeta(defaultComment)))
 	flushRules := []string{}
-	for _, rule := range strings.Split(rules, "\n") {
+	for rule := range strings.SplitSeq(rules, "\n") {
 		if re.MatchString(rule) {
 			newRule := fmt.Sprintf("-t %s %s", table, strings.Replace(rule, "-A", "-D", 1))
 			flushRules = append(flushRules, newRule)

--- a/daemon/jobs.go
+++ b/daemon/jobs.go
@@ -144,7 +144,7 @@ func (r *RPC) StartRemoteConfigLoaderJob(
 	// on first try - load remote config in non-blocking goroutine
 	go func(rcl remote.ConfigLoader) {
 		// try to load remote config 5 times with exponential backoff
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			err := rcl.Load()
 			if err == nil {
 				return

--- a/daemon/penalty_test.go
+++ b/daemon/penalty_test.go
@@ -127,12 +127,14 @@ func TestPenalty(t *testing.T) {
 		userCountry, serverCountry                           string
 		hubscore, randomComponent, expected, expectedPartial float64
 	}{
-		{true, 7000, 500, 8579,
+		{
+			true, 7000, 500, 8579,
 			1552329600, 1545329600, 1555329600,
 			20, "us", "uk", 0.68, 0,
 			4.936194, 0.936194,
 		},
-		{false, 500, 500, 10000,
+		{
+			false, 500, 500, 10000,
 			1552329600, 1522781999, 1522981000,
 			45, "tl", "tl", 0, 0,
 			869.8740656, 0.000142,
@@ -145,7 +147,7 @@ func TestPenalty(t *testing.T) {
 		if item.hubscore == 0 {
 			hubScore = nil
 		}
-		for i := 0; i < 500; i++ {
+		for range 500 {
 			// run through some different random values
 			item.randomComponent = randFloat(time.Now().UnixNano(), 0, 0.001)
 			got, gotPartial := penalty(item.obfuscated, item.d, item.dmin, item.dmax, item.t, item.tmin, item.tmax,

--- a/daemon/random_test.go
+++ b/daemon/random_test.go
@@ -23,7 +23,7 @@ func TestRandFloat(t *testing.T) {
 	}
 
 	for _, item := range testData {
-		for i := 0; i < 500; i++ {
+		for range 500 {
 			got := randFloat(time.Now().Unix(), item.min, item.max)
 			assert.Greater(t, got, item.min)
 			assert.Less(t, got, item.max)

--- a/daemon/recent_connections_rpc_helper_test.go
+++ b/daemon/recent_connections_rpc_helper_test.go
@@ -161,7 +161,7 @@ func TestStorePendingRecentConnection_ConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	const goroutines = 10
 
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()

--- a/daemon/recents/recent_connections_test.go
+++ b/daemon/recents/recent_connections_test.go
@@ -122,7 +122,7 @@ func TestRecentConnectionsStore_Add_RespectsCapacityLimit(t *testing.T) {
 	fs := fs.NewSystemFileHandleMock(t)
 	store := NewRecentConnectionsStore("/test/path", &fs, nil)
 
-	for i := 0; i < maxRecentConnections+5; i++ {
+	for i := range maxRecentConnections + 5 {
 		conn := Model{
 			Country:        string(rune('A' + i)),
 			ConnectionType: config.ServerSelectionRule_COUNTRY,
@@ -286,6 +286,7 @@ func TestRecentConnectionsStore_Persistence(t *testing.T) {
 		assert.Equal(t, connections[len(connections)-1-i], loadedConnections[i])
 	}
 }
+
 func TestRecentConnectionsStore_ConcurrentAccess(t *testing.T) {
 	category.Set(t, category.Unit)
 
@@ -314,32 +315,26 @@ func TestRecentConnectionsStore_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	errChan := make(chan error, 100)
 
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 5 {
+		wg.Go(func() {
 			if err := store.Add(denmark); err != nil {
 				errChan <- fmt.Errorf("add Denmark: %w", err)
 			}
-		}()
+		})
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if err := store.Add(finland); err != nil {
 				errChan <- fmt.Errorf("add Finland: %w", err)
 			}
-		}()
+		})
 	}
 
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 3 {
+		wg.Go(func() {
 			if err := store.Add(norway); err != nil {
 				errChan <- fmt.Errorf("add Norway: %w", err)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -347,7 +342,7 @@ func TestRecentConnectionsStore_ConcurrentAccess(t *testing.T) {
 	err := store.Clean()
 	require.NoError(t, err)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		country := Model{
 			Country:        fmt.Sprintf("Country%d", i),
 			ConnectionType: config.ServerSelectionRule_COUNTRY,
@@ -356,10 +351,8 @@ func TestRecentConnectionsStore_ConcurrentAccess(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			connections, err := store.Get()
 			if err != nil {
 				errChan <- fmt.Errorf("get connections: %w", err)
@@ -367,7 +360,7 @@ func TestRecentConnectionsStore_ConcurrentAccess(t *testing.T) {
 			if len(connections) != 3 {
 				errChan <- fmt.Errorf("expected 3 connections, got %d", len(connections))
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -404,7 +397,7 @@ func TestRecentConnectionsStore_RaceCondition(t *testing.T) {
 	var wg sync.WaitGroup
 	const iterations = 100
 
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		wg.Add(3)
 
 		go func(idx int) {
@@ -449,13 +442,11 @@ func TestRecentConnectionsStore_ConcurrentAdd_OrderingGuarantee(t *testing.T) {
 	var wg sync.WaitGroup
 	const goroutines = 50
 
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range goroutines {
+		wg.Go(func() {
 			err := store.Add(denmark)
 			assert.NoError(t, err)
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -907,7 +898,7 @@ func TestRecentConnectionsStore_AddPending_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	const goroutines = 50
 
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -1015,10 +1006,8 @@ func TestRecentConnectionsStore_PopPending_ConcurrentAccess(t *testing.T) {
 
 	const goroutines = 10
 
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range goroutines {
+		wg.Go(func() {
 			exists, _ := store.PopPending()
 			mu.Lock()
 			defer mu.Unlock()
@@ -1027,7 +1016,7 @@ func TestRecentConnectionsStore_PopPending_ConcurrentAccess(t *testing.T) {
 			} else {
 				errorCount++
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -1234,7 +1223,7 @@ func TestRecentConnectionsStore_EventPublisher_MultipleOperations(t *testing.T) 
 
 	store := NewRecentConnectionsStore("/test/path", &fs, eventPublisher)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		conn := Model{
 			Country:        fmt.Sprintf("Country%d", i),
 			ConnectionType: config.ServerSelectionRule_COUNTRY,
@@ -1275,7 +1264,7 @@ func TestRecentConnectionsStore_EventPublisher_ConcurrentOperations(t *testing.T
 	var wg sync.WaitGroup
 	const operations = 50
 
-	for i := 0; i < operations; i++ {
+	for i := range operations {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()

--- a/daemon/response/validate.go
+++ b/daemon/response/validate.go
@@ -142,8 +142,8 @@ func parseRSAPublicKey(rawKey []byte) (*rsa.PublicKey, error) {
 
 func parseKeyVal(str string) (map[string]string, error) {
 	keyVal := map[string]string{}
-	pairs := strings.Split(str, ",")
-	for _, pair := range pairs {
+	pairs := strings.SplitSeq(str, ",")
+	for pair := range pairs {
 		parts := strings.Split(pair, "=")
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid key-value format")
@@ -161,6 +161,7 @@ func getSignAlgoName(name string) string {
 	}
 	return ""
 }
+
 func getHashFunction(name string) func([]byte) []byte {
 	switch name {
 	case "sha256":
@@ -171,5 +172,5 @@ func getHashFunction(name string) func([]byte) []byte {
 
 func getSHA256Hash(data []byte) []byte {
 	sum := sha256.Sum256(data)
-	return []byte(fmt.Sprintf("%x", sum))
+	return fmt.Appendf(nil, "%x", sum)
 }

--- a/daemon/rpc_diagnostics.go
+++ b/daemon/rpc_diagnostics.go
@@ -817,7 +817,7 @@ func collectDesktopEnvironment(logf logFunc) string {
 		return fmt.Sprintf("loginctl error: %v\n", err)
 	}
 	var b strings.Builder
-	for _, session := range strings.Split(
+	for session := range strings.SplitSeq(
 		strings.TrimSpace(string(output)), "\n",
 	) {
 		fields := strings.Fields(session)

--- a/daemon/rpc_diagnostics_test.go
+++ b/daemon/rpc_diagnostics_test.go
@@ -463,7 +463,7 @@ func TestStreamFileToWriter_RespectsDaemonLogCap(t *testing.T) {
 	path := filepath.Join(t.TempDir(), uuid.NewString()+".log")
 	// 1 KiB of recognisable lines: 100 lines × ~10 bytes each.
 	var content bytes.Buffer
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		fmt.Fprintf(&content, "line %03d\n", i) // 9 bytes/line incl. newline
 	}
 	require.NoError(t, os.WriteFile(path, content.Bytes(), 0o600))
@@ -580,7 +580,7 @@ func TestCreateDiagnosticsZip_UniqueFilename(t *testing.T) {
 
 	const N = 5
 	seen := make(map[string]bool, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		f, err := createDiagnosticsZip(dir)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())

--- a/daemon/rpc_state_test.go
+++ b/daemon/rpc_state_test.go
@@ -118,8 +118,7 @@ func TestSubscribeToStateChanges_NoPeerContext(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	srv := &testStateServer{ctx: ctx, wg: &wg, states: make([]*pb.AppState, 0)}
 
 	r := testRPC()

--- a/daemon/session_error_handler_test.go
+++ b/daemon/session_error_handler_test.go
@@ -879,17 +879,15 @@ func TestSessionErrorHandler_ConcurrentLogoutPrevention(t *testing.T) {
 	numGoroutines := 5
 	startSignal := make(chan struct{})
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			<-startSignal
 			atomic.AddInt32(&handlerCalls, 1)
 			handlers := errorRegistry.GetHandlers(core.ErrUnauthorized)
 			for _, handler := range handlers {
 				handler(core.ErrUnauthorized)
 			}
-		}()
+		})
 	}
 
 	close(startSignal)
@@ -1006,20 +1004,16 @@ func TestSessionErrorHandler_ConcurrentAPICallsWithErrors(t *testing.T) {
 
 	startSignal := make(chan struct{})
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			<-startSignal
 			_, _ = smartAPI.CurrentUser()
-		}()
+		})
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-startSignal
 			_, _ = smartAPI.Services()
-		}()
+		})
 	}
 
 	close(startSignal)

--- a/daemon/versions_test.go
+++ b/daemon/versions_test.go
@@ -20,14 +20,22 @@ func TestGetLatestVersion(t *testing.T) {
 		input    []semver.Version
 		expected semver.Version
 	}{
-		{[]semver.Version{*semver.New("1.2.3-0"),
-			*semver.New("3.0.0-3"),
-			*semver.New("0.1.3-1"),
-			*semver.New("10.12.19-39")},
-			*semver.New("10.12.19-39")},
-		{[]semver.Version{*semver.New("3.0.0-0"),
-			*semver.New("3.0.0-1")},
-			*semver.New("3.0.0-1")},
+		{
+			[]semver.Version{
+				*semver.New("1.2.3-0"),
+				*semver.New("3.0.0-3"),
+				*semver.New("0.1.3-1"),
+				*semver.New("10.12.19-39"),
+			},
+			*semver.New("10.12.19-39"),
+		},
+		{
+			[]semver.Version{
+				*semver.New("3.0.0-0"),
+				*semver.New("3.0.0-1"),
+			},
+			*semver.New("3.0.0-1"),
+		},
 	}
 
 	for _, item := range tests {
@@ -39,8 +47,10 @@ func TestGetLatestVersion(t *testing.T) {
 func TestParseDebianVersions(t *testing.T) {
 	category.Set(t, category.File)
 
-	expected := []string{"2.2.0-0", "2.1.0-1", "3.0.0-2", "2.1.0-2", "2.0.0-0", "2.2.0-3", "3.0.0-4",
-		"2.1.0-5", "2.1.0-4", "2.1.0-0", "2.2.0-2", "3.0.0-1", "2.2.0-1", "3.0.0-3", "2.1.0-3"}
+	expected := []string{
+		"2.2.0-0", "2.1.0-1", "3.0.0-2", "2.1.0-2", "2.0.0-0", "2.2.0-3", "3.0.0-4",
+		"2.1.0-5", "2.1.0-4", "2.1.0-0", "2.2.0-2", "3.0.0-1", "2.2.0-1", "3.0.0-3", "2.1.0-3",
+	}
 	data, err := internal.FileRead(TestdataPath + TestVersionDeb)
 	assert.NoError(t, err)
 	parsed := ParseDebianVersions(data)
@@ -52,8 +62,10 @@ func TestParseDebianVersions(t *testing.T) {
 func TestParseRpmVersions(t *testing.T) {
 	category.Set(t, category.File)
 
-	expected := []string{"2.2.0-2", "3.0.0-4", "2.1.0-5", "2.1.0-1", "2.1.0-3", "2.1.0-2", "2.1.0-4",
-		"2.2.0-3", "2.1.0-0", "3.0.0-3", "2.2.0-0", "2.2.0-1", "2.0.0-1", "3.0.0-1", "3.0.0-2"}
+	expected := []string{
+		"2.2.0-2", "3.0.0-4", "2.1.0-5", "2.1.0-1", "2.1.0-3", "2.1.0-2", "2.1.0-4",
+		"2.2.0-3", "2.1.0-0", "3.0.0-3", "2.2.0-0", "2.2.0-1", "2.0.0-1", "3.0.0-1", "3.0.0-2",
+	}
 	data, err := internal.FileRead(TestdataPath + TestVersionRpm)
 	if err != nil {
 		t.Fatalf("ParseRpmVersions failed. Got error reading test file: %v.\n", err)
@@ -225,7 +237,7 @@ func TestParseRpmVersions_EdgeCases(t *testing.T) {
 				// Create a large input with many versions
 				var builder strings.Builder
 				builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
-				for i := 0; i < 100; i++ {
+				for i := range 100 {
 					builder.WriteString(fmt.Sprintf(`<package arch="x86_64" name="nordvpn" pkgid="test1"><version epoch="0" rel="%d" ver="1.0.%d" /></package>`, i%100, i%100))
 				}
 				return []byte(builder.String())

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -194,7 +194,7 @@ func newMockSystemEnvironment(t *testing.T) mockSystemEnvironment {
 
 	destinationDirectoryFilename := "tmp"
 	directories := fstest.MapFS{
-		destinationDirectoryFilename: &fstest.MapFile{Mode: os.ModeDir | 0777, Sys: stat_t},
+		destinationDirectoryFilename: &fstest.MapFile{Mode: os.ModeDir | 0o777, Sys: stat_t},
 	}
 
 	osInfo := mockEventManagerOsInfo{
@@ -260,7 +260,7 @@ func TestGetTransfers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 10, len(transfers))
 	// Check if ordered
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		assert.True(t, transfers[i].Created.AsTime().Before(transfers[i+1].Created.AsTime()))
 	}
 
@@ -383,8 +383,7 @@ func TestTransferProgress(t *testing.T) {
 	assert.Equal(t, expectedProgress, progressEvent.Transferred)
 
 	waitGroup := sync.WaitGroup{}
-	waitGroup.Add(1)
-	go func() {
+	waitGroup.Go(func() {
 		eventManager.Event(
 			Event{
 				Kind: EventKindFileDownloaded{
@@ -418,9 +417,7 @@ func TestTransferProgress(t *testing.T) {
 				},
 			},
 		)
-
-		waitGroup.Done()
-	}()
+	})
 
 	progressEvent = <-progCh
 	assert.Equal(t, pb.Status_SUCCESS, progressEvent.Status)
@@ -868,9 +865,9 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 			Gid: currentUserGID,
 		}
 		directories := fstest.MapFS{
-			"directory": &fstest.MapFile{Mode: os.ModeDir | 0777, Sys: stat_t},
-			"symlink":   &fstest.MapFile{Mode: os.ModeSymlink | 0777, Sys: stat_t},
-			"file":      &fstest.MapFile{Mode: 0777, Sys: stat_t},
+			"directory": &fstest.MapFile{Mode: os.ModeDir | 0o777, Sys: stat_t},
+			"symlink":   &fstest.MapFile{Mode: os.ModeSymlink | 0o777, Sys: stat_t},
+			"file":      &fstest.MapFile{Mode: 0o777, Sys: stat_t},
 		}
 
 		filesystem := mockEventManagerFilesystem{
@@ -1219,7 +1216,7 @@ func TestAutoaccept(t *testing.T) {
 
 	symlinkDirectoryName := "symlink"
 	mockOsEnvironment.MapFS[symlinkDirectoryName] = &fstest.MapFile{
-		Mode: os.ModeSymlink | 0777,
+		Mode: os.ModeSymlink | 0o777,
 		Sys: &syscall.Stat_t{
 			Uid: mockOsEnvironment.currentUserUID,
 			Gid: mockOsEnvironment.currentUserGID,
@@ -1228,7 +1225,7 @@ func TestAutoaccept(t *testing.T) {
 
 	fileDirectoryName := "not_dir"
 	mockOsEnvironment.MapFS[fileDirectoryName] = &fstest.MapFile{
-		Mode: 0777,
+		Mode: 0o777,
 		Sys: &syscall.Stat_t{
 			Uid: mockOsEnvironment.currentUserUID,
 			Gid: mockOsEnvironment.currentUserGID,
@@ -1417,7 +1414,7 @@ func TestEventsFlow(t *testing.T) {
 	// otherwise it's not chunked properly, as the size is not divisable by chunkSize(1026 % 8 = 2)
 	numProgressEvents := numEvents - uint64(len(events))
 
-	for i := uint64(0); i < numProgressEvents; i++ {
+	for i := range numProgressEvents {
 		events = append(events,
 			Event{
 				Kind: EventKindFileProgress{
@@ -1434,9 +1431,9 @@ func TestEventsFlow(t *testing.T) {
 	}
 
 	chunks := make([][]Event, chunkCount)
-	for i := uint64(0); i < chunkCount; i++ {
+	for i := range chunkCount {
 		chunks[i] = make([]Event, chunkSize)
-		for j := uint64(0); j < chunkSize; j++ {
+		for j := range chunkSize {
 			chunks[i][j] = events[(i*chunkSize)+j]
 		}
 	}
@@ -1463,7 +1460,7 @@ func TestEventsFlow(t *testing.T) {
 					em.Event(chunk...)
 				}
 				lastProgress := uint32(0)
-				for i := uint64(0); i < numProgressEvents; i++ {
+				for range numProgressEvents {
 					prog := <-progCh
 					if prog.Transferred < lastProgress {
 						t.Fatalf("unexpected `lastProgress` bigger than new `progress.Transferred`. it doesn't go in order: %d > %d", lastProgress, prog.Transferred)

--- a/fileshare/events.go
+++ b/fileshare/events.go
@@ -16,7 +16,7 @@ type Event struct {
 	Timestamp int64
 }
 
-type EventKind interface{}
+type EventKind any
 
 type EventKindRequestReceived struct {
 	Peer       string

--- a/fileshare/server_test.go
+++ b/fileshare/server_test.go
@@ -131,7 +131,7 @@ func populateMapFs(t *testing.T, mapfs *fstest.MapFS, directoryName string, file
 	t.Helper()
 
 	(*mapfs)[directoryName] = &fstest.MapFile{Mode: fs.ModeDir}
-	for filename := 0; filename < fileCount; filename++ {
+	for filename := range fileCount {
 		(*mapfs)[directoryName+"/"+strconv.Itoa(filename)] = &fstest.MapFile{}
 	}
 }
@@ -189,7 +189,7 @@ func getTransfers(t *testing.T, numberOfTransfers int) map[string]*pb.Transfer {
 	t.Helper()
 
 	transfersMap := make(map[string]*pb.Transfer, numberOfTransfers)
-	for transfer := 0; transfer < numberOfTransfers; transfer++ {
+	for transfer := range numberOfTransfers {
 		transferID := strconv.Itoa(transfer)
 		pbTransfer := &pb.Transfer{
 			Id: transferID,
@@ -375,7 +375,8 @@ func TestSend(t *testing.T) {
 				&pb.SendRequest{
 					Peer:   test.peer,
 					Paths:  []string{test.path},
-					Silent: test.transferSilent},
+					Silent: test.transferSilent,
+				},
 				&sendServer,
 			)
 			assert.Equal(t, nil, err)
@@ -394,7 +395,7 @@ func TestSendDirectoryFilesystemErrorHandling(t *testing.T) {
 
 	directoryTooDeepName := "directory_too_deep"
 	currentDir := directoryTooDeepName
-	for directory := 0; directory < 8; directory++ {
+	for directory := range 8 {
 		mockFs.MapFS[currentDir] = &fstest.MapFile{Mode: fs.ModeDir}
 		currentDir = currentDir + "/" + strconv.Itoa(directory)
 	}
@@ -507,13 +508,13 @@ func TestAccept(t *testing.T) {
 		Uid: currentUserUID,
 		Gid: currentUserGID,
 	}
-	mockFs.MapFS[acceptDirName] = &fstest.MapFile{Mode: os.ModeDir | 0777, Sys: statCurrentUserOwner}
+	mockFs.MapFS[acceptDirName] = &fstest.MapFile{Mode: os.ModeDir | 0o777, Sys: statCurrentUserOwner}
 
 	acceptSymlinkName := "link"
-	mockFs.MapFS[acceptSymlinkName] = &fstest.MapFile{Mode: os.ModeSymlink | 0777, Sys: statCurrentUserOwner}
+	mockFs.MapFS[acceptSymlinkName] = &fstest.MapFile{Mode: os.ModeSymlink | 0o777, Sys: statCurrentUserOwner}
 
 	acceptNotDirName := "not_dir"
-	mockFs.MapFS[acceptNotDirName] = &fstest.MapFile{Mode: 0777, Sys: statCurrentUserOwner}
+	mockFs.MapFS[acceptNotDirName] = &fstest.MapFile{Mode: 0o777, Sys: statCurrentUserOwner}
 
 	currentUserUIDStr := strconv.Itoa(int(currentUserUID))
 	currentUserGIDStr := strconv.Itoa(int(currentUserGID))
@@ -535,10 +536,10 @@ func TestAccept(t *testing.T) {
 	}
 
 	directoryGroupWriteName := "group_write"
-	mockFs.MapFS[directoryGroupWriteName] = &fstest.MapFile{Mode: os.ModeDir | 0220, Sys: statCurrentUserGroupOwner}
+	mockFs.MapFS[directoryGroupWriteName] = &fstest.MapFile{Mode: os.ModeDir | 0o220, Sys: statCurrentUserGroupOwner}
 
 	directoryGroupNoWrite := "group_no_write"
-	mockFs.MapFS[directoryGroupNoWrite] = &fstest.MapFile{Mode: os.ModeDir | 0200, Sys: statCurrentUserGroupOwner}
+	mockFs.MapFS[directoryGroupNoWrite] = &fstest.MapFile{Mode: os.ModeDir | 0o200, Sys: statCurrentUserGroupOwner}
 
 	statNoOwner := &syscall.Stat_t{
 		Uid: 2000,
@@ -546,11 +547,11 @@ func TestAccept(t *testing.T) {
 	}
 
 	directoryOtherWriteName := "other_write"
-	mockFs.MapFS[directoryOtherWriteName] = &fstest.MapFile{Mode: os.ModeDir | 0002, Sys: statNoOwner}
+	mockFs.MapFS[directoryOtherWriteName] = &fstest.MapFile{Mode: os.ModeDir | 0o002, Sys: statNoOwner}
 
 	directoryNoPermissionsName := "no_permissions"
 	//nolint:staticcheck
-	mockFs.MapFS[directoryNoPermissionsName] = &fstest.MapFile{Mode: os.ModeDir | 0000, Sys: statNoOwner}
+	mockFs.MapFS[directoryNoPermissionsName] = &fstest.MapFile{Mode: os.ModeDir | 0o000, Sys: statNoOwner}
 
 	fileshareTests := []struct {
 		testName          string
@@ -695,7 +696,8 @@ func TestAccept(t *testing.T) {
 				},
 			},
 			filesystem: &mockFs,
-			osInfo:     &mockOsInfo}
+			osInfo:     &mockOsInfo,
+		}
 		server := NewServer(
 			&mockServerFileshare{},
 			&eventManager,
@@ -773,7 +775,7 @@ func TestAcceptDirectory(t *testing.T) {
 	}
 
 	mockFs := newMockFilesystem()
-	mockFs.MapFS["tmp"] = &fstest.MapFile{Mode: fs.ModeDir | 0777, Sys: stat_t}
+	mockFs.MapFS["tmp"] = &fstest.MapFile{Mode: fs.ModeDir | 0o777, Sys: stat_t}
 
 	currentUserUIDStr := strconv.Itoa(int(currentUserUID))
 	currentUserGIDStr := strconv.Itoa(int(currentUserGID))
@@ -870,7 +872,8 @@ func TestAcceptDirectory(t *testing.T) {
 				},
 			},
 			filesystem: &mockFs,
-			osInfo:     &mockOsInfo}
+			osInfo:     &mockOsInfo,
+		}
 
 		fileshare := &mockServerFileshare{
 			acceptedFiles:          []string{},

--- a/fileshare/storage/combined.go
+++ b/fileshare/storage/combined.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"maps"
 	"os"
 	"time"
 
@@ -31,9 +32,7 @@ func (c *Combined) Load() (map[string]*pb.Transfer, error) {
 
 	jsonTransfers, err := c.json.Load()
 	if err == nil {
-		for key, value := range jsonTransfers {
-			libdropTransfers[key] = value
-		}
+		maps.Copy(libdropTransfers, jsonTransfers)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		log.Errorf("json history file corrupted: %s", err)
 	}

--- a/fileshare/storage/jsonfile_test.go
+++ b/fileshare/storage/jsonfile_test.go
@@ -167,7 +167,7 @@ func makeTransfer(transferID string, fileCount int, makeBigNames bool) *pb.Trans
 	}
 
 	var files []*pb.File
-	for i := 0; i < fileCount; i++ {
+	for i := range fileCount {
 		filePath := fmt.Sprintf("%s-%d", strings.Repeat("A", nameSize), i)
 		files = append(files, &pb.File{
 			Id:     fmt.Sprintf("%s-%d", "asdf845sad84fsadf485sa5d487", i),
@@ -230,7 +230,7 @@ func makeLegacyTransfer(transferID string, dirLevels, fileCount int, makeBigName
 		nameSize = 200
 	}
 
-	for i := 0; i < dirLevels; i++ {
+	for i := range dirLevels {
 		dirName := fmt.Sprintf("%s-%d", strings.Repeat("A", nameSize), i)
 		if crrDir == nil {
 			crrDir = &pb.File{
@@ -251,7 +251,7 @@ func makeLegacyTransfer(transferID string, dirLevels, fileCount int, makeBigName
 		}
 	}
 
-	for i := 0; i < fileCount; i++ {
+	for i := range fileCount {
 		fileID := fmt.Sprintf("%s-%d", strings.Repeat("A", nameSize), i)
 		crrDir.Children[fileID] = &pb.File{
 			Id:   fileID,

--- a/grpc_middleware/middleware.go
+++ b/grpc_middleware/middleware.go
@@ -7,14 +7,14 @@ import (
 	"google.golang.org/grpc"
 )
 
-type StreamMiddleware func(srv interface{},
+type StreamMiddleware func(srv any,
 	ss grpc.ServerStream,
 	info *grpc.StreamServerInfo) error
 
 type UnaryMiddleware func(
 	ctx context.Context,
-	req interface{},
-	info *grpc.UnaryServerInfo) (interface{}, error)
+	req any,
+	info *grpc.UnaryServerInfo) (any, error)
 
 type Middleware struct {
 	streamMiddleware []StreamMiddleware
@@ -34,10 +34,11 @@ func (m *Middleware) AddUnaryMiddleware(middleware UnaryMiddleware) {
 //	opts := []grpc.ServerOption{}
 //	opts = append(opts, grpc.StreamInterceptor(middleware.StreamIntercept))
 //	s := grpc.NewServer(opts...)
-func (m *Middleware) StreamIntercept(srv interface{},
+func (m *Middleware) StreamIntercept(srv any,
 	ss grpc.ServerStream,
 	info *grpc.StreamServerInfo,
-	handler grpc.StreamHandler) error {
+	handler grpc.StreamHandler,
+) error {
 	for _, m := range m.streamMiddleware {
 		if err := m(srv, ss, info); err != nil {
 			return err
@@ -53,10 +54,10 @@ func (m *Middleware) StreamIntercept(srv interface{},
 //	s := grpc.NewServer(opts...)
 func (m *Middleware) UnaryIntercept(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	for _, m := range m.unaryMiddleware {
 		if _, err := m(ctx, req, info); err != nil {
 			return nil, err

--- a/internal/caching/expiring_cache.go
+++ b/internal/caching/expiring_cache.go
@@ -124,7 +124,7 @@ func (c *Cache[T]) fetchLocked() (T, error) {
 		}
 
 		v := reflect.ValueOf(c.entry.data)
-		if v.Kind() == reflect.Ptr && v.IsNil() {
+		if v.Kind() == reflect.Pointer && v.IsNil() {
 			return zero, ErrNoCacheData
 		}
 

--- a/internal/caching/expiring_cache_test.go
+++ b/internal/caching/expiring_cache_test.go
@@ -265,7 +265,7 @@ func Test_ConcurrentAccess(t *testing.T) {
 	const numGoroutines = 10
 	done := make(chan bool, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			data, _ := cache.Get()
 			assert.Equal(t, 1, data, "expected all goroutines to get the same data")
@@ -274,7 +274,7 @@ func Test_ConcurrentAccess(t *testing.T) {
 	}
 
 	// wait for all goroutines to finish
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		<-done
 	}
 

--- a/internal/err_handler_registry_test.go
+++ b/internal/err_handler_registry_test.go
@@ -171,14 +171,14 @@ func Test_ThreadSafety(t *testing.T) {
 	// Concurrently add handlers for different errors
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			registry.Add(func(int) {}, err1)
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			registry.Add(func(int) {}, err2)
 		}
 	}()

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -523,7 +523,7 @@ func IsNetworkLinkUnmanaged(link string) bool {
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(strings.Trim(string(out), "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.Trim(string(out), "\n"), "\n") {
 		if strings.Contains(line, "State") && strings.Contains(line, "unmanaged") {
 			return true
 		}

--- a/internal/permissions.go
+++ b/internal/permissions.go
@@ -3,10 +3,13 @@ package internal
 import (
 	"fmt"
 	"os/user"
+	"slices"
 )
 
-var allowedGroups []string = []string{"nordvpn"}
-var ErrNoPermission error = fmt.Errorf("requesting user does not have permissions")
+var (
+	allowedGroups   []string = []string{"nordvpn"}
+	ErrNoPermission error    = fmt.Errorf("requesting user does not have permissions")
+)
 
 // IsInAllowedGroup returns true if user with the given UID is in nordvpn privileged group
 func IsInAllowedGroup(uid uint32) (bool, error) {
@@ -25,10 +28,8 @@ func IsInAllowedGroup(uid uint32) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("authenticate user, check user group: %s", err)
 		}
-		for _, allowGroupName := range allowedGroups {
-			if groupInfo.Name == allowGroupName {
-				return true, nil
-			}
+		if slices.Contains(allowedGroups, groupInfo.Name) {
+			return true, nil
 		}
 	}
 

--- a/internal/string.go
+++ b/internal/string.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -11,8 +12,8 @@ import (
 
 var notAlphanumeric = regexp.MustCompile(`[^0-9a-zA-Z \-_]+`)
 
-func StringsToInterfaces(strings []string) []interface{} {
-	interfaces := make([]interface{}, len(strings))
+func StringsToInterfaces(strings []string) []any {
+	interfaces := make([]any, len(strings))
 	for i, s := range strings {
 		interfaces[i] = s
 	}
@@ -29,14 +30,14 @@ func Title(name string) string {
 func SnakeCase(name string) string {
 	name = RemoveNonAlphanumeric(name)
 	splits := strings.Split(name, " ")
-	lower := ""
+	var lower strings.Builder
 	for _, v := range splits {
 		if len(v) == 0 {
 			continue
 		}
-		lower += strings.ToLower(v) + "_"
+		lower.WriteString(strings.ToLower(v) + "_")
 	}
-	return strings.TrimRight(lower, "_")
+	return strings.TrimRight(lower.String(), "_")
 }
 
 func RemoveNonAlphanumeric(name string) string {
@@ -44,12 +45,7 @@ func RemoveNonAlphanumeric(name string) string {
 }
 
 func StringsContains(haystack []string, needle string) bool {
-	for _, item := range haystack {
-		if item == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }
 
 func StringsGetNext(haystack []string, needle string) string {

--- a/internal/timezone.go
+++ b/internal/timezone.go
@@ -26,10 +26,10 @@ func Timezone() string {
 }
 
 func extractZone(input []byte) string {
-	for _, line := range strings.Split(string(input), "\n") {
+	for line := range strings.SplitSeq(string(input), "\n") {
 		prefix := "Timezone="
-		if strings.HasPrefix(line, prefix) {
-			return strings.TrimPrefix(line, prefix)
+		if after, ok := strings.CutPrefix(line, prefix); ok {
+			return after
 		}
 	}
 	return ""

--- a/ipv6/ipv6_test.go
+++ b/ipv6/ipv6_test.go
@@ -80,7 +80,7 @@ func TestGetRulesFrom(t *testing.T) {
 // parametersFrom parse output and put values into map
 func parametersFrom(output []byte) (map[string]int, error) {
 	rules := map[string]int{}
-	for _, line := range strings.Split(string(output), "\n") {
+	for line := range strings.SplitSeq(string(output), "\n") {
 		if line == "" {
 			continue
 		}

--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -32,7 +32,7 @@ func Parameter(prm string) (map[string]int, error) {
 // parametersFrom parse output and put values into map
 func parametersFrom(output []byte) (map[string]int, error) {
 	rules := map[string]int{}
-	for _, line := range strings.Split(string(output), "\n") {
+	for line := range strings.SplitSeq(string(output), "\n") {
 		if line == "" {
 			continue
 		}

--- a/nc/nc_test.go
+++ b/nc/nc_test.go
@@ -67,7 +67,7 @@ func (m *mockMqttClient) OptionsReader() mqtt.ClientOptionsReader {
 	})
 }
 
-func (m *mockMqttClient) Publish(topic string, qos byte, retained bool, payload interface{}) mqtt.Token {
+func (m *mockMqttClient) Publish(topic string, qos byte, retained bool, payload any) mqtt.Token {
 	return &mockMqttToken{}
 }
 
@@ -180,7 +180,7 @@ func TestStartStopNotificationClient(t *testing.T) {
 		},
 	}
 
-	mgmtChan := make(chan interface{})
+	mgmtChan := make(chan any)
 	go func() {
 		for {
 			<-mgmtChan
@@ -300,9 +300,9 @@ func TestConnectionCancellation(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			ctx, cancelFunc := context.WithCancel(context.Background())
-			connectedChan := make(chan interface{})
+			connectedChan := make(chan any)
 			go func() {
-				notificationClient.connect(&mockMqttClient, false, ctx, make(chan<- interface{}), make(chan<- mqtt.Client))
+				notificationClient.connect(&mockMqttClient, false, ctx, make(chan<- any), make(chan<- mqtt.Client))
 				connectedChan <- true
 			}()
 
@@ -403,7 +403,7 @@ func TestCreateClientOptions(t *testing.T) {
 				resolver:          tt.resolver,
 			}
 
-			mgmtChan := make(chan interface{}, 10)
+			mgmtChan := make(chan any, 10)
 			opts, err := client.createClientOptions(
 				creds, mgmtChan, context.Background(),
 			)
@@ -438,7 +438,7 @@ func TestCreateClientOptionsInvalidEndpoint(t *testing.T) {
 		Endpoint: "://invalid",
 	}
 
-	mgmtChan := make(chan interface{}, 10)
+	mgmtChan := make(chan any, 10)
 	_, err := client.createClientOptions(
 		creds, mgmtChan, context.Background(),
 	)
@@ -459,7 +459,7 @@ func TestCreateClientOptionsEndpointWithoutPort(t *testing.T) {
 		Endpoint: "ssl://mqtt.example.com",
 	}
 
-	mgmtChan := make(chan interface{}, 10)
+	mgmtChan := make(chan any, 10)
 	opts, err := client.createClientOptions(
 		creds, mgmtChan, context.Background(),
 	)

--- a/norduser/environ.go
+++ b/norduser/environ.go
@@ -7,8 +7,8 @@ import (
 )
 
 func findVariable(name string, environment string) string {
-	variables := strings.Split(environment, "\000")
-	for _, variable := range variables {
+	variables := strings.SplitSeq(environment, "\000")
+	for variable := range variables {
 		split := strings.Split(variable, "=")
 		if len(split) < 1 {
 			continue

--- a/norduser/fileshare.go
+++ b/norduser/fileshare.go
@@ -19,16 +19,16 @@ const (
 // StartFileshareManagementLoop starts the management loop in separate goroutine and returns a control channel and a
 // shutdown channel. Management loop will try to disable fileshare and close the shutdown chan when Shutdown message is
 // received.
-func StartFileshareManagementLoop() (chan<- FileshareManagementMsg, <-chan interface{}) {
+func StartFileshareManagementLoop() (chan<- FileshareManagementMsg, <-chan any) {
 	managementChan := make(chan FileshareManagementMsg)
-	shutdownChan := make(chan interface{})
+	shutdownChan := make(chan any)
 
 	go fileshareManagementLoop(managementChan, shutdownChan)
 
 	return managementChan, shutdownChan
 }
 
-func fileshareManagementLoop(managementChan <-chan FileshareManagementMsg, shutdownChan chan interface{}) {
+func fileshareManagementLoop(managementChan <-chan FileshareManagementMsg, shutdownChan chan any) {
 	fileshareProcessManager := fileshare_process.NewFileshareGRPCProcessManager()
 	for msg := range managementChan {
 		switch msg {
@@ -77,7 +77,7 @@ func startFileshare(fileshareProcessManager *childprocess.GRPCChildProcessManage
 
 func fileshareStartupLoop(fileshareProcessManager *childprocess.GRPCChildProcessManager,
 	managementChan <-chan FileshareManagementMsg,
-	shutdownChan chan interface{},
+	shutdownChan chan any,
 ) {
 	if startFileshare(fileshareProcessManager) {
 		return

--- a/norduser/group.go
+++ b/norduser/group.go
@@ -13,7 +13,7 @@ import (
 func findGroupEntry(groups string, groupName string) string {
 	r, _ := regexp.Compile(fmt.Sprintf("^%s:", groupName))
 
-	for _, groupEntry := range strings.Split(groups, "\n") {
+	for groupEntry := range strings.SplitSeq(groups, "\n") {
 		if r.MatchString(groupEntry) {
 			return groupEntry
 		}
@@ -75,7 +75,7 @@ func (osGetter) getUserID(username string) (userIDs, error) {
 		return userIDs{}, fmt.Errorf("looking up user: %w", err)
 	}
 
-	//both uid and gid are base-10 numbers
+	// both uid and gid are base-10 numbers
 	uid, err := strconv.ParseUint(user.Uid, 10, 32)
 	if err != nil {
 		return userIDs{}, fmt.Errorf("converting uid string to int: %w", err)

--- a/norduser/process_monitor_snap.go
+++ b/norduser/process_monitor_snap.go
@@ -10,7 +10,8 @@ import (
 )
 
 func (n *NorduserProcessMonitor) stopForDeletedGroupMembers(currentGroupMembers []string,
-	newGroupMembers []string) []string {
+	newGroupMembers []string,
+) []string {
 	groupMembersUpdate := []string{}
 	for _, username := range currentGroupMembers {
 		if slices.Contains(newGroupMembers, username) {
@@ -36,7 +37,7 @@ func (n *NorduserProcessMonitor) stopForDeletedGroupMembers(currentGroupMembers 
 
 // WaitForLogout will send over logoutChan when user under the username logs out(i.e there are no remaining user
 // processes for that user).
-func WaitForLogout(username string, logoutChan chan<- interface{}) error {
+func WaitForLogout(username string, logoutChan chan<- any) error {
 	watcher, err := filewatch.GetFileWatcher(utmpFilePath)
 	if err != nil {
 		return fmt.Errorf("creating a fsnotify watcher for utmp file: %w", err)

--- a/norduser/service/fork.go
+++ b/norduser/service/fork.go
@@ -51,7 +51,7 @@ func handlePsError(out []byte, err error) error {
 
 func parseNorduserPIDs(psOutput string) []int {
 	pids := []int{}
-	for _, pidStr := range strings.Split(psOutput, "\n") {
+	for pidStr := range strings.SplitSeq(psOutput, "\n") {
 		pidStr = strings.TrimSpace(pidStr)
 		if pidStr == "" {
 			continue
@@ -79,7 +79,7 @@ func getRunningNorduserPIDs() ([]int, error) {
 }
 
 func findPIDOfUID(uids string, desiredUID uint32) int {
-	for _, uidPid := range strings.Split(uids, "\n") {
+	for uidPid := range strings.SplitSeq(uids, "\n") {
 		var pid int
 		var uid int
 		n, err := fmt.Sscanf(uidPid, "%d%d", &uid, &pid)
@@ -151,11 +151,9 @@ func (c *ChildProcessNorduser) Enable(uid uint32, gid uint32, home string) (err 
 		return fmt.Errorf("starting the process: %w", err)
 	}
 
-	c.wg.Add(1)
-	go func() {
+	c.wg.Go(func() {
 		_ = cmd.Wait()
-		c.wg.Done()
-	}()
+	})
 
 	return nil
 }
@@ -208,7 +206,7 @@ func (c *ChildProcessNorduser) StopAll() {
 		}
 	}
 
-	doneChan := make(chan interface{})
+	doneChan := make(chan any)
 	go func() {
 		c.wg.Wait()
 		doneChan <- struct{}{}
@@ -290,7 +288,7 @@ func (s *systemGIDProvider) GetNordvpnGid() (uint32, error) {
 		return 0, errors.New("negative gid cannot be converted to uint32")
 	}
 
-	//no gosec violation, current Linux distributions use GID lower than uint32 max value
+	// no gosec violation, current Linux distributions use GID lower than uint32 max value
 	// #nosec G115
 	return uint32(gid), nil
 }

--- a/norduser/service/snap.go
+++ b/norduser/service/snap.go
@@ -48,14 +48,14 @@ func (n NorduserSnap) stopAll(disable bool) {
 	}
 	uids = strings.Trim(uids, "\n")
 
-	for _, uid := range strings.Split(uids, "\n") {
+	for uid := range strings.SplitSeq(uids, "\n") {
 		uidInt, err := strconv.ParseUint(strings.TrimSpace(uid), 10, 32)
 		if err != nil {
 			log.Errorf("Invalid unix user id, failed to convert from string: %s", uid)
 			continue
 		}
 
-		//parsed value is within uint32 range
+		// parsed value is within uint32 range
 		// #nosec G115
 		if err := process.NewNorduserGRPCProcessManager(uint32(uidInt)).StopProcess(disable); err != nil {
 			log.Error("Failed to stop norduserd for uid: ", uid)

--- a/request/h3_reproduce_race_test.go
+++ b/request/h3_reproduce_race_test.go
@@ -1,5 +1,4 @@
 //go:build race_repro
-// +build race_repro
 
 package request
 

--- a/request/http_retransport_test.go
+++ b/request/http_retransport_test.go
@@ -51,16 +51,14 @@ func TestHTTPReTransport_RoundTrip(t *testing.T) {
 	// Wrap access to `errs` with mutex to avoid modifying from same value twice.
 	mu := sync.Mutex{}
 	var errs []error
-	for i := 0; i < iterations; i++ {
-		wg.Add(1)
-		go func() {
+	for range iterations {
+		wg.Go(func() {
 			//nolint:bodyclose
 			_, err := transport.RoundTrip(&http.Request{})
 			mu.Lock()
 			errs = append(errs, err)
 			mu.Unlock()
-			wg.Done()
-		}()
+		})
 	}
 	// Wait until all of RoundTrip calls are started.
 	wg.Wait()

--- a/request/publishing_test.go
+++ b/request/publishing_test.go
@@ -22,7 +22,7 @@ func areParametersEqual(a string, b string) bool {
 		return false
 	}
 
-	for _, parameter := range strings.Split(a, "&") {
+	for parameter := range strings.SplitSeq(a, "&") {
 		if !strings.Contains(b, parameter) {
 			return false
 		}

--- a/request/rotating_test.go
+++ b/request/rotating_test.go
@@ -191,14 +191,12 @@ func TestRotatingRoundTripper_RoundTripThreadSafety(t *testing.T) {
 					}
 					continue
 				}
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					resp, err := tt.roundTripper.RoundTrip(&http.Request{})
 					if err != nil {
 						defer resp.Body.Close()
 					}
-				}()
+				})
 			}
 			wg.Wait()
 			now := time.Now()

--- a/session/validation_helpers_test.go
+++ b/session/validation_helpers_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -504,7 +505,7 @@ func TestValidateExpiry_TimeBoundary(t *testing.T) {
 		pastTime := time.Now().Add(-time.Hour)
 
 		done := make(chan bool, 10)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			go func(i int) {
 				if i%2 == 0 {
 					err := ValidateExpiry(futureTime)
@@ -517,7 +518,7 @@ func TestValidateExpiry_TimeBoundary(t *testing.T) {
 			}(i)
 		}
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			<-done
 		}
 	})
@@ -540,12 +541,12 @@ func TestValidateAccessTokenFormat_ExactLengthBoundaries(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		token := ""
+		var token strings.Builder
 		for i := 0; i < tc.length; i++ {
-			token += "a"
+			token.WriteString("a")
 		}
 
-		err := ValidateAccessTokenFormat(token)
+		err := ValidateAccessTokenFormat(token.String())
 		if tc.wantErr {
 			assert.Error(t, err)
 		} else {

--- a/sharedctx/sharedctx_test.go
+++ b/sharedctx/sharedctx_test.go
@@ -19,7 +19,7 @@ func TestContext_TryExecuteWith(t *testing.T) {
 	}
 
 	testExecute := func(ctx *Context, success bool) {
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			executed := false
 			assert.Equal(t,
 				success,

--- a/sysinfo/host_name_file_src.go
+++ b/sysinfo/host_name_file_src.go
@@ -31,7 +31,7 @@ func readTagFromOSRelease(r io.Reader, tag string) (string, error) {
 		return "", err
 	}
 
-	for _, line := range bytes.Split(data, []byte("\n")) {
+	for line := range bytes.SplitSeq(data, []byte("\n")) {
 		key, value, ok := bytes.Cut(line, []byte("="))
 		if !ok {
 			continue

--- a/test/mock/response.go
+++ b/test/mock/response.go
@@ -37,7 +37,7 @@ func CreateSignature(privateKey *rsa.PrivateKey, data string) (string, error) {
 
 func getSHA256Hash(data []byte) []byte {
 	sum := sha256.Sum256(data)
-	return []byte(fmt.Sprintf("%x", sum))
+	return fmt.Appendf(nil, "%x", sum)
 }
 
 type signerOpts struct{}

--- a/tray/expo_backoff.go
+++ b/tray/expo_backoff.go
@@ -49,10 +49,7 @@ func RetryWithBackoff(
 		maxDelay = time.Minute
 	}
 
-	maxRetries := cfg.MaxRetries
-	if maxRetries <= 0 {
-		maxRetries = 0
-	}
+	maxRetries := max(cfg.MaxRetries, 0)
 
 	var lastErr error
 	for i := 0; maxRetries == 0 || i < maxRetries; i++ {


### PR DESCRIPTION
Context:
- changes generated by `go fix ./...` and reformatted modified files

Changes:

- `interface{}` -> `any`
- `strings.Builder` instead of string concatenation
- `strings.SplitSeq()` instead of `strings.Split()`
- `max()` instead of `if .. else ..`
- `for range N { ... }` instead of regular loop
- `fmt.Appendf()` instead of `[]byte(fmt.Sprintf())`
- removal of `omitempty` from fields that `omitempty` ignores anyway
- `reflect.Pointer` instead of `reflect.Ptr`
- `wg.Go(func() { ... })` instead of `wg.Add(1) ... go func() { defer wg.Done() ... }` 
- `t.Context()` instead of `ctx, cancel := context.WithCancel(context.Background())` in tests
- `maps.Copy()` instead of manual copy with looping 
- `slices.Contains()` instead of manual check with looping
- `strings.CutPrefix()` instead of `strings.HasPrefix() ... strings.TrimPrefix()`
- removal of deprecated `// +build <tag>`
- formatting

