### PR TITLE
LVPN-10981: Add simple http transport recreation on connect

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -264,13 +264,15 @@ func main() {
 	// simple standard http client with dialer wrapped inside
 	simpleTransportNeedsRecreate := true
 	httpClientSimple := request.NewStdHTTP()
-	httpClientSimple.Transport = request.NewHTTPReTransport(
+	h1SimpleTransport := request.NewHTTPReTransport(
 		1, 1, "HTTP/1.1", func() http.RoundTripper {
 			return request.NewPublishingRoundTripper(
 				request.NewContextRoundTripper(createSimpleH1Transport(Environment)(), httpGlobalCtx),
 				httpCallsSubject,
 			)
 		}, nil, simpleTransportNeedsRecreate)
+	daemonEvents.Service.Connect.Subscribe(h1SimpleTransport.NotifyConnect)
+	httpClientSimple.Transport = h1SimpleTransport
 
 	cdnUrl := core.CDNURL
 	if !internal.IsProdEnv(Environment) && os.Getenv(EnvNordCdnUrl) != "" {

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -265,14 +265,12 @@ func main() {
 	simpleTransportNeedsRecreate := true
 	httpClientSimple := request.NewStdHTTP()
 	h1SimpleTransport := request.NewHTTPReTransport(
-		1, 1, "HTTP/1.1", func() http.RoundTripper {
-			return request.NewPublishingRoundTripper(
-				request.NewContextRoundTripper(createSimpleH1Transport(Environment)(), httpGlobalCtx),
-				httpCallsSubject,
-			)
-		}, nil, simpleTransportNeedsRecreate)
+		1, 1, "HTTP/1.1", createSimpleH1Transport(Environment), nil, simpleTransportNeedsRecreate)
 	daemonEvents.Service.Connect.Subscribe(h1SimpleTransport.NotifyConnect)
-	httpClientSimple.Transport = h1SimpleTransport
+	httpClientSimple.Transport = request.NewPublishingRoundTripper(
+		request.NewContextRoundTripper(h1SimpleTransport, httpGlobalCtx),
+		httpCallsSubject,
+	)
 
 	cdnUrl := core.CDNURL
 	if !internal.IsProdEnv(Environment) && os.Getenv(EnvNordCdnUrl) != "" {

--- a/request/http_retransport.go
+++ b/request/http_retransport.go
@@ -19,7 +19,7 @@ type HTTPReTransport struct {
 	protoMinor      int
 	proto           string
 	shouldRetryFunc ShouldRetryFunc
-	NeedRecreate    bool
+	needRecreate    bool
 	// counter provides a mechanism to check whether the inner RoundTripper was re-created
 	// in the background during this round trip. Integer overflow is not important here as only
 	// inequality operator is used.
@@ -48,7 +48,7 @@ func NewHTTPReTransport(
 		inner:           createFn(),
 		createFn:        createFn,
 		shouldRetryFunc: shouldRetryFn,
-		NeedRecreate:    needRecreate,
+		needRecreate:    needRecreate,
 	}
 }
 
@@ -65,12 +65,13 @@ func (m *HTTPReTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // NotifyConnect initiates re-creating the inner round tripper when called.
 func (m *HTTPReTransport) NotifyConnect(events.DataConnect) error {
-	if !m.NeedRecreate {
-		return nil
-	}
 	m.mu.RLock()
+	needRecreate := m.needRecreate
 	counter := m.counter
 	m.mu.RUnlock()
+	if !needRecreate {
+		return nil
+	}
 	m.recreateRoundTrip(counter)
 	return nil
 }

--- a/request/http_retransport.go
+++ b/request/http_retransport.go
@@ -65,6 +65,9 @@ func (m *HTTPReTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // NotifyConnect initiates re-creating the inner round tripper when called.
 func (m *HTTPReTransport) NotifyConnect(events.DataConnect) error {
+	if !m.NeedRecreate {
+		return nil
+	}
 	m.mu.RLock()
 	counter := m.counter
 	m.mu.RUnlock()
@@ -99,15 +102,18 @@ func (m *HTTPReTransport) executeRequest(req *http.Request) (*http.Response, err
 func (m *HTTPReTransport) recreateRoundTrip(counter int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if !m.NeedRecreate {
-		return
-	}
 	if counter != m.counter {
 		return
 	}
-	if inner, ok := m.inner.(io.Closer); ok {
+	switch inner := m.inner.(type) {
+	case io.Closer:
+		// HTTP3 branch when transport implements Close
 		log.Debug("Recreating round trip, closing inner transport")
 		_ = inner.Close()
+	case interface{ CloseIdleConnections() }:
+		// HTTP1 branch when transport does not implement close, we instead close all the idle connections
+		log.Debug("Recreating round trip, closing idle connections of inner transport")
+		inner.CloseIdleConnections()
 	}
 	m.counter++
 	m.inner = m.createFn()

--- a/request/http_retransport_test.go
+++ b/request/http_retransport_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/NordSecurity/nordvpn-linux/events"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
 	"github.com/stretchr/testify/assert"
 )
@@ -80,4 +81,49 @@ func TestHTTPReTransport_RoundTrip(t *testing.T) {
 
 	// Check if transports were recreated only once.
 	assert.Equal(t, 1, transport.counter)
+}
+
+// idleClosingRoundTripper stands for http.Transport, which does not implement io.Closer.
+type idleClosingRoundTripper struct {
+	closeCount int
+}
+
+func (rt *idleClosingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (rt *idleClosingRoundTripper) CloseIdleConnections() { rt.closeCount++ }
+
+// TestHTTPReTransport_ClosesIdleConnections covers the simple HTTP/1.1 transport, whose connections
+// have no fwmark and become unusable once the VPN is connected.
+func TestHTTPReTransport_ClosesIdleConnections(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name               string
+		needRecreate       bool
+		expectedCloseCount int
+	}{
+		{
+			name:               "re-creation enabled",
+			needRecreate:       true,
+			expectedCloseCount: 1,
+		},
+		{
+			name:         "re-creation disabled",
+			needRecreate: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inner := &idleClosingRoundTripper{}
+			transport := NewHTTPReTransport(1, 1, "HTTP/1.1", func() http.RoundTripper {
+				return inner
+			}, nil, test.needRecreate)
+
+			assert.NoError(t, transport.NotifyConnect(events.DataConnect{}))
+			assert.Equal(t, test.expectedCloseCount, inner.closeCount)
+		})
+	}
 }


### PR DESCRIPTION
This PR adds simple http transport recreation logic on connect event, so it's remade immediately after connect is successful and does not have to wait for errors to recreate itself