### PR TITLE
LVPN-10812: fix announcements for general settings page

### DIFF
--- a/gui/lib/constants.dart
+++ b/gui/lib/constants.dart
@@ -17,6 +17,8 @@ final daemonDateFormat = DateFormat("yyyy-MM-dd h:m:s");
 const animationDuration = Duration(milliseconds: 200);
 const loginTimeoutDuration = Duration(seconds: 10);
 
+const focusRingWidth = 2.0;
+
 const maxInt32 = 0xffffffff;
 const maxInt16 = 0xffff;
 const maxCustomDnsServers = 3;

--- a/gui/lib/settings/general_settings.dart
+++ b/gui/lib/settings/general_settings.dart
@@ -69,6 +69,7 @@ class GeneralSettings extends ConsumerWidget {
             return SettingsWrapperWidget.buildListItem(
               context,
               title: t.ui.showNotifications,
+              mergeSemantics: false,
               trailing: OnOffSwitch(
                 semanticLabel: t.ui.showNotifications,
                 value: settings.notifications,

--- a/gui/lib/settings/general_settings.dart
+++ b/gui/lib/settings/general_settings.dart
@@ -69,6 +69,7 @@ class GeneralSettings extends ConsumerWidget {
               context,
               title: t.ui.showNotifications,
               trailing: OnOffSwitch(
+                semanticLabel: t.ui.showNotifications,
                 value: settings.notifications,
                 onChanged: (value) => ref
                     .read(vpnSettingsControllerProvider.notifier)
@@ -92,13 +93,18 @@ class GeneralSettings extends ConsumerWidget {
                       termsUrl: termsOfServiceUrl,
                     ),
                   ),
-                  trailing: OnOffSwitch(value: true, onChanged: null),
+                  trailing: OnOffSwitch(
+                    semanticLabel: t.ui.essentialRequired,
+                    value: true,
+                    onChanged: null,
+                  ),
                 ),
                 SettingsWrapperWidget.buildListItem(
                   context,
                   title: t.ui.analytics,
                   subtitle: t.ui.analyticsDescription,
                   trailing: OnOffSwitch(
+                    semanticLabel: t.ui.analytics,
                     value:
                         settings.analyticsConsent == ConsentLevel.acceptedAll,
                     onChanged: (value) => ref
@@ -139,6 +145,7 @@ Widget _buildAppearanceTrailing(
         groupValue: mode,
         onChanged: (value) => _setAppearance(ref, value),
         label: t.ui.system,
+        semanticLabel: t.ui.system,
         labelStyle: appTheme.body,
       ),
       RadioButton(
@@ -146,6 +153,7 @@ Widget _buildAppearanceTrailing(
         groupValue: mode,
         onChanged: (value) => _setAppearance(ref, value),
         label: t.ui.light,
+        semanticLabel: t.ui.light,
         labelStyle: appTheme.body,
       ),
       RadioButton(
@@ -153,6 +161,7 @@ Widget _buildAppearanceTrailing(
         groupValue: mode,
         onChanged: (value) => _setAppearance(ref, value),
         label: t.ui.dark,
+        semanticLabel: t.ui.dark,
         labelStyle: appTheme.body,
       ),
     ],

--- a/gui/lib/settings/general_settings.dart
+++ b/gui/lib/settings/general_settings.dart
@@ -80,23 +80,34 @@ class GeneralSettings extends ConsumerWidget {
             );
           case _GeneralSettingsItems.analytics:
             return CustomExpansionTile(
-              title: Text(t.ui.privacyPreferences, style: appTheme.body),
-              subtitle: Text(
-                t.ui.privacyPreferencesDescription,
-                style: appTheme.caption,
+              title: Semantics(
+                container: true,
+                child: Text(t.ui.privacyPreferences, style: appTheme.body),
+              ),
+              subtitle: Semantics(
+                container: true,
+                child: Text(
+                  t.ui.privacyPreferencesDescription,
+                  style: appTheme.caption,
+                ),
               ),
               contentPadding: EdgeInsets.zero,
+              expandButtonSemanticLabel:
+                  '${t.ui.privacyPreferences} ${t.ui.privacyPreferencesDescription}',
               children: [
                 SettingsWrapperWidget.buildListItem(
                   context,
                   title: t.ui.essentialRequired,
+                  mergeSemantics: false,
+                  excludeTextSemantics: true,
                   subtitleWidget: RichTextMarkdownLinks(
                     text: t.ui.requiredAnalyticsDescription(
                       termsUrl: termsOfServiceUrl,
                     ),
                   ),
                   trailing: OnOffSwitch(
-                    semanticLabel: t.ui.essentialRequired,
+                    semanticLabel:
+                        '${t.ui.privacyPreferences} ${t.ui.essentialRequired}',
                     value: true,
                     onChanged: null,
                   ),
@@ -104,9 +115,12 @@ class GeneralSettings extends ConsumerWidget {
                 SettingsWrapperWidget.buildListItem(
                   context,
                   title: t.ui.analytics,
+                  mergeSemantics: false,
+                  excludeTextSemantics: true,
                   subtitle: t.ui.analyticsDescription,
                   trailing: OnOffSwitch(
-                    semanticLabel: t.ui.analytics,
+                    semanticLabel:
+                        '${t.ui.privacyPreferences} ${t.ui.analytics}',
                     value:
                         settings.analyticsConsent == ConsentLevel.acceptedAll,
                     onChanged: (value) => ref

--- a/gui/lib/settings/general_settings.dart
+++ b/gui/lib/settings/general_settings.dart
@@ -63,6 +63,7 @@ class GeneralSettings extends ConsumerWidget {
               context,
               title: t.ui.appearance,
               trailing: _buildAppearanceTrailing(context, ref, mode),
+              mergeSemantics: false,
             );
           case _GeneralSettingsItems.notifications:
             return SettingsWrapperWidget.buildListItem(
@@ -145,7 +146,7 @@ Widget _buildAppearanceTrailing(
         groupValue: mode,
         onChanged: (value) => _setAppearance(ref, value),
         label: t.ui.system,
-        semanticLabel: t.ui.system,
+        semanticLabel: '${t.ui.appearance} ${t.ui.system}',
         labelStyle: appTheme.body,
       ),
       RadioButton(
@@ -153,7 +154,7 @@ Widget _buildAppearanceTrailing(
         groupValue: mode,
         onChanged: (value) => _setAppearance(ref, value),
         label: t.ui.light,
-        semanticLabel: t.ui.light,
+        semanticLabel: '${t.ui.appearance} ${t.ui.light}',
         labelStyle: appTheme.body,
       ),
       RadioButton(
@@ -161,7 +162,7 @@ Widget _buildAppearanceTrailing(
         groupValue: mode,
         onChanged: (value) => _setAppearance(ref, value),
         label: t.ui.dark,
-        semanticLabel: t.ui.dark,
+        semanticLabel: '${t.ui.appearance} ${t.ui.dark}',
         labelStyle: appTheme.body,
       ),
     ],

--- a/gui/lib/settings/settings_wrapper_widget.dart
+++ b/gui/lib/settings/settings_wrapper_widget.dart
@@ -94,34 +94,42 @@ final class SettingsWrapperWidget extends StatelessWidget {
     bool enabled = true,
     EdgeInsetsGeometry? padding,
     Color? color,
+    bool mergeSemantics = true,
   }) {
     final settingsTheme = context.settingsTheme;
 
-    return MergeSemantics(
-      child: Semantics(
-        button: true,
-        enabled: enabled,
-        child: AdvancedListTile(
-          key: key ?? UniqueKey(),
-          leading: iconName != null ? DynamicThemeImage(iconName) : null,
-          title: Expanded(
-            child: Text(
-              title,
-              style: titleStyle ?? settingsTheme.itemTitleStyle,
-            ),
-          ),
-          subtitle: subtitle != null
-              ? Text(subtitle, style: settingsTheme.itemSubtitleStyle)
-              : subtitleWidget,
-          center: center,
-          trailing: trailing,
-          onTap: onTap,
-          trailingLocation: trailingLocation,
-          enabled: enabled,
-          padding: padding ?? settingsTheme.itemPadding,
-          color: color,
-        ),
+    final titleText = Text(
+      title,
+      style: titleStyle ?? settingsTheme.itemTitleStyle,
+    );
+
+    final tile = AdvancedListTile(
+      key: key ?? UniqueKey(),
+      leading: iconName != null ? DynamicThemeImage(iconName) : null,
+      title: Expanded(
+        child: mergeSemantics
+            ? titleText
+            : Semantics(container: true, child: titleText),
       ),
+      subtitle: subtitle != null
+          ? Text(subtitle, style: settingsTheme.itemSubtitleStyle)
+          : subtitleWidget,
+      center: center,
+      trailing: trailing,
+      onTap: onTap,
+      trailingLocation: trailingLocation,
+      enabled: enabled,
+      padding: padding ?? settingsTheme.itemPadding,
+      color: color,
+    );
+
+    if (!mergeSemantics) {
+      //this is to keep separate semantics across all sub-widgets of a single list item
+      return Semantics(container: true, explicitChildNodes: true, child: tile);
+    }
+
+    return MergeSemantics(
+      child: Semantics(button: true, enabled: enabled, child: tile),
     );
   }
 }

--- a/gui/lib/settings/settings_wrapper_widget.dart
+++ b/gui/lib/settings/settings_wrapper_widget.dart
@@ -95,25 +95,32 @@ final class SettingsWrapperWidget extends StatelessWidget {
     EdgeInsetsGeometry? padding,
     Color? color,
     bool mergeSemantics = true,
+    bool excludeTextSemantics = false,
   }) {
     final settingsTheme = context.settingsTheme;
 
-    final titleText = Text(
+    Widget titleChild = Text(
       title,
       style: titleStyle ?? settingsTheme.itemTitleStyle,
     );
 
+    if (excludeTextSemantics) {
+      titleChild = ExcludeSemantics(child: titleChild);
+    } else if (!mergeSemantics) {
+      titleChild = Semantics(container: true, child: titleChild);
+    }
+
+    final subtitleChild = subtitle != null
+        ? Text(subtitle, style: settingsTheme.itemSubtitleStyle)
+        : subtitleWidget;
+
     final tile = AdvancedListTile(
       key: key ?? UniqueKey(),
       leading: iconName != null ? DynamicThemeImage(iconName) : null,
-      title: Expanded(
-        child: mergeSemantics
-            ? titleText
-            : Semantics(container: true, child: titleText),
-      ),
-      subtitle: subtitle != null
-          ? Text(subtitle, style: settingsTheme.itemSubtitleStyle)
-          : subtitleWidget,
+      title: Expanded(child: titleChild),
+      subtitle: excludeTextSemantics && subtitleChild != null
+          ? ExcludeSemantics(child: subtitleChild)
+          : subtitleChild,
       center: center,
       trailing: trailing,
       onTap: onTap,
@@ -124,7 +131,7 @@ final class SettingsWrapperWidget extends StatelessWidget {
     );
 
     if (!mergeSemantics) {
-      //this is to keep separate semantics across all sub-widgets of a single list item
+      //this is to keep semantics separated across all sub-widgets of a single list item
       return Semantics(container: true, explicitChildNodes: true, child: tile);
     }
 

--- a/gui/lib/widgets/custom_expansion_tile.dart
+++ b/gui/lib/widgets/custom_expansion_tile.dart
@@ -17,6 +17,7 @@ final class CustomExpansionTile extends StatefulWidget {
   final bool enabled;
   final Widget? trailing;
   final EdgeInsetsGeometry? contentPadding;
+  final String? expandButtonSemanticLabel;
 
   const CustomExpansionTile({
     super.key,
@@ -32,6 +33,7 @@ final class CustomExpansionTile extends StatefulWidget {
     this.enabled = true,
     this.trailing,
     this.contentPadding,
+    this.expandButtonSemanticLabel,
   });
 
   @override
@@ -86,11 +88,17 @@ class _CustomExpansionTileState extends State<CustomExpansionTile> {
     if (widget.children == null) {
       return null;
     }
+    // if the trailing widget is provided with a custom semantics label, announce it in following format:
+    // <custom label> <expand/collapse>
+    // otherwise, announce only expand/collapse
+    final expandLabel = _isExpanded
+        ? t.a11y.expandibleEntryCollapse
+        : t.a11y.expandibleEntryExpand;
+    final entryLabel = widget.expandButtonSemanticLabel;
+
     return MergeSemantics(
       child: Semantics(
-        label: _isExpanded
-            ? t.a11y.expandibleEntryCollapse
-            : t.a11y.expandibleEntryExpand,
+        label: entryLabel == null ? expandLabel : '$entryLabel $expandLabel',
         expanded: _isExpanded,
         child: IconButton(
           icon: Icon(_isExpanded ? Icons.expand_less : Icons.expand_more),

--- a/gui/lib/widgets/on_off_switch.dart
+++ b/gui/lib/widgets/on_off_switch.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:nordvpn/constants.dart';
 import 'package:nordvpn/i18n/strings.g.dart';
 import 'package:nordvpn/internal/delayed_loading_manager.dart';
@@ -20,12 +21,14 @@ final class OnOffSwitch extends StatefulWidget {
 
   // When onChanged is null the widget is disabled
   final Future<void> Function(bool)? onChanged;
+  final String? semanticLabel;
 
   const OnOffSwitch({
     super.key,
     required this.onChanged,
     this.value = false,
     this.shouldChange,
+    this.semanticLabel,
   });
 
   @override
@@ -35,6 +38,7 @@ final class OnOffSwitch extends StatefulWidget {
 final class OnOffSwitchState extends State<OnOffSwitch> {
   bool _isSwitched = false;
   bool _isDisabled = false;
+  bool _hasFocus = false;
   late DelayedLoadingManager _loadingManager;
 
   @override
@@ -57,21 +61,32 @@ final class OnOffSwitchState extends State<OnOffSwitch> {
     final appTheme = context.appTheme;
     final switchTheme = context.onOffSwitchTheme;
 
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _label(appTheme, switchTheme),
-        Stack(
-          alignment: Alignment.center,
-          children: [
-            if (_loadingManager.isLoading) InlineLoadingIndicator(),
-            EnabledWidget(
-              enabled: !_loadingManager.isLoading,
-              child: _thumbSlider(switchTheme),
-            ),
-          ],
+    return MergeSemantics(
+      child: Semantics(
+        toggled: _isSwitched,
+        enabled: !_isDisabled,
+        label: widget.semanticLabel,
+        onTap: _isDisabled ? null : _toggle,
+        child: _focusableArea(
+          switchTheme,
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ExcludeSemantics(child: _label(appTheme, switchTheme)),
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  if (_loadingManager.isLoading) InlineLoadingIndicator(),
+                  EnabledWidget(
+                    enabled: !_loadingManager.isLoading,
+                    child: _thumbSlider(switchTheme),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
-      ],
+      ),
     );
   }
 
@@ -90,7 +105,50 @@ final class OnOffSwitchState extends State<OnOffSwitch> {
     );
   }
 
+  Widget _focusableArea(OnOffSwitchTheme switchTheme, Widget child) {
+    return FocusableActionDetector(
+      enabled: !_isDisabled,
+      mouseCursor: SystemMouseCursors.click,
+      onShowFocusHighlight: (value) {
+        if (mounted) setState(() => _hasFocus = value);
+      },
+      shortcuts: const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+        SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+      },
+      actions: <Type, Action<Intent>>{
+        ActivateIntent: CallbackAction<ActivateIntent>(
+          onInvoke: (_) {
+            unawaited(_toggle());
+            return null;
+          },
+        ),
+      },
+      child: child,
+    );
+  }
+
   Widget _thumbSlider(OnOffSwitchTheme switchTheme) {
+    return _focusRing(switchTheme, _gestureSlider(switchTheme));
+  }
+
+  Widget _focusRing(OnOffSwitchTheme switchTheme, Widget child) {
+    return Container(
+      padding: EdgeInsets.all(focusRingWidth),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(switchTheme.slider.borderRadius),
+        border: Border.all(
+          color: _hasFocus
+              ? Theme.of(context).colorScheme.primary
+              : Colors.transparent,
+          width: focusRingWidth,
+        ),
+      ),
+      child: child,
+    );
+  }
+
+  Widget _gestureSlider(OnOffSwitchTheme switchTheme) {
     return GestureDetector(
       onTap: _isDisabled ? null : _toggle,
       child: AnimatedContainer(

--- a/gui/lib/widgets/radio_button.dart
+++ b/gui/lib/widgets/radio_button.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:nordvpn/constants.dart';
 import 'package:nordvpn/internal/delayed_loading_manager.dart';
 import 'package:nordvpn/logger.dart';
@@ -15,6 +16,7 @@ final class RadioButton<T> extends StatefulWidget {
   final FutureOr<void> Function(T value) onChanged;
   final String label;
   final TextStyle? labelStyle;
+  final String? semanticLabel;
 
   const RadioButton({
     super.key,
@@ -23,6 +25,7 @@ final class RadioButton<T> extends StatefulWidget {
     required this.onChanged,
     required this.label,
     this.labelStyle,
+    this.semanticLabel,
   });
 
   @override
@@ -33,6 +36,7 @@ final class RadioButtonState<T> extends State<RadioButton<T>> {
   late DelayedLoadingManager _loadingManager;
   bool isSelected = false;
   bool _isLoading = false;
+  bool _hasFocus = false;
 
   @override
   void initState() {
@@ -61,23 +65,69 @@ final class RadioButtonState<T> extends State<RadioButton<T>> {
     final radioTheme = context.radioButtonTheme;
     isSelected = (widget.value == widget.groupValue);
 
-    return GestureDetector(
-      onTap: _onTap,
-      child: Padding(
-        padding: EdgeInsets.all(radioTheme.padding),
-        child: Row(
-          children: [
-            Stack(
-              alignment: Alignment.center,
-              children: [
-                if (_isLoading) InlineLoadingIndicator(),
-                EnabledWidget(enabled: !_isLoading, child: _radio(radioTheme)),
-              ],
+    return MergeSemantics(
+      child: Semantics(
+        inMutuallyExclusiveGroup: true,
+        checked: isSelected,
+        label: widget.semanticLabel ?? widget.label,
+        enabled: true,
+        onTap: isSelected ? null : _onTap,
+        child: FocusableActionDetector(
+          mouseCursor: SystemMouseCursors.click,
+          onShowFocusHighlight: (value) {
+            if (mounted) setState(() => _hasFocus = value);
+          },
+          shortcuts: const <ShortcutActivator, Intent>{
+            SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+            SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+          },
+          actions: <Type, Action<Intent>>{
+            ActivateIntent: CallbackAction<ActivateIntent>(
+              onInvoke: (_) {
+                unawaited(_onTap());
+                return null;
+              },
             ),
-            _label(radioTheme, appTheme),
-          ],
+          },
+          child: GestureDetector(
+            onTap: _onTap,
+            child: Padding(
+              padding: EdgeInsets.all(radioTheme.padding),
+              child: Row(
+                children: [
+                  Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      if (_isLoading) InlineLoadingIndicator(),
+                      EnabledWidget(
+                        enabled: !_isLoading,
+                        child: _focusRing(_radio(radioTheme)),
+                      ),
+                    ],
+                  ),
+                  ExcludeSemantics(child: _label(radioTheme, appTheme)),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
+    );
+  }
+
+  Widget _focusRing(Widget child) {
+    return Container(
+      padding: EdgeInsets.all(focusRingWidth),
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: _hasFocus
+              ? Theme.of(context).colorScheme.primary
+              : Colors.transparent,
+          width: focusRingWidth,
+        ),
+      ),
+      child: child,
     );
   }
 


### PR DESCRIPTION
Changes under this PR:
- `RadioButton` and `OnOffSwitch` widgets are now focusable and thus capable of handling a11y semantics
- some changes to `SettingsWrapperWidget.buildListItem` required to correctly handle semantics (specifically between leading/trailing widgets)
- `CustomExpansionTile` now takes `expandButtonSemanticLabel` so the expand button is announced with a meaningful labal, rather than a generic `push button`
- `GeneralSettings` with fixed announcements, and OK(ish) keyboard navigation (however, keyboard navi wasn't in the scope of this PR, per se)