### PR TITLE
LVPN-10985: Bump CI ref tag to v1.8.1

### DIFF
--- a/.github/workflows/ci-gitlab.yml
+++ b/.github/workflows/ci-gitlab.yml
@@ -18,4 +18,4 @@ jobs:
       project-id: ${{ secrets.PROJECT_ID }}
     with:
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v1.8.0
+      triggered-ref: v1.8.1


### PR DESCRIPTION
Old logic for `check_install` jobs will keep running, until we update the CI tag ref.