### PR TITLE
Misc change to get a new snap sha

### DIFF
--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -46,7 +46,7 @@ const (
 	packageTypeDeb  = "deb"
 )
 
-// Aliases shorthands for daily commands
+// Aliases shorthands for daily commands.
 var Aliases = map[string]any{
 	"bb":  Build.Binaries,
 	"bbd": Build.BinariesDocker,


### PR DESCRIPTION
This change was created in order to get a release snap package with a new sha. The old one was already in revision on snap, blocking subsequent package uploads.