### PR TITLE
LVPN-10814 announcements for popups

### DIFF
--- a/gui/lib/i18n/en/a11y.i18n.json
+++ b/gui/lib/i18n/en/a11y.i18n.json
@@ -12,5 +12,6 @@
   "expandibleEntryCollapse": "Collapse",
   "expandibleEntryExpanded": "Expanded",
   "expandibleEntryCollapsed": "Collapsed",
-  "clear": "Clear"
+  "clear": "Clear",
+  "popupWithContent": "Popup: $content"
 }

--- a/gui/lib/i18n/en/a11y.i18n.json
+++ b/gui/lib/i18n/en/a11y.i18n.json
@@ -13,5 +13,5 @@
   "expandibleEntryExpanded": "Expanded",
   "expandibleEntryCollapsed": "Collapsed",
   "clear": "Clear",
-  "popupWithContent": "Popup: $content"
+  "popupWithContent": "$title. $message"
 }

--- a/gui/lib/i18n/strings.g.dart
+++ b/gui/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 712
+/// Strings: 713
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/gui/lib/i18n/strings_en.g.dart
+++ b/gui/lib/i18n/strings_en.g.dart
@@ -97,8 +97,8 @@ class Translations$a11y$en {
 	/// en: 'Clear'
 	String get clear => 'Clear';
 
-	/// en: 'Popup: $content'
-	String popupWithContent({required Object content}) => 'Popup: ${content}';
+	/// en: '$title. $message'
+	String popupWithContent({required Object title, required Object message}) => '${title}. ${message}';
 }
 
 // Path: cities
@@ -2253,7 +2253,7 @@ extension on Translations {
 			'a11y.expandibleEntryExpanded' => 'Expanded',
 			'a11y.expandibleEntryCollapsed' => 'Collapsed',
 			'a11y.clear' => 'Clear',
-			'a11y.popupWithContent' => ({required Object content}) => 'Popup: ${content}',
+			'a11y.popupWithContent' => ({required Object title, required Object message}) => '${title}. ${message}',
 			'cities.tirana' => 'Tirana',
 			'cities.algiers' => 'Algiers',
 			'cities.addis_ababa' => 'Addis Ababa',

--- a/gui/lib/i18n/strings_en.g.dart
+++ b/gui/lib/i18n/strings_en.g.dart
@@ -96,6 +96,9 @@ class Translations$a11y$en {
 
 	/// en: 'Clear'
 	String get clear => 'Clear';
+
+	/// en: 'Popup: $content'
+	String popupWithContent({required Object content}) => 'Popup: ${content}';
 }
 
 // Path: cities
@@ -2250,6 +2253,7 @@ extension on Translations {
 			'a11y.expandibleEntryExpanded' => 'Expanded',
 			'a11y.expandibleEntryCollapsed' => 'Collapsed',
 			'a11y.clear' => 'Clear',
+			'a11y.popupWithContent' => ({required Object content}) => 'Popup: ${content}',
 			'cities.tirana' => 'Tirana',
 			'cities.algiers' => 'Algiers',
 			'cities.addis_ababa' => 'Addis Ababa',
@@ -2747,9 +2751,9 @@ extension on Translations {
 			'ui.searchServersHint' => 'Search countries, cities, or servers',
 			'ui.citiesAvailable' => ({required Object n}) => '${n} cities available',
 			'ui.virtual' => 'Virtual',
-			'ui.dedicatedIp' => 'Dedicated IP',
 			_ => null,
 		} ?? switch (path) {
+			'ui.dedicatedIp' => 'Dedicated IP',
 			'ui.dedicatedServer' => 'Dedicated Server',
 			'ui.doubleVpn' => 'Double VPN',
 			'ui.onionOverVpn' => 'Onion over VPN',

--- a/gui/lib/widgets/dialog_factory.dart
+++ b/gui/lib/widgets/dialog_factory.dart
@@ -41,6 +41,7 @@ final class DialogFactory {
                   leading: icon,
                   title: Text(title, style: appTheme.bodyStrong),
                   trailing: IconButton(
+                    tooltip: t.ui.close,
                     icon: Semantics(
                       label: t.ui.close,
                       child: DynamicThemeImage("close.svg"),

--- a/gui/lib/widgets/dialog_factory.dart
+++ b/gui/lib/widgets/dialog_factory.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:nordvpn/i18n/strings.g.dart';
 import 'package:nordvpn/theme/app_theme.dart';
 import 'package:nordvpn/widgets/dynamic_theme_image.dart';
 import 'package:nordvpn/widgets/round_container.dart';
@@ -40,7 +41,10 @@ final class DialogFactory {
                   leading: icon,
                   title: Text(title, style: appTheme.bodyStrong),
                   trailing: IconButton(
-                    icon: DynamicThemeImage("close.svg"),
+                    icon: Semantics(
+                      label: t.ui.close,
+                      child: DynamicThemeImage("close.svg"),
+                    ),
                     onPressed: () {
                       Navigator.of(context).pop();
                     },

--- a/gui/lib/widgets/popups/decision_popup.dart
+++ b/gui/lib/widgets/popups/decision_popup.dart
@@ -19,7 +19,10 @@ final class DecisionPopup extends Popup {
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: theme.verticalElementSpacing,
       children: [
-        Text(message(ref), style: theme.textSecondary),
+        Semantics(
+          container: true,
+          child: Text(message(ref), style: theme.textSecondary),
+        ),
         Row(
           spacing: theme.gapBetweenElements,
           children: [

--- a/gui/lib/widgets/popups/decision_popup.dart
+++ b/gui/lib/widgets/popups/decision_popup.dart
@@ -21,7 +21,11 @@ final class DecisionPopup extends Popup {
       children: [
         Semantics(
           container: true,
-          child: Text(message(ref), style: theme.textSecondary),
+          child: Text(
+            message(ref),
+            key: Popup.messageKey,
+            style: theme.textSecondary,
+          ),
         ),
         Row(
           spacing: theme.gapBetweenElements,

--- a/gui/lib/widgets/popups/info_popup.dart
+++ b/gui/lib/widgets/popups/info_popup.dart
@@ -23,7 +23,11 @@ final class InfoPopup extends Popup {
       children: [
         Semantics(
           container: true,
-          child: Text(message(ref), style: theme.textSecondary),
+          child: Text(
+            message(ref),
+            key: Popup.messageKey,
+            style: theme.textSecondary,
+          ),
         ),
         Align(alignment: Alignment.centerRight, child: _closeButton(context)),
       ],

--- a/gui/lib/widgets/popups/info_popup.dart
+++ b/gui/lib/widgets/popups/info_popup.dart
@@ -21,7 +21,10 @@ final class InfoPopup extends Popup {
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: theme.verticalElementSpacing,
       children: [
-        Text(message(ref), style: theme.textSecondary),
+        Semantics(
+          container: true,
+          child: Text(message(ref), style: theme.textSecondary),
+        ),
         Align(alignment: Alignment.centerRight, child: _closeButton(context)),
       ],
     );

--- a/gui/lib/widgets/popups/popup.dart
+++ b/gui/lib/widgets/popups/popup.dart
@@ -11,6 +11,11 @@ import 'package:nordvpn/widgets/dynamic_theme_image.dart';
 
 // Base class providing "template" for popups.
 abstract class Popup extends ConsumerWidget {
+  static const semanticsKey = Key("popup_semantics");
+  static const titleKey = Key("popup_title");
+  static const messageKey = Key("popup_message");
+  static const closeButtonKey = Key("popup_close_button");
+
   final PopupMetadata metadata;
 
   const Popup({super.key, required this.metadata});
@@ -22,28 +27,31 @@ abstract class Popup extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return _AnnounceOnShow(
-      announcement: t.a11y.popupWithContent(
-        content: "$title. ${message(ref)}",
-      ),
-      child: Dialog(
-        backgroundColor: Colors.transparent,
-        child: Container(
-          decoration: BoxDecoration(
-            color: theme.colorScheme.surface,
-            borderRadius: popupTheme.widgetRadius,
-          ),
-          padding: EdgeInsets.all(popupTheme.verticalElementSpacing),
-          width: min(
-            dynamicScale(popupTheme.widgetWidth),
-            screenSize.width * 0.8,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _titleBar(context, popupTheme),
-              buildContent(context, ref),
-            ],
+      announcement: () => semanticLabel(ref),
+      child: Semantics(
+        key: semanticsKey,
+        scopesRoute: true,
+        explicitChildNodes: true,
+        child: Dialog(
+          backgroundColor: Colors.transparent,
+          child: Container(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surface,
+              borderRadius: popupTheme.widgetRadius,
+            ),
+            padding: EdgeInsets.all(popupTheme.verticalElementSpacing),
+            width: min(
+              dynamicScale(popupTheme.widgetWidth),
+              screenSize.width * 0.8,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _titleBar(context, popupTheme),
+                buildContent(context, ref),
+              ],
+            ),
           ),
         ),
       ),
@@ -68,23 +76,27 @@ abstract class Popup extends ConsumerWidget {
     );
   }
 
-  // the title and the message are kept in their own semantics nodes, otherwise
-  // they are merged into the dialog and read again for each of its buttons
+  // `MergeSemantics` is required, otherwise `header` is set on this node while
+  // the label stays on the child text and the flag has no effect.
   Widget _title(PopupTheme theme) {
-    return Semantics(
-      container: true,
-      child: Text(title, style: theme.textPrimary),
+    return MergeSemantics(
+      child: Semantics(
+        header: true,
+        child: Text(title, key: titleKey, style: theme.textPrimary),
+      ),
     );
   }
 
   Widget _closeIcon(BuildContext context) {
     final theme = context.popupTheme;
+    // `tooltip` covers pointer and keyboard users, the `Semantics` label names
+    // the icon for the screen reader. Same pairing as `input.dart` and
+    // `bin_button.dart`; the button role comes from IconButton itself.
     return IconButton(
+      key: closeButtonKey,
       padding: EdgeInsetsGeometry.all(theme.xButtonAllPadding),
-      icon: Semantics(
-        label: t.ui.close,
-        child: DynamicThemeImage("close.svg"),
-      ),
+      tooltip: t.ui.close,
+      icon: Semantics(label: t.ui.close, child: DynamicThemeImage("close.svg")),
       onPressed: () => Navigator.of(context).pop(),
     );
   }
@@ -93,12 +105,25 @@ abstract class Popup extends ConsumerWidget {
   String get title => metadata.title ?? t.ui.nordVpn;
   String message(WidgetRef ref) => metadata.message(ref);
 
+  // Accessible name of the popup, read by the screen reader when it opens.
+  // Subclasses override it when their visible heading is not [title].
+  @protected
+  String semanticLabel(WidgetRef ref) => joinSemanticLabel(title, message(ref));
+
+  @protected
+  String joinSemanticLabel(String heading, String body) => body.isEmpty
+      ? heading
+      : t.a11y.popupWithContent(title: heading, message: body);
+
   Widget? get leadingIcon => null;
   Widget buildContent(BuildContext context, WidgetRef ref);
 }
 
+// Announces the popup once, when it appears. This is imperative on purpose: a
+// name on the dialog node would be re-read on every focus change inside the
+// popup, prepending the title and the message to each of its buttons.
 final class _AnnounceOnShow extends StatefulWidget {
-  final String announcement;
+  final ValueGetter<String> announcement;
   final Widget child;
 
   const _AnnounceOnShow({required this.announcement, required this.child});
@@ -108,22 +133,57 @@ final class _AnnounceOnShow extends StatefulWidget {
 }
 
 final class _AnnounceOnShowState extends State<_AnnounceOnShow> {
+  Animation<double>? _transition;
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _announce());
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _scheduleAnnouncement(),
+    );
   }
 
-  void _announce() {
-    if (!mounted || !MediaQuery.supportsAnnounceOf(context)) {
+  // Wait for the popup to finish appearing: announcing while the route is still
+  // animating competes with the speech for the route change itself.
+  void _scheduleAnnouncement() {
+    if (!mounted) return;
+
+    // No route to wait for when a popup is built directly, as in tests.
+    final transition = ModalRoute.of(context)?.animation;
+    if (transition == null || transition.isCompleted) {
+      _announce();
       return;
     }
 
+    _transition = transition..addStatusListener(_onTransitionStatus);
+  }
+
+  void _onTransitionStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed) return;
+
+    _stopListening();
+    _announce();
+  }
+
+  void _stopListening() {
+    _transition?.removeStatusListener(_onTransitionStatus);
+    _transition = null;
+  }
+
+  void _announce() {
+    if (!mounted || !MediaQuery.supportsAnnounceOf(context)) return;
+
     SemanticsService.sendAnnouncement(
       View.of(context),
-      widget.announcement,
+      widget.announcement(),
       Directionality.of(context),
     );
+  }
+
+  @override
+  void dispose() {
+    _stopListening();
+    super.dispose();
   }
 
   @override

--- a/gui/lib/widgets/popups/popup.dart
+++ b/gui/lib/widgets/popups/popup.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nordvpn/data/models/popup_metadata.dart';
 import 'package:nordvpn/i18n/strings.g.dart';
@@ -20,25 +21,30 @@ abstract class Popup extends ConsumerWidget {
     final popupTheme = context.popupTheme;
     final theme = Theme.of(context);
 
-    return Dialog(
-      backgroundColor: Colors.transparent,
-      child: Container(
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surface,
-          borderRadius: popupTheme.widgetRadius,
-        ),
-        padding: EdgeInsets.all(popupTheme.verticalElementSpacing),
-        width: min(
-          dynamicScale(popupTheme.widgetWidth),
-          screenSize.width * 0.8,
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _titleBar(context, popupTheme),
-            buildContent(context, ref),
-          ],
+    return _AnnounceOnShow(
+      announcement: t.a11y.popupWithContent(
+        content: "$title. ${message(ref)}",
+      ),
+      child: Dialog(
+        backgroundColor: Colors.transparent,
+        child: Container(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surface,
+            borderRadius: popupTheme.widgetRadius,
+          ),
+          padding: EdgeInsets.all(popupTheme.verticalElementSpacing),
+          width: min(
+            dynamicScale(popupTheme.widgetWidth),
+            screenSize.width * 0.8,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _titleBar(context, popupTheme),
+              buildContent(context, ref),
+            ],
+          ),
         ),
       ),
     );
@@ -62,15 +68,23 @@ abstract class Popup extends ConsumerWidget {
     );
   }
 
+  // the title and the message are kept in their own semantics nodes, otherwise
+  // they are merged into the dialog and read again for each of its buttons
   Widget _title(PopupTheme theme) {
-    return Text(title, style: theme.textPrimary);
+    return Semantics(
+      container: true,
+      child: Text(title, style: theme.textPrimary),
+    );
   }
 
   Widget _closeIcon(BuildContext context) {
     final theme = context.popupTheme;
     return IconButton(
       padding: EdgeInsetsGeometry.all(theme.xButtonAllPadding),
-      icon: DynamicThemeImage("close.svg"),
+      icon: Semantics(
+        label: t.ui.close,
+        child: DynamicThemeImage("close.svg"),
+      ),
       onPressed: () => Navigator.of(context).pop(),
     );
   }
@@ -81,4 +95,37 @@ abstract class Popup extends ConsumerWidget {
 
   Widget? get leadingIcon => null;
   Widget buildContent(BuildContext context, WidgetRef ref);
+}
+
+final class _AnnounceOnShow extends StatefulWidget {
+  final String announcement;
+  final Widget child;
+
+  const _AnnounceOnShow({required this.announcement, required this.child});
+
+  @override
+  State<_AnnounceOnShow> createState() => _AnnounceOnShowState();
+}
+
+final class _AnnounceOnShowState extends State<_AnnounceOnShow> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _announce());
+  }
+
+  void _announce() {
+    if (!mounted || !MediaQuery.supportsAnnounceOf(context)) {
+      return;
+    }
+
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      widget.announcement,
+      Directionality.of(context),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
 }

--- a/gui/lib/widgets/popups/rich_popup.dart
+++ b/gui/lib/widgets/popups/rich_popup.dart
@@ -47,11 +47,17 @@ final class RichNotificationPopup extends Popup {
   }
 
   Widget _header(AppTheme theme) {
-    return Text(richMetadata.header, style: theme.title);
+    return Semantics(
+      container: true,
+      child: Text(richMetadata.header, style: theme.title),
+    );
   }
 
   Widget _message(WidgetRef ref, AppTheme theme) {
-    return Text(richMetadata.message(ref), style: theme.body);
+    return Semantics(
+      container: true,
+      child: Text(richMetadata.message(ref), style: theme.body),
+    );
   }
 
   Widget _actionButton(BuildContext context, WidgetRef ref) {

--- a/gui/lib/widgets/popups/rich_popup.dart
+++ b/gui/lib/widgets/popups/rich_popup.dart
@@ -7,6 +7,8 @@ import 'package:nordvpn/widgets/popups/popup.dart';
 
 // Popup with styled header, message, one button and image on the right.
 final class RichNotificationPopup extends Popup {
+  static const headerKey = Key("rich_popup_header");
+
   final RichPopupMetadata richMetadata;
 
   const RichNotificationPopup({super.key, required super.metadata})
@@ -47,18 +49,29 @@ final class RichNotificationPopup extends Popup {
   }
 
   Widget _header(AppTheme theme) {
-    return Semantics(
-      container: true,
-      child: Text(richMetadata.header, style: theme.title),
+    return MergeSemantics(
+      child: Semantics(
+        header: true,
+        child: Text(richMetadata.header, key: headerKey, style: theme.title),
+      ),
     );
   }
 
   Widget _message(WidgetRef ref, AppTheme theme) {
     return Semantics(
       container: true,
-      child: Text(richMetadata.message(ref), style: theme.body),
+      child: Text(
+        richMetadata.message(ref),
+        key: Popup.messageKey,
+        style: theme.body,
+      ),
     );
   }
+
+  // The visible heading of a rich popup is `header`, not the title bar text.
+  @override
+  String semanticLabel(WidgetRef ref) =>
+      joinSemanticLabel(richMetadata.header, richMetadata.message(ref));
 
   Widget _actionButton(BuildContext context, WidgetRef ref) {
     return ElevatedButton(

--- a/gui/test/utils/finders.dart
+++ b/gui/test/utils/finders.dart
@@ -13,6 +13,7 @@ import 'package:nordvpn/vpn/connection_card_server_info.dart';
 import 'package:nordvpn/vpn/servers_list_card.dart';
 import 'package:nordvpn/vpn/vpn.dart';
 import 'package:nordvpn/widgets/login_form.dart';
+import 'package:nordvpn/widgets/popups/popup.dart';
 
 Finder serverInfoText() {
   final serverInfoTextFinder = find.byKey(ConnectionCardServerInfo.textKey);
@@ -252,4 +253,20 @@ Finder snapErrorScreenDescription() {
 
 Finder snapErrorScreenCopyField() {
   return find.byKey(SnapWidgetKeys.copyField);
+}
+
+Finder popupSemantics() {
+  return find.byKey(Popup.semanticsKey);
+}
+
+Finder popupTitle() {
+  return find.byKey(Popup.titleKey);
+}
+
+Finder popupMessage() {
+  return find.byKey(Popup.messageKey);
+}
+
+Finder popupCloseButton() {
+  return find.byKey(Popup.closeButtonKey);
 }

--- a/gui/test/widgets/popup_announcements_test.dart
+++ b/gui/test/widgets/popup_announcements_test.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nordvpn/data/models/popup_metadata.dart';
+import 'package:nordvpn/i18n/strings.g.dart';
+import 'package:nordvpn/service_locator.dart';
+import 'package:nordvpn/widgets/popups/decision_popup.dart';
+import 'package:nordvpn/widgets/popups/info_popup.dart';
+import 'package:nordvpn/widgets/popups/rich_popup.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../utils/fake_shared_preferences.dart';
+import '../utils/finders.dart';
+import '../utils/test_helpers.dart';
+
+// Popups are read by the screen reader from the semantics tree:
+// - the dialog node carries the popup name (title + message), which is what the
+//   screen reader announces when the popup opens;
+// - `explicitChildNodes` on that node keeps the name off the buttons, so tabbing
+//   between them announces only the focused control.
+void main() {
+  const title = "Popup title";
+  const message = "Popup message";
+  const header = "Rich popup header";
+  const yesButtonText = "Turn off";
+  const noButtonText = "Cancel";
+  const actionButtonText = "Renew subscription";
+
+  setUpAll(() async {
+    SharedPreferencesAsyncPlatform.instance = FakeSharedPreferencesAsync();
+    await initServiceLocator();
+  });
+
+  // The test binding reports announce support by default, so only the negative
+  // case has to override it.
+  Widget withoutAnnounceSupport(Widget child) => Builder(
+    builder: (context) => MediaQuery(
+      data: MediaQuery.of(context).copyWith(supportsAnnounce: false),
+      child: child,
+    ),
+  );
+
+  Future<void> withSemantics(
+    WidgetTester tester,
+    Future<void> Function() body,
+  ) async {
+    final handle = tester.ensureSemantics();
+    try {
+      await body();
+    } finally {
+      handle.dispose();
+    }
+  }
+
+  InfoPopup infoPopup({String text = message}) => InfoPopup(
+    metadata: InfoPopupMetadata(id: 1, title: title, message: (_) => text),
+  );
+
+  DecisionPopup decisionPopup() => DecisionPopup(
+    metadata: DecisionPopupMetadata(
+      id: 2,
+      title: title,
+      message: (_) => message,
+      noButtonText: noButtonText,
+      yesButtonText: yesButtonText,
+      yesAction: (_) {},
+    ),
+  );
+
+  RichNotificationPopup richPopup({String text = message}) =>
+      RichNotificationPopup(
+        metadata: RichPopupMetadata(
+          id: 3,
+          header: header,
+          message: (_) => text,
+          actionButtonText: actionButtonText,
+          image: const SizedBox.shrink(),
+          action: (_) {},
+        ),
+      );
+
+  group('announced when it opens', () {
+    testWidgets('info popup announces its title and message', (tester) async {
+      await tester.setupWidgetTest(infoPopup());
+
+      final announcements = tester.takeAnnouncements();
+      expect(announcements, hasLength(1));
+      expect(
+        announcements.single.message,
+        t.a11y.popupWithContent(title: title, message: message),
+      );
+    });
+
+    testWidgets('decision popup announces its title and message', (
+      tester,
+    ) async {
+      await tester.setupWidgetTest(decisionPopup());
+
+      expect(
+        tester.takeAnnouncements().single.message,
+        t.a11y.popupWithContent(title: title, message: message),
+      );
+    });
+
+    // Rich popups keep their heading in `header` and leave `title` unset, so the
+    // announcement must use the header and not the "NordVPN" title fallback.
+    testWidgets('rich popup announces its header and message', (tester) async {
+      await tester.setupWidgetTest(richPopup());
+
+      final announced = tester.takeAnnouncements().single.message;
+      expect(
+        announced,
+        t.a11y.popupWithContent(title: header, message: message),
+      );
+      expect(announced, isNot(contains(t.ui.nordVpn)));
+    });
+
+    testWidgets('popup with an empty message announces its title alone', (
+      tester,
+    ) async {
+      await tester.setupWidgetTest(infoPopup(text: ""));
+
+      expect(tester.takeAnnouncements().single.message, title);
+    });
+
+    testWidgets('popup is announced once, not on every rebuild', (
+      tester,
+    ) async {
+      await tester.setupWidgetTest(infoPopup());
+      expect(tester.takeAnnouncements(), hasLength(1));
+
+      await tester.pumpAndSettleWithTimeout();
+
+      expect(tester.takeAnnouncements(), isEmpty);
+    });
+
+    testWidgets('nothing is announced when the platform has no support', (
+      tester,
+    ) async {
+      await tester.setupWidgetTest(withoutAnnounceSupport(infoPopup()));
+
+      expect(tester.takeAnnouncements(), isEmpty);
+    });
+  });
+
+  group('the dialog node stays unnamed', () {
+    // A name on the dialog node is re-read on every focus change inside the
+    // popup: that is what prepended the popup title and message to each button
+    // when tabbing. The popup name belongs to the on-open announcement instead.
+    testWidgets('decision popup dialog node carries no name', (tester) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(decisionPopup());
+
+        expect(
+          tester.getSemantics(popupSemantics()),
+          isSemantics(label: "", scopesRoute: true),
+        );
+      });
+    });
+
+    testWidgets('rich popup dialog node carries no name', (tester) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(richPopup());
+
+        expect(tester.getSemantics(popupSemantics()), isSemantics(label: ""));
+      });
+    });
+  });
+
+  group('focusable controls announce only themselves', () {
+    testWidgets('decision popup buttons carry only their own label', (
+      tester,
+    ) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(decisionPopup());
+
+        for (final buttonText in [yesButtonText, noButtonText]) {
+          final node = tester.getSemantics(find.text(buttonText));
+          expect(
+            node,
+            isSemantics(label: buttonText, isButton: true),
+            reason: "$buttonText should be announced as a button",
+          );
+          expect(
+            node.label,
+            isNot(contains(message)),
+            reason: "$buttonText must not repeat the popup message",
+          );
+          expect(
+            node.label,
+            isNot(contains(title)),
+            reason: "$buttonText must not repeat the popup title",
+          );
+        }
+      });
+    });
+
+    // The reported repro: the reconnect dialog announced each button with the
+    // dialog title and message prepended.
+    testWidgets('reconnect popup buttons carry only their own label', (
+      tester,
+    ) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(
+          DecisionPopup(
+            metadata: DecisionPopupMetadata(
+              id: 4,
+              title: t.ui.reconnectToChangeProtocol,
+              message: (_) => t.ui.reconnectToChangeProtocolDescription,
+              noButtonText: t.ui.cancel,
+              yesButtonText: t.ui.reconnectNow,
+              yesAction: (_) {},
+            ),
+          ),
+        );
+
+        for (final buttonText in [t.ui.cancel, t.ui.reconnectNow]) {
+          final node = tester.getSemantics(find.text(buttonText));
+          expect(node, isSemantics(label: buttonText, isButton: true));
+          expect(
+            node.label,
+            isNot(contains(t.ui.reconnectToChangeProtocol)),
+            reason: "$buttonText must not repeat the dialog title",
+          );
+          expect(
+            node.label,
+            isNot(contains(t.ui.reconnectToChangeProtocolDescription)),
+            reason: "$buttonText must not repeat the dialog message",
+          );
+        }
+      });
+    });
+
+    testWidgets('rich popup action button carries only its own label', (
+      tester,
+    ) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(richPopup());
+
+        final node = tester.getSemantics(find.text(actionButtonText));
+        expect(node, isSemantics(label: actionButtonText, isButton: true));
+        expect(node.label, isNot(contains(message)));
+        expect(node.label, isNot(contains(header)));
+      });
+    });
+
+    testWidgets('close button is announced as a button named "Close"', (
+      tester,
+    ) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(infoPopup());
+
+        expect(
+          tester.getSemantics(popupCloseButton()),
+          isSemantics(label: t.ui.close, isButton: true),
+        );
+      });
+    });
+  });
+
+  group('popup structure', () {
+    testWidgets('title is a header node', (tester) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(infoPopup());
+
+        expect(
+          tester.getSemantics(popupTitle()),
+          isSemantics(label: title, isHeader: true),
+        );
+      });
+    });
+
+    testWidgets('rich popup header is a header node', (tester) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(richPopup());
+
+        expect(
+          tester.getSemantics(find.byKey(RichNotificationPopup.headerKey)),
+          isSemantics(label: header, isHeader: true),
+        );
+      });
+    });
+
+    testWidgets('message is its own node', (tester) async {
+      await withSemantics(tester, () async {
+        await tester.setupWidgetTest(infoPopup());
+
+        expect(
+          tester.getSemantics(popupMessage()),
+          isSemantics(label: message),
+        );
+      });
+    });
+  });
+}

--- a/gui/test/widgets/popup_announcements_test.dart
+++ b/gui/test/widgets/popup_announcements_test.dart
@@ -154,6 +154,12 @@ void main() {
           tester.getSemantics(popupSemantics()),
           isSemantics(label: "", scopesRoute: true),
         );
+        // the role:dialog node is the one the screen reader names, and a bare
+        // Text inside the popup would have its label absorbed into it
+        expect(
+          tester.getSemantics(find.byType(Dialog)),
+          isSemantics(label: ""),
+        );
       });
     });
 
@@ -162,6 +168,10 @@ void main() {
         await tester.setupWidgetTest(richPopup());
 
         expect(tester.getSemantics(popupSemantics()), isSemantics(label: ""));
+        expect(
+          tester.getSemantics(find.byType(Dialog)),
+          isSemantics(label: ""),
+        );
       });
     });
   });
@@ -284,9 +294,14 @@ void main() {
       await withSemantics(tester, () async {
         await tester.setupWidgetTest(infoPopup());
 
+        final node = tester.getSemantics(popupMessage());
+        expect(node, isSemantics(label: message));
         expect(
-          tester.getSemantics(popupMessage()),
-          isSemantics(label: message),
+          node.childrenCount,
+          0,
+          reason:
+              "the message must be a leaf node, not a container that "
+              "absorbed the label from an ancestor",
         );
       });
     });


### PR DESCRIPTION
With this PR, popups are now announced in a following manner:
- popups' content is announced with a `Popup` information (hence added `popupWithContent` into a11y strings)
- popups' buttons are now separately announced (such as cancel, accept, `X` close button)
- popups are announced now upon being shown