### PR TITLE
Allow to set connection limit reached event before connecting

### DIFF
--- a/daemon/ens/ens_monitoring.go
+++ b/daemon/ens/ens_monitoring.go
@@ -133,7 +133,7 @@ func (m *Monitor) serverMaintenanceEventProcessing(e events.VPNConnectionErrorEv
 	}
 }
 
-func (m *Monitor) connectionLimitReachedEventProcessing(e events.VPNConnectionErrorEvent) {
+func (m *Monitor) connectionLimitReachedEventProcessing(events.VPNConnectionErrorEvent) {
 	if !m.netw.CancelConnecting(ErrConnectionLimitReached) {
 		log.ENS.Info("connection limit reach ignored")
 	}

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -259,7 +259,6 @@ func TestCombined_ENSConnectionsLimitReached(t *testing.T) {
 			Code:           events.VPNConnectionErrorConnectionLimitReached,
 			ServerEndpoint: "",
 		}))
-
 	}()
 
 	err := netw.Start(

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -2,6 +2,7 @@ package ens
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -212,9 +213,13 @@ func TestENSMonitoringEventHandling(t *testing.T) {
 func TestCombined_ENSConnectionsLimitReached(t *testing.T) {
 	category.Set(t, category.Unit)
 
+	// synchronize connecting with send ENS event
+	var wg sync.WaitGroup
+	wg.Add(1)
 	netw := netw.NewCombined(
 		&mock.WorkingVPN{
 			ConnectingFn: func(ctx context.Context, c vpn.Credentials, sd vpn.ServerData) error {
+				wg.Done()
 				// block until the context is canceled by an ENS connection limit reached
 				<-ctx.Done()
 				return context.Cause(ctx)
@@ -247,12 +252,18 @@ func TestCombined_ENSConnectionsLimitReached(t *testing.T) {
 	}, &subs.Subject[events.DebuggerEvent]{})
 	monitor.Start()
 
-	assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
-		Code:           events.VPNConnectionErrorConnectionLimitReached,
-		ServerEndpoint: "",
-	}))
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 
-	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+	go func() {
+		// wait until in connecting state
+		wg.Wait()
+		assert.NilError(t, monitor.HandleENSNotification(events.VPNConnectionErrorEvent{
+			Code:           events.VPNConnectionErrorConnectionLimitReached,
+			ServerEndpoint: "",
+		}))
+
+	}()
+
 	err := netw.Start(
 		ctx,
 		vpn.Credentials{},

--- a/daemon/ens/ens_monitoring_test.go
+++ b/daemon/ens/ens_monitoring_test.go
@@ -252,8 +252,6 @@ func TestCombined_ENSConnectionsLimitReached(t *testing.T) {
 	}, &subs.Subject[events.DebuggerEvent]{})
 	monitor.Start()
 
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-
 	go func() {
 		// wait until in connecting state
 		wg.Wait()
@@ -265,7 +263,7 @@ func TestCombined_ENSConnectionsLimitReached(t *testing.T) {
 	}()
 
 	err := netw.Start(
-		ctx,
+		context.Background(),
 		vpn.Credentials{},
 		vpn.ServerData{},
 		config.NewAllowlist(nil, nil, nil),

--- a/daemon/vpn/nordlynx/libtelio/dev_ens.go
+++ b/daemon/vpn/nordlynx/libtelio/dev_ens.go
@@ -1,0 +1,49 @@
+package libtelio
+
+import (
+	"errors"
+	"sync/atomic"
+
+	telio "github.com/NordSecurity/libtelio-go/v6"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+)
+
+type ensDev struct {
+	ch                      chan vpnConnError
+	nextConnectLimitReached atomic.Bool
+}
+
+func newEnsDev(prod bool) *ensDev {
+	var ch chan vpnConnError
+	if !prod {
+		ch = make(chan vpnConnError)
+	}
+	return &ensDev{
+		ch: ch,
+	}
+}
+
+func (ed *ensDev) startNewConnect() {
+	if ed.ch == nil {
+		return
+	}
+	if ed.nextConnectLimitReached.Load() {
+		ed.ch <- vpnConnError{code: telio.VpnConnectionErrorConnectionLimitReached}
+		ed.nextConnectLimitReached.Store(false)
+	}
+}
+
+func (ed *ensDev) add(event vpnConnError) error {
+	if ed.ch == nil {
+		return errors.New("ENS injection is unavailable outside the dev environment")
+	}
+	if event.code == telio.VpnConnectionErrorConnectionLimitReached {
+		ed.nextConnectLimitReached.Store(true)
+	} else {
+		if !internal.TrySend(ed.ch, event) {
+			return errors.New("dropping event")
+		}
+	}
+
+	return nil
+}

--- a/daemon/vpn/nordlynx/libtelio/dev_ens.go
+++ b/daemon/vpn/nordlynx/libtelio/dev_ens.go
@@ -8,8 +8,13 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/internal"
 )
 
+// The was extracted from libtelio to handle the ENS events injection in dev builds.
+// It also handles the cases where the application is "put" in error mode,
+// e.g. ENS VpnConnectionErrorConnectionLimitReached is injected, for the next VPN connect
+
 type ensDev struct {
-	ch                      chan vpnConnError
+	ch chan vpnConnError
+	// Setting this to true will result in an ENS event generated next time startNewConnect is executed.
 	nextConnectLimitReached atomic.Bool
 }
 
@@ -23,6 +28,7 @@ func newEnsDev(prod bool) *ensDev {
 	}
 }
 
+// This needs to be called when libtelio starts the events monitoring, for the new VPN connect
 func (ed *ensDev) startNewConnect() {
 	if ed.ch == nil {
 		return

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -7,6 +7,7 @@ package libtelio
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -833,6 +834,9 @@ func (l *Libtelio) GetConnectionParameters() (vpn.ServerData, bool) {
 // InjectVPNConnectionError is a DEV-only helper that feeds a simulated ENS error
 // through the same monitor that real libtelio events use.
 func (l *Libtelio) InjectVPNConnectionError(code int32, serverEndpoint string) error {
+	if l.injectedErrors == nil {
+		return errors.New("It works only on dev builds")
+	}
 	// #nosec G115 - dev-only injection — out-of-range codes map to Unknown
 	connErr := vpnConnError{code: teliogo.VpnConnectionError(code), serverEndpoint: serverEndpoint}
 	return l.injectedErrors.add(connErr)
@@ -944,19 +948,25 @@ func (l *Libtelio) startConnectionErrorMonitor(ctx context.Context, serverData v
 	}()
 
 	wg.Wait()
-	l.injectedErrors.startNewConnect()
+	if l.injectedErrors != nil {
+		l.injectedErrors.startNewConnect()
+	}
 }
 
 // monitorConnectionErrors awaits ENS connection errors extracted from telio node events,
 // maps them to the protocol-agnostic events and publishes them on the internal VPN event bus.
 func (l *Libtelio) monitorConnectionErrors(ctx context.Context, serverData vpn.ServerData) {
+	var ch chan vpnConnError
+	if l.injectedErrors != nil {
+		ch = l.injectedErrors.ch
+	}
 	for {
 		select {
 		case connErr := <-l.vpnErrorEvents:
 			publishConnError(l.eventsPublisher, connErr)
 
 		// DEV only: a simulated ENS error injected via the gRPC tool. It's nil in production.
-		case injErr := <-l.injectedErrors.ch:
+		case injErr := <-ch:
 			if injErr.serverEndpoint == "" {
 				injErr.serverEndpoint = serverData.Endpoint
 			}

--- a/daemon/vpn/nordlynx/libtelio/libtelio.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio.go
@@ -7,7 +7,6 @@ package libtelio
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -231,7 +230,7 @@ type Libtelio struct {
 	stateEvents    <-chan state
 	vpnErrorEvents <-chan vpnConnError
 	// injectedErrors carries DEV-only simulated ENS errors. nil in production.
-	injectedErrors             chan vpnConnError
+	injectedErrors             *ensDev
 	cancelConnectionMonitoring func()
 	active                     bool
 	tun                        tunnel.T
@@ -324,13 +323,6 @@ func New(
 	stateEvents := make(chan state)
 	errorEvents := make(chan vpnConnError, 1)
 
-	// DEV only
-	var injectedErrors chan vpnConnError
-	if !prod {
-		injectedErrors = make(chan vpnConnError)
-	}
-	// end of DEV only
-
 	features, err := handleTelioConfig(eventPath, prod, vpnLibCfg)
 	if err != nil {
 		log.Error("failed to get telio config:", err)
@@ -374,7 +366,7 @@ func New(
 		stateEvents:     stateEvents,
 		state:           vpn.ExitedState,
 		vpnErrorEvents:  errorEvents,
-		injectedErrors:  injectedErrors,
+		injectedErrors:  newEnsDev(prod),
 		fwmark:          fwmark,
 		eventsPublisher: eventsPublisher,
 		callbackHandler: telioCallbackHandler,
@@ -436,7 +428,7 @@ func (l *Libtelio) connect(
 		l.eventsPublisher)
 
 	// Start monitoring ENS connection errors before connecting so no early error is missed.
-	l.startConnectionErrorMonitor(ctx)
+	l.startConnectionErrorMonitor(ctx, l.currentServer)
 
 	var err error
 	port := "51820"
@@ -841,27 +833,9 @@ func (l *Libtelio) GetConnectionParameters() (vpn.ServerData, bool) {
 // InjectVPNConnectionError is a DEV-only helper that feeds a simulated ENS error
 // through the same monitor that real libtelio events use.
 func (l *Libtelio) InjectVPNConnectionError(code int32, serverEndpoint string) error {
-	if l.injectedErrors == nil {
-		return errors.New("ENS injection is unavailable outside the dev environment")
-	}
-
-	if serverEndpoint == "" {
-		// Allow ENS events to be generated while connecting, when l.mu is locked
-		if l.mu.TryLock() {
-			serverEndpoint = l.currentServer.Endpoint
-			l.mu.Unlock()
-		}
-	}
-
 	// #nosec G115 - dev-only injection — out-of-range codes map to Unknown
 	connErr := vpnConnError{code: teliogo.VpnConnectionError(code), serverEndpoint: serverEndpoint}
-
-	select {
-	case l.injectedErrors <- connErr:
-		return nil
-	default:
-		return errors.New("no active NordLynx connection monitor; connect with NordLynx first")
-	}
+	return l.injectedErrors.add(connErr)
 }
 
 // isConnected function designed to be called before performing an action which trigger events.
@@ -960,28 +934,32 @@ func monitorConnectionState(
 
 // startConnectionErrorMonitor starts connection error monitoring in a goroutine and returns
 // once goroutine started
-func (l *Libtelio) startConnectionErrorMonitor(ctx context.Context) {
+func (l *Libtelio) startConnectionErrorMonitor(ctx context.Context, serverData vpn.ServerData) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	go func() {
 		wg.Done()
-		l.monitorConnectionErrors(ctx)
+		l.monitorConnectionErrors(ctx, serverData)
 	}()
 
 	wg.Wait()
+	l.injectedErrors.startNewConnect()
 }
 
 // monitorConnectionErrors awaits ENS connection errors extracted from telio node events,
 // maps them to the protocol-agnostic events and publishes them on the internal VPN event bus.
-func (l *Libtelio) monitorConnectionErrors(ctx context.Context) {
+func (l *Libtelio) monitorConnectionErrors(ctx context.Context, serverData vpn.ServerData) {
 	for {
 		select {
 		case connErr := <-l.vpnErrorEvents:
 			publishConnError(l.eventsPublisher, connErr)
 
 		// DEV only: a simulated ENS error injected via the gRPC tool. It's nil in production.
-		case injErr := <-l.injectedErrors:
+		case injErr := <-l.injectedErrors.ch:
+			if injErr.serverEndpoint == "" {
+				injErr.serverEndpoint = serverData.Endpoint
+			}
 			log.Info("[DEV] injecting simulated ENS connection error:", injErr.code)
 			publishConnError(l.eventsPublisher, injErr)
 

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -529,7 +529,6 @@ func TestLibtelio_connect(t *testing.T) {
 				eventsPublisher: pub,
 				tun:             mockTunnel{},
 				callbackHandler: callbackHandlerStub{},
-				injectedErrors:  newEnsDev(false),
 			}
 
 			// connect ctx
@@ -813,7 +812,6 @@ func TestMonitorConnectionErrors_PublishesMappedEvent(t *testing.T) {
 		vpnErrorEvents:  errorsChan,
 		active:          true,
 		currentServer:   serverData,
-		injectedErrors:  newEnsDev(true),
 	}
 
 	go l.monitorConnectionErrors(t.Context(), serverData)
@@ -835,7 +833,7 @@ func TestInjectVPNConnectionError_UnavailableOutsideDev(t *testing.T) {
 
 	// In production the injectedErrors channel is nil, so injection is rejected
 	// and nothing can be published.
-	l := &Libtelio{injectedErrors: newEnsDev(true)}
+	l := &Libtelio{}
 
 	err := l.InjectVPNConnectionError(int32(teliogo.VpnConnectionErrorServerMaintenance), "")
 
@@ -847,7 +845,7 @@ func TestInjectVPNConnectionError_NoActiveMonitor(t *testing.T) {
 
 	// The dev channel exists but no monitor goroutine is draining it (no active
 	// NordLynx connection).
-	l := &Libtelio{injectedErrors: newEnsDev(true)}
+	l := &Libtelio{injectedErrors: newEnsDev(false)}
 
 	err := l.InjectVPNConnectionError(int32(teliogo.VpnConnectionErrorServerMaintenance), "")
 

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -529,6 +529,7 @@ func TestLibtelio_connect(t *testing.T) {
 				eventsPublisher: pub,
 				tun:             mockTunnel{},
 				callbackHandler: callbackHandlerStub{},
+				injectedErrors:  newEnsDev(false),
 			}
 
 			// connect ctx

--- a/daemon/vpn/nordlynx/libtelio/libtelio_test.go
+++ b/daemon/vpn/nordlynx/libtelio/libtelio_test.go
@@ -805,15 +805,17 @@ func TestMonitorConnectionErrors_PublishesMappedEvent(t *testing.T) {
 		return nil
 	})
 
+	serverData := vpn.ServerData{NordLynxPublicKey: "lel"}
 	errorsChan := make(chan vpnConnError, 1)
 	l := &Libtelio{
 		eventsPublisher: pub,
 		vpnErrorEvents:  errorsChan,
 		active:          true,
-		currentServer:   vpn.ServerData{NordLynxPublicKey: "lel"},
+		currentServer:   serverData,
+		injectedErrors:  newEnsDev(true),
 	}
 
-	go l.monitorConnectionErrors(t.Context())
+	go l.monitorConnectionErrors(t.Context(), serverData)
 
 	serverEndpoint := "192.168.1.1:51820"
 	errorsChan <- vpnConnError{code: teliogo.VpnConnectionErrorSuperseded, serverEndpoint: serverEndpoint}
@@ -832,7 +834,7 @@ func TestInjectVPNConnectionError_UnavailableOutsideDev(t *testing.T) {
 
 	// In production the injectedErrors channel is nil, so injection is rejected
 	// and nothing can be published.
-	l := &Libtelio{}
+	l := &Libtelio{injectedErrors: newEnsDev(true)}
 
 	err := l.InjectVPNConnectionError(int32(teliogo.VpnConnectionErrorServerMaintenance), "")
 
@@ -844,7 +846,7 @@ func TestInjectVPNConnectionError_NoActiveMonitor(t *testing.T) {
 
 	// The dev channel exists but no monitor goroutine is draining it (no active
 	// NordLynx connection).
-	l := &Libtelio{injectedErrors: make(chan vpnConnError)}
+	l := &Libtelio{injectedErrors: newEnsDev(true)}
 
 	err := l.InjectVPNConnectionError(int32(teliogo.VpnConnectionErrorServerMaintenance), "")
 
@@ -897,15 +899,16 @@ func TestInjectVPNConnectionError_DeliversThroughMonitor(t *testing.T) {
 				return nil
 			})
 
-			injectedChan := make(chan vpnConnError)
+			serverData := vpn.ServerData{Endpoint: tt.connectedEndpoint}
+
 			l := &Libtelio{
 				eventsPublisher: pub,
-				injectedErrors:  injectedChan,
+				injectedErrors:  newEnsDev(false),
 				active:          true,
-				currentServer:   vpn.ServerData{Endpoint: tt.connectedEndpoint},
+				currentServer:   serverData,
 			}
 
-			go l.monitorConnectionErrors(t.Context())
+			go l.monitorConnectionErrors(t.Context(), serverData)
 
 			injected := assert.Eventually(t, func() bool {
 				return l.InjectVPNConnectionError(tt.code, tt.inputEndpoint) == nil

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -4,7 +4,6 @@ import time
 
 import pytest
 import sh
-import subprocess
 import grpc
 
 from constants import NORDVPND_SOCKET

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -605,28 +605,14 @@ def test_obfuscation_prevents_virtual_location_connection(tech, proto, obfuscate
 ENS_CONN_LIMIT_REACHED = 2
 def test_ens_connection_limit():
     """Test ENS connection limit"""
-    if "dev" not in sh.nordvpn("version"):
+    if "dev" not in sh.nordvpn.version():
         pytest.skip("can run only for dev builds")
 
     sh.nordvpn.set.technology("nordlynx")
-    # fetch account info before stopping the internet otherwise connect fails because account info fails
-    sh.nordvpn.account()
+    with grpc.insecure_channel(NORDVPND_SOCKET) as channel:
+        stub = service_pb2_grpc.DaemonStub(channel)
+        stub.InjectVpnConnectionError(common_pb2.InjectVpnConnectionErrorRequest(telio_code=ENS_CONN_LIMIT_REACHED))
 
-    with network.remove_default_gateway():
-        helper = subprocess.Popen(
-            ["nordvpn", "c"],
-            stdout=subprocess.PIPE,
-            text=True,
-        )
-        with grpc.insecure_channel(NORDVPND_SOCKET) as channel:
-            stub = service_pb2_grpc.DaemonStub(channel)
-            # try to send the event multiple times, until libtelio starts the connection
-            while True:
-                try:
-                    stub.InjectVpnConnectionError(common_pb2.InjectVpnConnectionErrorRequest(telio_code=ENS_CONN_LIMIT_REACHED))
-                    break
-                except Exception as e:  # noqa: BLE001
-                    print(e)
-                    time.sleep(1)
-        output = helper.stdout.read()
-        assert "TODO: connection limit reached." in output
+    with pytest.raises(sh.ErrorReturnCode_1) as ex:
+        sh.nordvpn.connect()
+    assert "TODO: connection limit reached." in ex.value.stdout.decode("utf-8")


### PR DESCRIPTION
Changes are only for dev builds:
* Moved ENS part from libtelio.
* Added an atomic bool to keep track if connection limit reach event should be returned at the next connect.
* Fix tests to be less likely to be flaky. 