### PR TITLE
LVPN-10874: Fix flaky `test_killswitch_autoconnect_to_fastest_debug` test

### DIFF
--- a/test/qa/test_killswitch.py
+++ b/test/qa/test_killswitch.py
@@ -285,4 +285,6 @@ def test_killswitch_autoconnect_to_fastest_debug():
     duration = time.monotonic() - start_time
     assert duration < 7, "Autoconnect with killswitch on should connect in less than 7 seconds"
     status_data = daemon.get_status_data()
-    assert device_country in status_data["country"], "Fastest server should be in the same country"
+    # list of closest countries that surround Germany
+    allowed_countries = ["Germany", "Poland", "Czech_Republic", "Austria", "Switzerland", "France", "Belgium", "Netherlands", "Denmark"]
+    assert status_data["country"] in allowed_countries, "Fastest server should be in the same country"

--- a/test/qa/test_killswitch.py
+++ b/test/qa/test_killswitch.py
@@ -277,6 +277,7 @@ def test_killswitch_mode_daemon():
 
 def test_killswitch_autoconnect_to_fastest():
     device_country = network.get_external_device_country()
+    assert "Germany" in device_country
     sh.nordvpn.set.killswitch.on()
     sh.nordvpn.set.autoconnect.on()
     daemon.restart()

--- a/test/qa/test_killswitch.py
+++ b/test/qa/test_killswitch.py
@@ -261,7 +261,7 @@ def test_nc_mqtt_connection_with_killswitch():
     assert network.is_available(), "Network should be available after test"
 
 
-def test_killswitch_mode_daemon_debug():
+def test_killswitch_mode_daemon():
     sh.nordvpn.set.killswitch.on()
     daemon.stop()
     daemon.start_with_arg("--killswitch-mode")
@@ -275,7 +275,7 @@ def test_killswitch_mode_daemon_debug():
     assert network.is_available(), "Network should be available"
 
 
-def test_killswitch_autoconnect_to_fastest_debug():
+def test_killswitch_autoconnect_to_fastest():
     device_country = network.get_external_device_country()
     sh.nordvpn.set.killswitch.on()
     sh.nordvpn.set.autoconnect.on()


### PR DESCRIPTION
Sometimes this test fails due to fact, that it expects country it connects to, to be in the same country as our device. This is incorrect approach, since API may return a neighboring country for Quick Connect recommendations, and in such case test fails. Due to this reason, from now on in this test we will compare the country we've been connected to, with a hard-coded list of countries surrounding Germany.