### PR TITLE
LVPN-10882: Tray notifications

### DIFF
--- a/alert/alert_builder.go
+++ b/alert/alert_builder.go
@@ -1,0 +1,42 @@
+package alert
+
+import "github.com/NordSecurity/nordvpn-linux/internal"
+
+type AlertBuilder struct {
+	send  func(Alert)
+	alert Alert
+}
+
+func NewAlertBuilder(send func(Alert), body string) *AlertBuilder {
+	return &AlertBuilder{
+		send: send,
+		alert: Alert{
+			Summary: internal.AppName,
+			Body:    body,
+			Urgency: UrgencyNormal,
+		},
+	}
+}
+
+func (b *AlertBuilder) Summary(summary string) *AlertBuilder {
+	b.alert.Summary = summary
+	return b
+}
+
+func (b *AlertBuilder) Urgent() *AlertBuilder {
+	b.alert.Urgency = UrgencyCritical
+	return b
+}
+
+func (b *AlertBuilder) Action(key, label string, callback func()) *AlertBuilder {
+	b.alert.Actions = append(b.alert.Actions, Action{
+		Key:      key,
+		Label:    label,
+		Callback: callback,
+	})
+	return b
+}
+
+func (b *AlertBuilder) Show() {
+	b.send(b.alert)
+}

--- a/alert/dbus_notifier.go
+++ b/alert/dbus_notifier.go
@@ -1,0 +1,211 @@
+// Package alert delivers API for sending OS notification.
+package alert
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/log"
+	"github.com/esiqveland/notify"
+	"github.com/godbus/dbus/v5"
+)
+
+type AlertID = uint32
+
+type Urgency int
+
+const (
+	// UrgencyNormal indicates that the alert should respect the user's settings.
+	UrgencyNormal Urgency = iota
+	// UrgencyCritical indicates that the alert should be shown regardless of the user's settings.
+	UrgencyCritical
+)
+
+func (u Urgency) String() string {
+	switch u {
+	case UrgencyNormal:
+		return "normal"
+	case UrgencyCritical:
+		return "critical"
+	default:
+		return "unknown"
+	}
+}
+
+type Notifier interface {
+	Alert(body string) *AlertBuilder
+	Mute()
+	Unmute()
+	Close() error
+}
+
+type Alert struct {
+	Summary string
+	Body    string
+	Actions []Action
+	Urgency Urgency
+}
+
+func (a Alert) String() string {
+	return fmt.Sprintf("[%s] %q (%s)", a.Summary, a.Body, a.Urgency)
+}
+
+type Action struct {
+	Key      string
+	Label    string
+	Callback func()
+}
+
+type DbusNotifier struct {
+	mu        sync.Mutex
+	isActive  bool
+	transient bool
+	notifier  notify.Notifier
+	actions   map[AlertID]map[string]func()
+}
+
+type Option func(*DbusNotifier)
+
+func WithTransient() Option {
+	return func(n *DbusNotifier) {
+		n.transient = true
+	}
+}
+
+func NewDbusNotifier(opts ...Option) (*DbusNotifier, error) {
+	dbusConn, err := dbus.SessionBusPrivate()
+	if err != nil {
+		return nil, fmt.Errorf("creating D-Bus connection: %w", err)
+	}
+
+	var success bool
+	defer func() {
+		if !success {
+			_ = dbusConn.Close()
+		}
+	}()
+
+	if err = dbusConn.Auth(nil); err != nil {
+		return nil, fmt.Errorf("authenticating to D-Bus: %w", err)
+	}
+
+	if err = dbusConn.Hello(); err != nil {
+		return nil, fmt.Errorf("sending D-Bus hello: %w", err)
+	}
+
+	n := &DbusNotifier{
+		actions:  make(map[AlertID]map[string]func()),
+		isActive: true,
+	}
+	for _, opt := range opts {
+		opt(n)
+	}
+
+	notifier, err := notify.New(
+		dbusConn,
+		notify.WithOnAction(n.dispatchAction),
+		notify.WithOnClosed(n.forget),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating new notifier: %w", err)
+	}
+
+	n.notifier = notifier
+	success = true
+
+	return n, nil
+}
+
+func (n *DbusNotifier) Alert(body string) *AlertBuilder {
+	return NewAlertBuilder(n.doNotify, body)
+}
+
+func (n *DbusNotifier) doNotify(alert Alert) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if !n.isActive && alert.Urgency == UrgencyNormal {
+		log.Infof("notification suppressed: %s", alert)
+		return
+	}
+
+	alertActions := make([]notify.Action, 0, len(alert.Actions))
+	for _, action := range alert.Actions {
+		alertActions = append(alertActions, notify.Action{Key: action.Key, Label: action.Label})
+	}
+
+	notif := notify.Notification{
+		AppName:       internal.AppName,
+		Summary:       alert.Summary,
+		AppIcon:       GetIconPath("nordvpn"),
+		Body:          alert.Body,
+		ExpireTimeout: notify.ExpireTimeoutSetByNotificationServer,
+		Actions:       alertActions,
+	}
+
+	if n.transient {
+		notif.Hints = map[string]dbus.Variant{"transient": dbus.MakeVariant(1)}
+	}
+
+	log.Infof("sending notification: %s", alert)
+	id, err := n.notifier.SendNotification(notif)
+	if err != nil {
+		log.Errorf("failed to send notification '%s': %v", notif, err)
+		return
+	}
+
+	if len(alert.Actions) > 0 {
+		callbacks := make(map[string]func(), len(alert.Actions))
+		for _, action := range alert.Actions {
+			if action.Callback != nil {
+				callbacks[action.Key] = action.Callback
+			}
+		}
+		n.actions[id] = callbacks
+	}
+}
+
+func (n *DbusNotifier) dispatchAction(action *notify.ActionInvokedSignal) {
+	n.mu.Lock()
+	callbacks, ok := n.actions[action.ID]
+	delete(n.actions, action.ID)
+	n.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	callback, ok := callbacks[action.ActionKey]
+	if !ok || callback == nil {
+		log.Error("Unknown action key: ", action.ActionKey)
+		return
+	}
+
+	callback()
+}
+
+func (n *DbusNotifier) forget(ncs *notify.NotificationClosedSignal) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.actions, ncs.ID)
+}
+
+func (n *DbusNotifier) Mute() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.isActive = false
+}
+
+func (n *DbusNotifier) Unmute() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.isActive = true
+}
+
+func (n *DbusNotifier) Close() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.isActive = false
+
+	return n.notifier.Close()
+}

--- a/alert/dbus_notifier_test.go
+++ b/alert/dbus_notifier_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/NordSecurity/nordvpn-linux/test/category"
-	mocknotify "github.com/NordSecurity/nordvpn-linux/test/mock/notify"
+	"github.com/NordSecurity/nordvpn-linux/test/mock/mocknotify"
 	"github.com/esiqveland/notify"
 	"github.com/godbus/dbus/v5"
 	"github.com/stretchr/testify/assert"

--- a/alert/dbus_notifier_test.go
+++ b/alert/dbus_notifier_test.go
@@ -1,0 +1,192 @@
+package alert
+
+import (
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	mocknotify "github.com/NordSecurity/nordvpn-linux/test/mock/notify"
+	"github.com/esiqveland/notify"
+	"github.com/godbus/dbus/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDbusNotifier() *DbusNotifier {
+	return &DbusNotifier{
+		notifier: &mocknotify.UpstreamNotifierMock{},
+		actions:  make(map[AlertID]map[string]func()),
+		isActive: true,
+	}
+}
+
+func TestDbusNotifierDispatchAction(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name       string
+		actionKey  string
+		wantCalled bool
+	}{
+		{
+			name:       "known action key invokes callback",
+			actionKey:  "open",
+			wantCalled: true,
+		},
+		{
+			name:       "unknown action key is a no-op",
+			actionKey:  "unknown-key",
+			wantCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := newTestDbusNotifier()
+
+			called := false
+			n.Alert("body").Action("open", "Open", func() { called = true }).Show()
+			n.dispatchAction(&notify.ActionInvokedSignal{ID: 0, ActionKey: tt.actionKey})
+
+			assert.Equal(t, tt.wantCalled, called)
+		})
+	}
+}
+
+func TestDbusNotifierSingleActionIsConsumedAtMostOnce(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name       string
+		firstStep  func(n *DbusNotifier, id AlertID)
+		wantCalled bool
+	}{
+		{
+			name: "dispatching twice invokes callback only once",
+			firstStep: func(n *DbusNotifier, id AlertID) {
+				n.dispatchAction(&notify.ActionInvokedSignal{ID: id, ActionKey: "open"})
+			},
+			wantCalled: true,
+		},
+		{
+			name: "forgetting before dispatch discards the callback",
+			firstStep: func(n *DbusNotifier, id AlertID) {
+				n.forget(&notify.NotificationClosedSignal{ID: id})
+			},
+			wantCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := newTestDbusNotifier()
+
+			callCount := 0
+			n.Alert("body").Action("open", "Open", func() { callCount++ }).Show()
+
+			const id AlertID = 0
+			tt.firstStep(n, id)
+			n.dispatchAction(&notify.ActionInvokedSignal{ID: id, ActionKey: "open"})
+
+			wantCount := 0
+			if tt.wantCalled {
+				wantCount = 1
+			}
+			assert.Equal(t, wantCount, callCount)
+		})
+	}
+}
+
+func TestDbusNotifierDispatchActionMutualExclusion(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	n := newTestDbusNotifier()
+
+	var accepted, declined bool
+	n.Alert("body").
+		Action("accept", "Accept", func() { accepted = true }).
+		Action("decline", "Decline", func() { declined = true }).
+		Show()
+
+	n.dispatchAction(&notify.ActionInvokedSignal{ID: 0, ActionKey: "accept"})
+	n.dispatchAction(&notify.ActionInvokedSignal{ID: 0, ActionKey: "decline"})
+
+	assert.True(t, accepted)
+	assert.False(t, declined)
+}
+
+func TestDbusNotifierDisableRespectsUrgency(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name          string
+		urgent        bool
+		wantDelivered bool
+	}{
+		{
+			name:          "normal alert suppressed when disabled",
+			urgent:        false,
+			wantDelivered: false,
+		},
+		{
+			name:          "urgent alert bypasses disable",
+			urgent:        true,
+			wantDelivered: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &mocknotify.UpstreamNotifierMock{}
+			n := &DbusNotifier{
+				notifier: upstream,
+				actions:  make(map[AlertID]map[string]func()),
+				isActive: true,
+			}
+
+			n.Mute()
+
+			b := n.Alert("body")
+			if tt.urgent {
+				b = b.Urgent()
+			}
+			b.Show()
+
+			assert.Equal(t, tt.wantDelivered, len(upstream.Sent) == 1)
+		})
+	}
+}
+
+func TestDbusNotifierTransientHint(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name      string
+		transient bool
+	}{
+		{name: "transient option sets the hint", transient: true},
+		{name: "without the option no hint is set", transient: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &mocknotify.UpstreamNotifierMock{}
+			n := &DbusNotifier{
+				notifier:  upstream,
+				actions:   make(map[AlertID]map[string]func()),
+				isActive:  true,
+				transient: tt.transient,
+			}
+
+			n.Alert("body").Show()
+
+			require.Len(t, upstream.Sent, 1)
+			hint, ok := upstream.Sent[0].Hints["transient"]
+			if tt.transient {
+				assert.True(t, ok)
+				assert.Equal(t, dbus.MakeVariant(1), hint)
+			} else {
+				assert.False(t, ok)
+			}
+		})
+	}
+}

--- a/alert/noop_notifier.go
+++ b/alert/noop_notifier.go
@@ -1,0 +1,17 @@
+package alert
+
+import "github.com/NordSecurity/nordvpn-linux/log"
+
+type NoopNotifier struct{}
+
+func (NoopNotifier) Alert(body string) *AlertBuilder {
+	return NewAlertBuilder(func(a Alert) {
+		log.Warnf("notifier unavailable, dropping alert: %s", a)
+	}, body)
+}
+
+func (NoopNotifier) Mute() {}
+
+func (NoopNotifier) Unmute() {}
+
+func (NoopNotifier) Close() error { return nil }

--- a/alert/notify.go
+++ b/alert/notify.go
@@ -1,4 +1,4 @@
-package notify
+package alert
 
 import (
 	"path"

--- a/fileshare/event_manager.go
+++ b/fileshare/event_manager.go
@@ -155,7 +155,7 @@ func (em *EventManager) DisableNotifications() error {
 		return ErrNotificationsAlreadyDisabled
 	}
 
-	if err := em.notificationManager.notifier.Close(); err != nil {
+	if err := em.notificationManager.n.Close(); err != nil {
 		return fmt.Errorf("failed to disable notifier: %s", err)
 	}
 	em.notificationManager = nil
@@ -351,7 +351,7 @@ func (em *EventManager) handleFileFailedEvent(event EventKindFileFailed) {
 	}
 	file.Finished = true
 
-	//no gosec violation, values from the enumeration are within the int32 max range
+	// no gosec violation, values from the enumeration are within the int32 max range
 	// #nosec G115
 	fileStatusInNotification := pb.Status(event.Status.Status)
 	removeFileFromLiveTransfer(transfer, file)
@@ -626,17 +626,17 @@ func isFileWriteable(fileInfo fs.FileInfo, user *user.User, gids []string) bool 
 	isOwner := uid == ownerUID
 
 	if isOwner {
-		return fileInfo.Mode().Perm()&os.FileMode(0200) != 0
+		return fileInfo.Mode().Perm()&os.FileMode(0o200) != 0
 	}
 
 	ownerGIDStr := strconv.Itoa(ownerGID)
 	gidIndex := slices.Index(gids, ownerGIDStr)
 	isGroup := gidIndex != -1
 	if isGroup {
-		return fileInfo.Mode().Perm()&os.FileMode(0020) != 0
+		return fileInfo.Mode().Perm()&os.FileMode(0o020) != 0
 	}
 
-	return fileInfo.Mode().Perm()&os.FileMode(0002) != 0
+	return fileInfo.Mode().Perm()&os.FileMode(0o002) != 0
 }
 
 // TransferProgressInfo info to report to the user

--- a/fileshare/event_manager_test.go
+++ b/fileshare/event_manager_test.go
@@ -15,9 +15,11 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/NordSecurity/nordvpn-linux/alert"
 	"github.com/NordSecurity/nordvpn-linux/fileshare/pb"
 	meshpb "github.com/NordSecurity/nordvpn-linux/meshnet/pb"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	mockalert "github.com/NordSecurity/nordvpn-linux/test/mock/alert"
 	"golang.org/x/sys/unix"
 
 	"github.com/stretchr/testify/assert"
@@ -31,54 +33,19 @@ const (
 	tmpDir         = "/tmp"
 )
 
-type mockNotification struct {
-	id      uint32
-	summary string
-	body    string
-	actions []Action
-}
-
-type mockNotifier struct {
-	notifications []mockNotification
-	nextID        uint32
-	updateCh      chan struct{}
-}
-
-func (mn *mockNotifier) Wait() {
-	select {
-	case <-time.After(1 * time.Second):
-	case <-mn.updateCh:
+func actionsWithoutCallbacks(actions []alert.Action) []alert.Action {
+	if actions == nil {
+		return nil
 	}
-}
-
-func (mn *mockNotifier) SendNotification(summary string, body string, actions []Action) (uint32, error) {
-	notificationID := mn.nextID
-	mn.notifications = append(mn.notifications, mockNotification{id: notificationID, summary: summary, body: body, actions: actions})
-	mn.nextID++
-
-	if mn.updateCh != nil {
-		select {
-		case mn.updateCh <- struct{}{}:
-		default:
-			<-mn.updateCh
-			mn.updateCh <- struct{}{}
-		}
+	stripped := make([]alert.Action, len(actions))
+	for i, action := range actions {
+		stripped[i] = alert.Action{Key: action.Key, Label: action.Label}
 	}
-	return notificationID, nil
-}
-
-func (mn *mockNotifier) Close() error {
-	return nil
-}
-
-func (mn *mockNotifier) getLastNotification() mockNotification {
-	return mn.notifications[len(mn.notifications)-1]
+	return stripped
 }
 
 func NewMockNotificationManager(osInfo *mockEventManagerOsInfo) NotificationManager {
-	return NotificationManager{
-		notifications: newNotificationStorage(),
-	}
+	return NotificationManager{}
 }
 
 type mockEventManagerFilesystem struct {
@@ -194,7 +161,7 @@ func newMockSystemEnvironment(t *testing.T) mockSystemEnvironment {
 
 	destinationDirectoryFilename := "tmp"
 	directories := fstest.MapFS{
-		destinationDirectoryFilename: &fstest.MapFile{Mode: os.ModeDir | 0777, Sys: stat_t},
+		destinationDirectoryFilename: &fstest.MapFile{Mode: os.ModeDir | 0o777, Sys: stat_t},
 	}
 
 	osInfo := mockEventManagerOsInfo{
@@ -575,14 +542,14 @@ func TestTransferFinishedNotifications(t *testing.T) {
 	fileID := "file_id"
 	filePath := "file_path"
 
-	initializeEventManager := func(direction pb.Direction) (*EventManager, *mockNotifier) {
-		notifier := mockNotifier{
-			notifications: []mockNotification{},
-			nextID:        0,
-			updateCh:      make(chan struct{}, 1),
+	initializeEventManager := func(direction pb.Direction) (*EventManager, *mockalert.NotifierMock) {
+		notifier := mockalert.NotifierMock{
+			Alerts:   []mockalert.Alert{},
+			NextID:   0,
+			UpdateCh: make(chan struct{}, 1),
 		}
 		notificationManager := NewMockNotificationManager(&mockEventManagerOsInfo{})
-		notificationManager.notifier = &notifier
+		notificationManager.n = &notifier
 
 		eventManager := NewEventManager(false,
 			&mockMeshClient{},
@@ -615,7 +582,7 @@ func TestTransferFinishedNotifications(t *testing.T) {
 		reason          string
 		expectedSummary string
 		expectedBody    string
-		expectedActions []Action
+		expectedActions []alert.Action
 	}{
 		{
 			name: "download finished success",
@@ -630,7 +597,7 @@ func TestTransferFinishedNotifications(t *testing.T) {
 			direction:       pb.Direction_INCOMING,
 			reason:          "FileDownloaded",
 			expectedSummary: "downloaded",
-			expectedActions: []Action{{actionKeyOpenFile, "Open"}},
+			expectedActions: []alert.Action{{Key: actionKeyOpenFile, Label: "Open"}},
 		},
 		{
 			name: "download finished failure",
@@ -689,16 +656,16 @@ func TestTransferFinishedNotifications(t *testing.T) {
 			)
 			notifier.Wait()
 
-			assert.Equal(t, 1, len(notifier.notifications),
+			assert.Equal(t, 1, len(notifier.Alerts),
 				"TransferFinished event was received, but EventManager did not send any notifications.")
 
-			notification := notifier.notifications[0]
+			notification := notifier.Alerts[0]
 
-			assert.Equal(t, test.expectedSummary, notification.summary,
+			assert.Equal(t, test.expectedSummary, notification.Summary,
 				"Invalid notification summary")
-			assert.Equal(t, filePath, notification.body,
+			assert.Equal(t, filePath, notification.Body,
 				"Notification body should be a filename")
-			assert.Equal(t, test.expectedActions, notification.actions,
+			assert.Equal(t, test.expectedActions, actionsWithoutCallbacks(notification.Actions),
 				"Actions associated with notifications are invalid.")
 		})
 	}
@@ -709,10 +676,10 @@ func TestTransferFinishedNotificationsOpenFile(t *testing.T) {
 	fileID := "file_id"
 	filePath := "file_path"
 
-	notifier := mockNotifier{
-		notifications: []mockNotification{},
-		nextID:        0,
-		updateCh:      make(chan struct{}, 1),
+	notifier := mockalert.NotifierMock{
+		Alerts:   []mockalert.Alert{},
+		NextID:   0,
+		UpdateCh: make(chan struct{}, 1),
 	}
 
 	openedFiles := []string{}
@@ -721,7 +688,7 @@ func TestTransferFinishedNotificationsOpenFile(t *testing.T) {
 	}
 
 	notificationManager := NewMockNotificationManager(&mockEventManagerOsInfo{})
-	notificationManager.notifier = &notifier
+	notificationManager.n = &notifier
 	notificationManager.openFileFunc = openFileFunc
 
 	eventManager := NewEventManager(false,
@@ -753,23 +720,22 @@ func TestTransferFinishedNotificationsOpenFile(t *testing.T) {
 	})
 
 	notifier.Wait()
-	notification := notifier.notifications[0]
+	notification := notifier.Alerts[0]
 
-	notificationManager.OpenFile(notification.id)
-	assert.Equal(t, 1, len(openedFiles), "Open event was emitted, but no files were opened.")
+	if assert.Len(t, notification.Actions, 1, "Expected exactly one action on the file notification.") {
+		notification.Actions[0].Callback()
+	}
+	assert.Equal(t, 1, len(openedFiles), "Open action callback did not open the file.")
 	assert.Equal(t, filePath, openedFiles[0], "Invalid file opened.")
-
-	notificationManager.OpenFile(notification.id)
-	assert.Equal(t, 1, len(openedFiles), "File was opened but it was already opened once.")
 }
 
 func TestTransferRequestNotification(t *testing.T) {
 	transferID := exampleUUID
 
-	notifier := mockNotifier{
-		notifications: []mockNotification{},
-		nextID:        0,
-		updateCh:      make(chan struct{}, 1),
+	notifier := mockalert.NotifierMock{
+		Alerts:   []mockalert.Alert{},
+		NextID:   0,
+		UpdateCh: make(chan struct{}, 1),
 	}
 
 	openedFiles := []string{}
@@ -778,7 +744,7 @@ func TestTransferRequestNotification(t *testing.T) {
 	}
 
 	notificationManager := NewMockNotificationManager(&mockEventManagerOsInfo{})
-	notificationManager.notifier = &notifier
+	notificationManager.n = &notifier
 	notificationManager.openFileFunc = openFileFunc
 
 	eventManager := NewEventManager(false,
@@ -815,28 +781,28 @@ func TestTransferRequestNotification(t *testing.T) {
 	eventManager.Event(event)
 	notifier.Wait()
 
-	assert.Equal(t, 1, len(notifier.notifications),
+	assert.Equal(t, 1, len(notifier.Alerts),
 		"Transfer request notification was not sent after transfer request event was received.")
 
-	transferRequestNotification := notifier.getLastNotification()
-	assert.Equal(t, notifyNewTransferSummary, transferRequestNotification.summary)
+	transferRequestNotification := notifier.GetLastNotification()
+	assert.Equal(t, notifyNewTransferSummary, transferRequestNotification.Summary)
 
 	expectedNotificationBody := fmt.Sprintf(notifyNewTransferBody, transferID, hostname)
-	assert.Equal(t, expectedNotificationBody, transferRequestNotification.body,
+	assert.Equal(t, expectedNotificationBody, transferRequestNotification.Body,
 		"Invalid notification body.")
 
-	expectedActions := []Action{
+	expectedActions := []alert.Action{
 		{
-			Action: transferAcceptAction,
-			Key:    actionKeyAcceptTransfer,
+			Label: transferAcceptAction,
+			Key:   actionKeyAcceptTransfer,
 		},
 		{
-			Action: transferCancelAction,
-			Key:    actionKeyCancelTransfer,
+			Label: transferCancelAction,
+			Key:   actionKeyCancelTransfer,
 		},
 	}
 
-	assert.Equal(t, expectedActions, transferRequestNotification.actions)
+	assert.Equal(t, expectedActions, actionsWithoutCallbacks(transferRequestNotification.Actions))
 }
 
 func TestTransferRequestNotificationAccept(t *testing.T) {
@@ -846,12 +812,11 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 	pendingTransferNotificationID := uint32(0)
 
 	transferFinishedID := "022cb1eb-ee22-431a-80c5-ba3050493c17"
-	transferFinishedNotificationID := uint32(1)
 
 	type testEnv struct {
 		notificationManager *NotificationManager
 		eventManager        *EventManager
-		notifier            *mockNotifier
+		notifier            *mockalert.NotifierMock
 		fileshare           *mockEventManagerFileshare
 	}
 
@@ -868,9 +833,9 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 			Gid: currentUserGID,
 		}
 		directories := fstest.MapFS{
-			"directory": &fstest.MapFile{Mode: os.ModeDir | 0777, Sys: stat_t},
-			"symlink":   &fstest.MapFile{Mode: os.ModeSymlink | 0777, Sys: stat_t},
-			"file":      &fstest.MapFile{Mode: 0777, Sys: stat_t},
+			"directory": &fstest.MapFile{Mode: os.ModeDir | 0o777, Sys: stat_t},
+			"symlink":   &fstest.MapFile{Mode: os.ModeSymlink | 0o777, Sys: stat_t},
+			"file":      &fstest.MapFile{Mode: 0o777, Sys: stat_t},
 		}
 
 		filesystem := mockEventManagerFilesystem{
@@ -878,10 +843,10 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 			freeSpace: freeSpace,
 		}
 
-		notifier := mockNotifier{
-			notifications: []mockNotification{},
-			nextID:        pendingTransferNotificationID,
-			updateCh:      make(chan struct{}, 1),
+		notifier := mockalert.NotifierMock{
+			Alerts:   []mockalert.Alert{},
+			NextID:   pendingTransferNotificationID,
+			UpdateCh: make(chan struct{}, 1),
 		}
 
 		osInfo := mockEventManagerOsInfo{
@@ -892,7 +857,7 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		}
 
 		notificationManager := NewMockNotificationManager(&osInfo)
-		notificationManager.notifier = &notifier
+		notificationManager.n = &notifier
 
 		eventManager := NewEventManager(false,
 			&mockMeshClient{},
@@ -928,11 +893,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		notificationManager.fileshare = fileshare
 		notificationManager.defaultDownloadDir = destinationDirectory
 
-		notificationManager.notifications.transfers = map[uint32]string{
-			pendingTransferNotificationID:  pendingTransferID,
-			transferFinishedNotificationID: transferFinishedID,
-		}
-
 		eventManager.meshClient = &mockMeshClient{externalPeers: []*meshpb.Peer{
 			{
 				Ip:                peer,
@@ -951,7 +911,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 	tests := []struct {
 		name                      string
 		destinationDirectoryName  string
-		notificationID            uint32
 		transferID                string
 		freeSpace                 uint64
 		expectedTransferStatus    pb.Status
@@ -960,7 +919,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		{
 			name:                      "transfer successfully accepted",
 			destinationDirectoryName:  "directory",
-			notificationID:            pendingTransferNotificationID,
 			transferID:                pendingTransferID,
 			freeSpace:                 math.MaxUint64,
 			expectedTransferStatus:    pb.Status_ONGOING,
@@ -969,7 +927,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		{
 			name:                      "destination directory is a symlink",
 			destinationDirectoryName:  "symlink",
-			notificationID:            pendingTransferNotificationID,
 			transferID:                pendingTransferID,
 			freeSpace:                 math.MaxUint64,
 			expectedTransferStatus:    pb.Status_REQUESTED,
@@ -978,7 +935,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		{
 			name:                      "destination directory is a file",
 			destinationDirectoryName:  "file",
-			notificationID:            pendingTransferNotificationID,
 			transferID:                pendingTransferID,
 			freeSpace:                 math.MaxUint64,
 			expectedTransferStatus:    pb.Status_REQUESTED,
@@ -987,7 +943,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		{
 			name:                      "directory doesn't exist",
 			destinationDirectoryName:  "no_dir",
-			notificationID:            pendingTransferNotificationID,
 			transferID:                pendingTransferID,
 			freeSpace:                 math.MaxUint64,
 			expectedTransferStatus:    pb.Status_REQUESTED,
@@ -996,7 +951,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		{
 			name:                      "not enough free space",
 			destinationDirectoryName:  "directory",
-			notificationID:            pendingTransferNotificationID,
 			transferID:                pendingTransferID,
 			freeSpace:                 1,
 			expectedTransferStatus:    pb.Status_REQUESTED,
@@ -1005,7 +959,6 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 		{
 			name:                      "transfer already finished",
 			destinationDirectoryName:  "directory",
-			notificationID:            transferFinishedNotificationID,
 			transferID:                transferFinishedID,
 			freeSpace:                 math.MaxUint64,
 			expectedTransferStatus:    pb.Status_SUCCESS,
@@ -1016,28 +969,28 @@ func TestTransferRequestNotificationAccept(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testEnv := setup(test.destinationDirectoryName, test.freeSpace)
-			testEnv.notificationManager.AcceptTransfer(test.notificationID)
+			testEnv.notificationManager.acceptTransfer(test.transferID)
 
 			if test.expectedErrorNotification == "" {
-				assert.Empty(t, testEnv.notifier.notifications,
+				assert.Empty(t, testEnv.notifier.Alerts,
 					"Unexpected notifications received: %v",
-					testEnv.notifier.notifications)
+					testEnv.notifier.Alerts)
 
 				acceptedTransfer := testEnv.fileshare.getLastAcceptedTransferID()
 				assert.Equal(t, test.transferID, acceptedTransfer, "Invalid transfer was accepted")
 				return
 			}
 
-			assert.Equal(t, 1, len(testEnv.notifier.notifications), "Accept error notification was not received")
+			assert.Equal(t, 1, len(testEnv.notifier.Alerts), "Accept error notification was not received")
 
-			errorNotification := testEnv.notifier.getLastNotification()
-			assert.Equal(t, acceptFailedNotificationSummary, errorNotification.summary,
+			errorNotification := testEnv.notifier.GetLastNotification()
+			assert.Equal(t, acceptFailedNotificationSummary, errorNotification.Summary,
 				"Error notification has invalid summary.")
-			assert.Equal(t, test.expectedErrorNotification, errorNotification.body,
+			assert.Equal(t, test.expectedErrorNotification, errorNotification.Body,
 				"Error notification has invalid body.")
-			assert.Equal(t, 0, len(errorNotification.actions),
+			assert.Equal(t, 0, len(errorNotification.Actions),
 				"Unexpected actions found in error notification: \n%v",
-				errorNotification.actions)
+				errorNotification.Actions)
 		})
 	}
 }
@@ -1046,18 +999,16 @@ func TestTransterRequestNotificationAcceptInvalidTransfer(t *testing.T) {
 	peer := exampleIP1
 
 	transferID := exampleUUID
-	transferNotificationID := uint32(0)
 
 	mockOsEnvironment := newMockSystemEnvironment(t)
 
-	notifier := mockNotifier{
-		notifications: []mockNotification{},
-		nextID:        transferNotificationID,
-		updateCh:      make(chan struct{}, 1),
+	notifier := mockalert.NotifierMock{
+		Alerts:   []mockalert.Alert{},
+		UpdateCh: make(chan struct{}, 1),
 	}
 
 	notificationManager := NewMockNotificationManager(&mockOsEnvironment.mockEventManagerOsInfo)
-	notificationManager.notifier = &notifier
+	notificationManager.n = &notifier
 
 	eventManager := NewEventManager(false,
 		&mockMeshClient{},
@@ -1071,10 +1022,6 @@ func TestTransterRequestNotificationAcceptInvalidTransfer(t *testing.T) {
 	notificationManager.fileshare = &mockEventManagerFileshare{}
 	notificationManager.defaultDownloadDir = mockOsEnvironment.destinationDirectory
 
-	notificationManager.notifications.transfers = map[uint32]string{
-		transferNotificationID: transferID,
-	}
-
 	eventManager.meshClient = &mockMeshClient{externalPeers: []*meshpb.Peer{
 		{
 			Ip:                peer,
@@ -1082,47 +1029,38 @@ func TestTransterRequestNotificationAcceptInvalidTransfer(t *testing.T) {
 		},
 	}}
 
-	notificationManager.AcceptTransfer(transferNotificationID)
+	notificationManager.acceptTransfer(transferID)
 
-	assert.Equal(t, 1, len(notifier.notifications), "Accept error notification was not received")
+	assert.Equal(t, 1, len(notifier.Alerts), "Accept error notification was not received")
 
-	errorNotification := notifier.getLastNotification()
-	assert.Equal(t, acceptFailedNotificationSummary, errorNotification.summary,
+	errorNotification := notifier.GetLastNotification()
+	assert.Equal(t, acceptFailedNotificationSummary, errorNotification.Summary,
 		"Error notification has invalid summary.")
-	assert.Equal(t, genericError, errorNotification.body,
+	assert.Equal(t, genericError, errorNotification.Body,
 		"Error notification has invalid body.")
-	assert.Equal(t, 0, len(errorNotification.actions),
+	assert.Equal(t, 0, len(errorNotification.Actions),
 		"Unexpected actions found in error notification: \n%v",
-		errorNotification.actions)
+		errorNotification.Actions)
 }
 
 func TestTransferRequestNotificationCancel(t *testing.T) {
 	peer := exampleIP1
 
 	pendingTransferID := exampleUUID
-	pendingTransferNotificationID := uint32(0)
 
 	transferAlreadyCanceledID := "5f4c3ec4-d4fe-4335-beb6-5db2ffbae351"
-	transferAlreadyCanceledNotificationID := uint32(1)
 
 	transferFinishedID := "022cb1eb-ee22-431a-80c5-ba3050493c17"
-	transferFinishedNotificationID := uint32(2)
 
 	invalidTransferID := "022cb1eb-invalid-ba3050493c17"
-	invalidTransferNotificationID := uint32(3)
 
-	setup := func() (*NotificationManager, *mockEventManagerFileshare, *mockNotifier) {
-		notifier := mockNotifier{
-			notifications: []mockNotification{},
-			nextID:        pendingTransferNotificationID,
+	setup := func() (*NotificationManager, *mockEventManagerFileshare, *mockalert.NotifierMock) {
+		notifier := mockalert.NotifierMock{
+			Alerts: []mockalert.Alert{},
 		}
 
 		notificationManager := NewMockNotificationManager(&mockEventManagerOsInfo{})
-		notificationManager.notifications.transfers[pendingTransferNotificationID] = pendingTransferID
-		notificationManager.notifications.transfers[transferAlreadyCanceledNotificationID] = transferAlreadyCanceledID
-		notificationManager.notifications.transfers[transferFinishedNotificationID] = transferFinishedID
-		notificationManager.notifications.transfers[invalidTransferNotificationID] = invalidTransferID
-		notificationManager.notifier = &notifier
+		notificationManager.n = &notifier
 
 		eventManager := NewEventManager(false,
 			&mockMeshClient{},
@@ -1154,31 +1092,26 @@ func TestTransferRequestNotificationCancel(t *testing.T) {
 
 	tests := []struct {
 		name                      string
-		notificationID            uint32
 		transferID                string
 		expectedErrorNotification string // empty for no error notifications
 	}{
 		{
 			name:                      "transfer successfully canceled",
-			notificationID:            pendingTransferNotificationID,
 			transferID:                pendingTransferID,
 			expectedErrorNotification: "",
 		},
 		{
 			name:                      "transfer already canceled",
-			notificationID:            transferAlreadyCanceledNotificationID,
 			transferID:                transferAlreadyCanceledID,
 			expectedErrorNotification: transferInvalidated,
 		},
 		{
 			name:                      "transfer finished",
-			notificationID:            transferFinishedNotificationID,
-			transferID:                transferAlreadyCanceledID,
+			transferID:                transferFinishedID,
 			expectedErrorNotification: transferInvalidated,
 		},
 		{
 			name:                      "transfer does not exist",
-			notificationID:            invalidTransferNotificationID,
 			transferID:                invalidTransferID,
 			expectedErrorNotification: genericError,
 		},
@@ -1187,29 +1120,29 @@ func TestTransferRequestNotificationCancel(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			notificationManager, fileshare, notifier := setup()
-			notificationManager.CancelTransfer(test.notificationID)
+			notificationManager.cancelTransfer(test.transferID)
 
 			if test.expectedErrorNotification == "" {
 				// Assert that only the transfer request notification was received
 				assert.NotEmpty(t, fileshare.canceledTransferIDs, "No transfers were canceled")
 				assert.Equal(t, test.transferID, fileshare.getLastCanceledTransferID(),
 					"Invalid transfer was canceled")
-				assert.Empty(t, notifier.notifications,
+				assert.Empty(t, notifier.Alerts,
 					"Unexpected notification received: %v",
-					notifier.notifications)
+					notifier.Alerts)
 				return
 			}
 
-			assert.Equal(t, 1, len(notifier.notifications), "Cancel error notification was not received")
+			assert.Equal(t, 1, len(notifier.Alerts), "Cancel error notification was not received")
 
-			errorNotification := notifier.getLastNotification()
-			assert.Equal(t, cancelFailedNotificationSummary, errorNotification.summary,
+			errorNotification := notifier.GetLastNotification()
+			assert.Equal(t, cancelFailedNotificationSummary, errorNotification.Summary,
 				"Error notification has invalid summary.")
-			assert.Equal(t, test.expectedErrorNotification, errorNotification.body,
+			assert.Equal(t, test.expectedErrorNotification, errorNotification.Body,
 				"Error notification has invalid body.")
-			assert.Equal(t, 0, len(errorNotification.actions),
+			assert.Equal(t, 0, len(errorNotification.Actions),
 				"Unexpected actions found in error notification: \n%v",
-				errorNotification.actions)
+				errorNotification.Actions)
 		})
 	}
 }
@@ -1219,7 +1152,7 @@ func TestAutoaccept(t *testing.T) {
 
 	symlinkDirectoryName := "symlink"
 	mockOsEnvironment.MapFS[symlinkDirectoryName] = &fstest.MapFile{
-		Mode: os.ModeSymlink | 0777,
+		Mode: os.ModeSymlink | 0o777,
 		Sys: &syscall.Stat_t{
 			Uid: mockOsEnvironment.currentUserUID,
 			Gid: mockOsEnvironment.currentUserGID,
@@ -1228,21 +1161,21 @@ func TestAutoaccept(t *testing.T) {
 
 	fileDirectoryName := "not_dir"
 	mockOsEnvironment.MapFS[fileDirectoryName] = &fstest.MapFile{
-		Mode: 0777,
+		Mode: 0o777,
 		Sys: &syscall.Stat_t{
 			Uid: mockOsEnvironment.currentUserUID,
 			Gid: mockOsEnvironment.currentUserGID,
 		},
 	}
 
-	notifier := mockNotifier{
-		notifications: []mockNotification{},
-		nextID:        0,
-		updateCh:      make(chan struct{}, 1),
+	notifier := mockalert.NotifierMock{
+		Alerts:   []mockalert.Alert{},
+		NextID:   0,
+		UpdateCh: make(chan struct{}, 1),
 	}
 
 	notificationManager := NewMockNotificationManager(&mockOsEnvironment.mockEventManagerOsInfo)
-	notificationManager.notifier = &notifier
+	notificationManager.n = &notifier
 
 	eventManager := NewEventManager(false,
 		&mockMeshClient{},
@@ -1255,8 +1188,6 @@ func TestAutoaccept(t *testing.T) {
 
 	notificationManager.eventManager = eventManager
 	notificationManager.defaultDownloadDir = mockOsEnvironment.destinationDirectory
-
-	notificationManager.notifications.transfers = map[uint32]string{}
 
 	peerAutoAcceptIP := exampleIP1
 	peerAutoacceptHostname := "internal.peer1.nord"
@@ -1363,13 +1294,13 @@ func TestAutoaccept(t *testing.T) {
 					"Unexpected incoming transfer was accepted")
 			}
 
-			notification := notifier.getLastNotification()
-			assert.Equal(t, test.expectedNotificationSummary, notification.summary,
+			notification := notifier.GetLastNotification()
+			assert.Equal(t, test.expectedNotificationSummary, notification.Summary,
 				"Invalid notification summary")
 
-			assert.Equal(t, test.expectedNotificationBody, notification.body, "Invalid notification body")
+			assert.Equal(t, test.expectedNotificationBody, notification.Body, "Invalid notification body")
 
-			assert.Empty(t, notification.actions,
+			assert.Empty(t, notification.Actions,
 				"Unexpected actions found in autoaccepted transfer notification")
 		})
 	}

--- a/fileshare/notification_manager.go
+++ b/fileshare/notification_manager.go
@@ -4,13 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"sync"
 
+	"github.com/NordSecurity/nordvpn-linux/alert"
 	"github.com/NordSecurity/nordvpn-linux/fileshare/pb"
 	"github.com/NordSecurity/nordvpn-linux/log"
-	inotify "github.com/NordSecurity/nordvpn-linux/notify"
-	"github.com/esiqveland/notify"
-	"github.com/godbus/dbus/v5"
 )
 
 const (
@@ -43,112 +40,6 @@ const (
 	genericError        = "Something went wrong."
 )
 
-// Action represents an action available to the user when notification is displayed
-type Action struct {
-	Key    string
-	Action string
-}
-
-// Notifier is responsible for sending notifications to the user
-type Notifier interface {
-	SendNotification(summary string, body string, actions []Action) (uint32, error)
-	Close() error
-}
-
-// DbusNotifier wraps github.com/esiqveland/notify notifier implementation
-type DbusNotifier struct {
-	mu       sync.Mutex
-	notifier notify.Notifier
-}
-
-// SendNotification sends notification via dbus. Thread safe.
-func (n *DbusNotifier) SendNotification(summary string, body string, actions []Action) (uint32, error) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	notifyActions := []notify.Action{}
-
-	for _, action := range actions {
-		notifyActions = append(notifyActions, notify.Action{Key: action.Key, Label: action.Action})
-	}
-
-	notification := notify.Notification{
-		AppName:       "NordVPN",
-		Summary:       summary,
-		AppIcon:       inotify.GetIconPath("nordvpn"),
-		Body:          body,
-		ExpireTimeout: notify.ExpireTimeoutSetByNotificationServer,
-		Actions:       notifyActions,
-	}
-
-	return n.notifier.SendNotification(notification)
-}
-
-// Close dbus connection. Thread safe.
-func (n *DbusNotifier) Close() error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	return n.notifier.Close()
-}
-
-func newDbusNotifier(notificationManager *NotificationManager) (*DbusNotifier, error) {
-	dbusConn, err := dbus.SessionBusPrivate()
-	defer func() {
-		if err != nil && dbusConn != nil {
-			if err := dbusConn.Close(); err != nil {
-				log.Error("failed to close dbus connection: ", err)
-			}
-		}
-	}()
-
-	if err != nil {
-		return nil, fmt.Errorf("creating D-Bus con: %w", err)
-	}
-
-	if err = dbusConn.Auth(nil); err != nil {
-		return nil, fmt.Errorf("authenticating to D-Bus: %w", err)
-	}
-
-	if err = dbusConn.Hello(); err != nil {
-		return nil, fmt.Errorf("sending D-Bus hello: %w", err)
-	}
-
-	onAction := func(action *notify.ActionInvokedSignal) {
-		switch action.ActionKey {
-		case actionKeyOpenFile:
-			notificationManager.OpenFile(action.ID)
-		case actionKeyAcceptTransfer:
-			notificationManager.AcceptTransfer(action.ID)
-		case actionKeyCancelTransfer:
-			notificationManager.CancelTransfer(action.ID)
-		default:
-			log.Error("Unknown action key: ", action.ActionKey)
-		}
-	}
-
-	notifier, err := notify.New(
-		dbusConn,
-		notify.WithOnAction(onAction),
-		notify.WithOnClosed(func(ncs *notify.NotificationClosedSignal) {
-			notificationManager.CloseNotification(ncs.ID)
-		}),
-	)
-	defer func() {
-		if err != nil && notifier != nil {
-			if err := notifier.Close(); err != nil {
-				log.Error("failed to close notifier: ", err)
-			}
-		}
-	}()
-
-	if err != nil {
-		return nil, fmt.Errorf("creating new notifier: %w", err)
-	}
-
-	return &DbusNotifier{notifier: notifier}, nil
-}
-
 // openFileXdg opens a file with xdg-open command
 func openFileXdg(path string) {
 	if err := exec.Command("xdg-open", path).Start(); err != nil {
@@ -156,75 +47,13 @@ func openFileXdg(path string) {
 	}
 }
 
-type notificationsStorage struct {
-	// maps Open action id to file path for downloaded files
-	downloadedFiles map[uint32]string
-	// maps Accept action id to transfer id for incoming transfers
-	transfers map[uint32]string
-	mu        sync.Mutex
-}
-
-func newNotificationStorage() notificationsStorage {
-	return notificationsStorage{
-		downloadedFiles: make(map[uint32]string),
-		transfers:       make(map[uint32]string),
-	}
-}
-
-// AddTransferNotification, thread safe
-func (ns *notificationsStorage) AddTransferNotification(notificationID uint32, transferID string) {
-	ns.mu.Lock()
-	defer ns.mu.Unlock()
-
-	ns.transfers[notificationID] = transferID
-}
-
-// GetAndDeleteTransferNotification, returns transfer id associated with give notification id and
-// removes it from the storage. Second return value denotes if given notification id was found in
-// the storage. Thread safe.
-func (ns *notificationsStorage) GetAndDeleteTransferNotification(notificationID uint32) (string, bool) {
-	ns.mu.Lock()
-	defer ns.mu.Unlock()
-
-	transferID, ok := ns.transfers[notificationID]
-
-	delete(ns.transfers, notificationID)
-
-	return transferID, ok
-}
-
-// AddFileNotification, thread safe
-func (ns *notificationsStorage) AddFileNotification(notificationID uint32, file string) {
-	ns.mu.Lock()
-	defer ns.mu.Unlock()
-
-	ns.downloadedFiles[notificationID] = file
-}
-
-// GetAndDeleteFileNotification, returns filename associated with given notification id and removes it
-// from the storage. Second return value denotes if given notification id was found in the storage.
-// Thread safe.
-func (ns *notificationsStorage) GetAndDeleteFileNotification(notificationID uint32) (string, bool) {
-	ns.mu.Lock()
-	defer ns.mu.Unlock()
-
-	file, ok := ns.downloadedFiles[notificationID]
-
-	delete(ns.downloadedFiles, notificationID)
-
-	return file, ok
-}
-
 // NotificationManager is responsible for creating gui pop-up notifications for changes in transfer file status
 type NotificationManager struct {
-	notifications      notificationsStorage
-	notifier           Notifier
+	n                  alert.Notifier
 	eventManager       *EventManager
 	fileshare          Fileshare
 	openFileFunc       func(string)
 	defaultDownloadDir string
-	// fileOperationLock guards OpenFile and NotifyFile operations, as they cannot be performed at the same time
-	fileOperationLock sync.Mutex
 }
 
 // NewNotificationManager creates a new notification
@@ -234,38 +63,18 @@ func NewNotificationManager(fileshare Fileshare, eventManager *EventManager) (*N
 		log.Error("Failed to find default download directory: ", err.Error())
 	}
 
-	notificationManager := NotificationManager{
-		notifications:      newNotificationStorage(),
-		fileshare:          fileshare,
-		openFileFunc:       openFileXdg,
-		defaultDownloadDir: defaultDownloadDir,
-		eventManager:       eventManager,
-	}
-
-	notifier, err := newDbusNotifier(&notificationManager)
+	notifier, err := alert.NewDbusNotifier()
 	if err != nil {
 		return nil, err
 	}
 
-	notificationManager.notifier = notifier
-
-	return &notificationManager, nil
-}
-
-func (nm *NotificationManager) Disable() {
-	if err := nm.notifier.Close(); err != nil {
-		log.Error("Failed to close notifier: ", err)
-	}
-}
-
-// OpenFile associated with notificationID
-func (nm *NotificationManager) OpenFile(notificationID uint32) {
-	nm.fileOperationLock.Lock()
-	defer nm.fileOperationLock.Unlock()
-
-	if filename, ok := nm.notifications.GetAndDeleteFileNotification(notificationID); ok {
-		nm.openFileFunc(filename)
-	}
+	return &NotificationManager{
+		n:                  notifier,
+		fileshare:          fileshare,
+		openFileFunc:       openFileXdg,
+		defaultDownloadDir: defaultDownloadDir,
+		eventManager:       eventManager,
+	}, nil
 }
 
 func acceptErrorToNotificationBody(err error) string {
@@ -316,45 +125,15 @@ func fileStatusToNotificationSummary(direction pb.Direction, status pb.Status) s
 // (download path + filename), so that it can be opened by the user.
 func (nm *NotificationManager) NotifyFile(filename string, direction pb.Direction, status pb.Status) {
 	summary := fileStatusToNotificationSummary(direction, status)
-
+	b := nm.n.Alert(filename).Summary(summary)
 	if direction == pb.Direction_INCOMING && status == pb.Status_SUCCESS {
-		// lock fileLock, because in case of incoming files both SendNotification and AddFileNotification need to finish
-		// before OpenFile can proceed. Otherwise it would be possible for the following race to occur:
-		// 1. SendNotification finishes, notification is displayerd for the user.
-		// 2. User clicks Open File, OpenFile is called.
-		// 3. Because AddFileNotification was not called at this point, the requested file notification is not found and
-		// the operation fails.
-		nm.fileOperationLock.Lock()
-		defer nm.fileOperationLock.Unlock()
-		if notificationID, err := nm.notifier.SendNotification(summary, filename, []Action{{actionKeyOpenFile, "Open"}}); err == nil {
-			nm.notifications.AddFileNotification(notificationID, filename)
-		} else {
-			log.Errorf("failed to send notification for file %s: %s", filename, err)
-		}
-		return
+		b = b.Action(actionKeyOpenFile, "Open", func() { nm.openFileFunc(filename) })
 	}
-
-	_, err := nm.notifier.SendNotification(summary, filename, nil)
-	if err != nil {
-		log.Errorf("failed to send notification for file %s: %s", filename, err)
-	}
+	b.Show()
 }
 
-func (nm *NotificationManager) sendGenericNotification(summary string, body string) {
-	_, err := nm.notifier.SendNotification(summary, body, nil)
-	if err != nil {
-		log.Error("failed to send generic notification: ", err)
-	}
-}
-
-// AcceptTransfer associated with notificationID, generates notifications on failure
-func (nm *NotificationManager) AcceptTransfer(notificationID uint32) {
-	transferID, ok := nm.notifications.GetAndDeleteTransferNotification(notificationID)
-
-	if !ok {
-		return
-	}
-
+// acceptTransfer accepts transferID, generates notifications on failure
+func (nm *NotificationManager) acceptTransfer(transferID string) {
 	transfer, err := nm.eventManager.AcceptTransfer(transferID,
 		nm.defaultDownloadDir,
 		[]string{})
@@ -365,14 +144,19 @@ func (nm *NotificationManager) AcceptTransfer(notificationID uint32) {
 	}
 
 	if err != nil {
-		notificationBody := acceptErrorToNotificationBody(err)
-		nm.sendGenericNotification(notificationSummary, notificationBody)
+		nm.n.
+			Alert(acceptErrorToNotificationBody(err)).
+			Summary(notificationSummary).
+			Show()
 		return
 	}
 
 	for _, file := range transfer.Files {
 		if err = nm.fileshare.Accept(transferID, nm.defaultDownloadDir, file.Id); err != nil {
-			nm.sendGenericNotification(acceptFileFailedNotificationSummary, file.Id)
+			nm.n.
+				Alert(file.Id).
+				Summary(acceptFileFailedNotificationSummary).
+				Show()
 		}
 	}
 
@@ -381,73 +165,57 @@ func (nm *NotificationManager) AcceptTransfer(notificationID uint32) {
 	}
 }
 
-// CancelTransfer associated with notificationID, generates error notifiacation on failure
-func (nm *NotificationManager) CancelTransfer(notificationID uint32) {
-	transferID, ok := nm.notifications.GetAndDeleteTransferNotification(notificationID)
-
-	if !ok {
-		return
-	}
-
+// cancelTransfer cancels transferID, generates error notification on failure
+func (nm *NotificationManager) cancelTransfer(transferID string) {
 	transfer, err := nm.eventManager.GetTransfer(transferID)
 	if err != nil {
 		log.Error("Failed to cancel transfer from notification manager: ", err)
-		nm.sendGenericNotification(cancelFailedNotificationSummary, genericError)
+		nm.n.
+			Alert(genericError).
+			Summary(cancelFailedNotificationSummary).
+			Show()
 		return
 	}
 
 	if transfer.Status != pb.Status_ONGOING && transfer.Status != pb.Status_REQUESTED {
 		if transfer.Status == pb.Status_CANCELED_BY_PEER {
-			nm.sendGenericNotification(transferCanceledByPeerNotificationSummary, transferCanceledByPeerNotificationBody)
+			nm.n.
+				Alert(transferCanceledByPeerNotificationBody).
+				Summary(transferCanceledByPeerNotificationSummary).
+				Show()
 			return
 		}
-		nm.sendGenericNotification(cancelFailedNotificationSummary, transferInvalidated)
+		nm.n.Alert(transferInvalidated).Summary(cancelFailedNotificationSummary).Show()
 		return
 	}
 
 	if err := nm.fileshare.Finalize(transferID); err != nil {
 		log.Error("Failed to cancel transfer from notification manager: ", err)
-		nm.sendGenericNotification(cancelFailedNotificationSummary, err.Error())
+		nm.n.Alert(err.Error()).Summary(cancelFailedNotificationSummary).Show()
 	}
 }
 
-// NotifyTransfer creates a pop-up gui notification
+// NotifyNewTransfer creates a pop-up gui notification
 func (nm *NotificationManager) NotifyNewTransfer(transferID string, peer string) {
-	body := fmt.Sprintf(notifyNewTransferBody, transferID, peer)
-
-	notificationID, err := nm.notifier.SendNotification(
-		notifyNewTransferSummary,
-		body,
-		[]Action{
-			{actionKeyAcceptTransfer, transferAcceptAction},
-			{actionKeyCancelTransfer, transferCancelAction},
-		})
-	if err != nil {
-		log.Error("failed to send notification for new transfer: ", err)
-	}
-
-	nm.notifications.AddTransferNotification(notificationID, transferID)
+	nm.n.Alert(fmt.Sprintf(notifyNewTransferBody, transferID, peer)).
+		Summary(notifyNewTransferSummary).
+		Action(actionKeyAcceptTransfer, transferAcceptAction, func() { nm.acceptTransfer(transferID) }).
+		Action(actionKeyCancelTransfer, transferCancelAction, func() { nm.cancelTransfer(transferID) }).
+		Show()
 }
 
 // NotifyNewAutoacceptTransfer creates a pop-up gui notification
-func (nm *NotificationManager) NotifyNewAutoacceptTransfer(transferID string, peer string) {
+func (nm *NotificationManager) NotifyNewAutoacceptTransfer(
+	transferID string,
+	peer string,
+) {
 	body := fmt.Sprintf(notifyNewTransferBody, transferID, peer)
-
-	nm.sendGenericNotification(notifyNewAutoacceptTransfer, body)
+	nm.n.Alert(body).Summary(notifyNewAutoacceptTransfer).Show()
 }
 
 // NotifyAutoacceptFailed creates a pop-up gui notification
 func (nm *NotificationManager) NotifyAutoacceptFailed(transferID string, peer string, reason error) {
 	transferInfo := fmt.Sprintf(notifyNewTransferBody, transferID, peer)
 	body := fmt.Sprintf("%s\n%s", acceptErrorToNotificationBody(reason), transferInfo)
-
-	nm.sendGenericNotification(notifyAutoacceptFailed, body)
-}
-
-// CloseNotification cleans up any data associated with notificationID
-func (nm *NotificationManager) CloseNotification(notificationID uint32) {
-	nm.fileOperationLock.Lock()
-	defer nm.fileOperationLock.Unlock()
-	nm.notifications.GetAndDeleteFileNotification(notificationID)
-	nm.notifications.GetAndDeleteTransferNotification(notificationID)
+	nm.n.Alert(body).Summary(notifyAutoacceptFailed).Show()
 }

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -31,25 +31,25 @@ const (
 	NordvpnGroup = "nordvpn"
 
 	// PermUserRWX user permission type to read write and execute
-	PermUserRWX = 0700
+	PermUserRWX = 0o700
 
 	// PermUserRW user permission type to read and write
-	PermUserRW = 0600
+	PermUserRW = 0o600
 
 	// PermUserRWGroupRW permission type for user and group to read and write, everyone else - no access.
-	PermUserRWGroupRW = 0660
+	PermUserRWGroupRW = 0o660
 
 	// PermUserRWGroupROthersR user permission type for user to read and write to it, everyone else can only read it.
-	PermUserRWGroupROthersR = 0644
+	PermUserRWGroupROthersR = 0o644
 
 	// PermUserRWGroupRWOthersR allows user and group to read and write, other only read
-	PermUserRWGroupRWOthersR = 0664
+	PermUserRWGroupRWOthersR = 0o664
 
 	// PermUserRWGroupRWOthersRW user permission type for everyone to read and write to it.
-	PermUserRWGroupRWOthersRW = 0666
+	PermUserRWGroupRWOthersRW = 0o666
 
 	// PermUserRWXGroupRXOthersRX forbidding group and others to write to it
-	PermUserRWXGroupRXOthersRX = 0755
+	PermUserRWXGroupRXOthersRX = 0o755
 
 	// ChattrExec is the chattr command executable name
 	ChattrExec = "chattr"
@@ -111,6 +111,8 @@ const (
 
 	// Subnets wider than this are considered as potentially unsafe to allowlist
 	AllowlistTooWideSubnetPrefixThreshold = 8
+
+	AppName = "NordVPN"
 )
 
 var (

--- a/test/mock/alert/alert.go
+++ b/test/mock/alert/alert.go
@@ -1,0 +1,56 @@
+package alert
+
+import (
+	"time"
+
+	"github.com/NordSecurity/nordvpn-linux/alert"
+)
+
+type Alert struct {
+	ID uint32
+	alert.Alert
+}
+
+type NotifierMock struct {
+	Alerts   []Alert
+	NextID   uint32
+	UpdateCh chan struct{}
+}
+
+func (nm *NotifierMock) Wait() {
+	select {
+	case <-time.After(1 * time.Second):
+	case <-nm.UpdateCh:
+	}
+}
+
+func (nm *NotifierMock) Alert(body string) *alert.AlertBuilder {
+	return alert.NewAlertBuilder(nm.record, body)
+}
+
+func (nm *NotifierMock) record(alert alert.Alert) {
+	alertID := nm.NextID
+	nm.Alerts = append(nm.Alerts, Alert{ID: alertID, Alert: alert})
+	nm.NextID++
+
+	if nm.UpdateCh != nil {
+		select {
+		case nm.UpdateCh <- struct{}{}:
+		default:
+			<-nm.UpdateCh
+			nm.UpdateCh <- struct{}{}
+		}
+	}
+}
+
+func (nm *NotifierMock) Mute() {}
+
+func (nm *NotifierMock) Unmute() {}
+
+func (nm *NotifierMock) Close() error {
+	return nil
+}
+
+func (nm *NotifierMock) GetLastNotification() Alert {
+	return nm.Alerts[len(nm.Alerts)-1]
+}

--- a/test/mock/mocknotify/notify.go
+++ b/test/mock/mocknotify/notify.go
@@ -1,4 +1,4 @@
-package notify
+package mocknotify
 
 import "github.com/esiqveland/notify"
 

--- a/test/mock/notify/notify.go
+++ b/test/mock/notify/notify.go
@@ -1,0 +1,31 @@
+package notify
+
+import "github.com/esiqveland/notify"
+
+type UpstreamNotifierMock struct {
+	NextID uint32
+	Sent   []notify.Notification
+}
+
+func (f *UpstreamNotifierMock) SendNotification(n notify.Notification) (uint32, error) {
+	f.Sent = append(f.Sent, n)
+	id := f.NextID
+	f.NextID++
+	return id, nil
+}
+
+func (f *UpstreamNotifierMock) GetCapabilities() ([]string, error) {
+	return nil, nil
+}
+
+func (f *UpstreamNotifierMock) GetServerInformation() (notify.ServerInformation, error) {
+	return notify.ServerInformation{}, nil
+}
+
+func (f *UpstreamNotifierMock) CloseNotification(uint32) (bool, error) {
+	return true, nil
+}
+
+func (f *UpstreamNotifierMock) Close() error {
+	return nil
+}

--- a/test/mock/vpn.go
+++ b/test/mock/vpn.go
@@ -54,6 +54,7 @@ func (w *WorkingVPN) NetworkChanged() error {
 
 	return w.ErrNetworkChanges
 }
+
 func (w *WorkingVPN) GetConnectionParameters() (vpn.ServerData, bool) {
 	return vpn.ServerData{}, false
 }

--- a/tray/actions.go
+++ b/tray/actions.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/cli"
-	"github.com/NordSecurity/nordvpn-linux/client"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/filewatch"
 	"github.com/NordSecurity/nordvpn-linux/internal"
@@ -46,7 +45,7 @@ func (ti *Instance) login() {
 	resp, err := ti.client.IsLoggedIn(context.Background(), &pb.Empty{})
 	if err != nil {
 		log.Error("Failed to login:", err)
-		ti.notify(NoForce, "Login failed")
+		ti.n.Alert("Login failed").Show()
 		return
 	}
 	if resp.Status == pb.LoginStatus_CONSENT_MISSING {
@@ -58,7 +57,7 @@ func (ti *Instance) login() {
 	}
 
 	if resp.GetIsLoggedIn() {
-		ti.notify(NoForce, "You are already logged in")
+		ti.n.Alert("You are already logged in").Show()
 		return
 	}
 
@@ -76,22 +75,22 @@ func (ti *Instance) login() {
 		},
 	)
 	if err != nil {
-		ti.notify(NoForce, "Login error: %s", err)
+		ti.n.Alert(fmt.Sprintf("Login error: %s", err)).Show()
 		return
 	}
 
 	switch loginResp.Status {
 	case pb.LoginStatus_UNKNOWN_OAUTH2_ERROR:
-		ti.notify(NoForce, "Login error: %s", internal.ErrUnhandled)
+		ti.n.Alert(fmt.Sprintf("Login error: %s", internal.ErrUnhandled)).Show()
 	case pb.LoginStatus_NO_NET:
-		ti.notify(NoForce, internal.ErrNoNetWhenLoggingIn.Error())
+		ti.n.Alert(internal.ErrNoNetWhenLoggingIn.Error()).Show()
 	case pb.LoginStatus_ALREADY_LOGGED_IN:
-		ti.notify(NoForce, internal.ErrAlreadyLoggedIn.Error())
+		ti.n.Alert(internal.ErrAlreadyLoggedIn.Error()).Show()
 	case pb.LoginStatus_CONSENT_MISSING:
 		// NOTE: This should never happen, because analytics consent is
 		// triggered above, so at this point it should already be completed.
 		log.Error("analytics consent should be already completed at this point")
-		ti.notify(NoForce, internal.ErrAnalyticsConsentMissing.Error())
+		ti.n.Alert(internal.ErrAnalyticsConsentMissing.Error()).Show()
 	case pb.LoginStatus_SUCCESS:
 		if url := loginResp.Url; url != "" {
 			// #nosec G204 -- user input is not passed in
@@ -100,7 +99,7 @@ func (ti *Instance) login() {
 			if err != nil {
 				log.Error("Failed to open login webpage:", err)
 				// we want to force a notification here, otherwise there will be no reaction to user action
-				ti.notify(Force, "Continue log in in the browser: %s", url)
+				ti.n.Alert(fmt.Sprintf("Continue log in in the browser: %s", url)).Urgent().Show()
 				return
 			}
 
@@ -112,7 +111,7 @@ func (ti *Instance) login() {
 			environment, err := getDesktopEnvironment()
 			if err != nil {
 				log.Error("Failed to read desktop environment manually:", err)
-				ti.notify(Force, "Continue log in in the browser: %s", url)
+				ti.n.Alert(fmt.Sprintf("Continue log in in the browser: %s", url)).Urgent().Show()
 				return
 			}
 
@@ -122,7 +121,7 @@ func (ti *Instance) login() {
 			err = cmd.Run()
 			if err != nil {
 				log.Error("Failed to open login webpage with manually loaded environment:", err)
-				ti.notify(Force, "Continue log in in the browser: %s", url)
+				ti.n.Alert(fmt.Sprintf("Continue log in in the browser: %s", url)).Urgent().Show()
 			}
 		}
 	}
@@ -232,7 +231,7 @@ func (ti *Instance) openGUI() {
 
 	if err := openURI(guiLaunchURI); err != nil {
 		log.Error("Failed to open GUI:", err)
-		ti.notify(Force, "Failed to open the NordVPN app")
+		ti.n.Alert("Failed to open the NordVPN app").Urgent().Show()
 	}
 }
 
@@ -249,7 +248,7 @@ func (ti *Instance) openGUIDownloadPage() {
 
 	if err := openURI(guiDownloadPageURL); err != nil {
 		log.Error("Failed to open GUI download page:", err)
-		ti.notify(Force, "Failed to open the NordVPN download page")
+		ti.n.Alert("Failed to open the NordVPN download page").Urgent().Show()
 	}
 }
 
@@ -307,7 +306,7 @@ func (ti *Instance) logout(persistToken bool) bool {
 		PersistToken: persistToken,
 	})
 	if err != nil {
-		ti.notify(NoForce, "Logout error: %s", err)
+		ti.n.Alert(fmt.Sprintf("Logout error: %s", err)).Show()
 		return false
 	}
 
@@ -317,20 +316,9 @@ func (ti *Instance) logout(persistToken bool) bool {
 	case internal.CodeTokenInvalidated:
 		return true
 	default:
-		ti.notify(NoForce, cli.CheckYourInternetConnMessage)
+		ti.n.Alert(cli.CheckYourInternetConnMessage).Show()
 		return false
 	}
-}
-
-func (ti *Instance) notifyServiceExpired(url string, trustedPassURL string, message string) {
-	resp, err := ti.client.TokenInfo(context.Background(), &pb.Empty{})
-
-	link := url
-	if err == nil && (resp.TrustedPassToken != "" && resp.TrustedPassOwnerId != "") {
-		link = fmt.Sprintf(trustedPassURL, resp.TrustedPassToken, resp.TrustedPassOwnerId)
-	}
-
-	ti.notify(Force, message, link)
 }
 
 func (ti *Instance) connect(serverTag string, serverGroup string) {
@@ -364,7 +352,7 @@ func (ti *Instance) connectWithUIEvent(
 		ServerGroup: strings.ToLower(serverGroup),
 	})
 	if err != nil {
-		ti.notify(NoForce, "Connect error: %s", err)
+		ti.n.Alert(fmt.Sprintf("Connect error: %s", err)).Show()
 		return false
 	}
 
@@ -374,59 +362,20 @@ func (ti *Instance) connectWithUIEvent(
 			if err == io.EOF {
 				break
 			}
-			ti.notify(NoForce, "Connect error: %s", err)
+			ti.n.Alert(fmt.Sprintf("Connect error: %s", err)).Show()
 			return false
 		}
 
-		switch out.Type {
-		case internal.CodeFailure:
-			ti.notify(NoForce, "Connect error: %s", client.ConnectCantConnect)
-		case internal.CodeExpiredRenewToken:
-			ti.notify(NoForce, client.RelogRequest)
+		if b := ti.connectionResultAlert(out); b != nil {
+			b.Show()
+		}
+
+		if out.Type == internal.CodeExpiredRenewToken {
 			ti.login()
 			return ti.connectWithUIEvent(serverTag, serverGroup, itemName, itemValue)
-		case internal.CodeTokenRenewError:
-			ti.notify(NoForce, client.AccountTokenRenewError)
-		case internal.CodeAccountExpired:
-			ti.notifyServiceExpired(client.SubscriptionURL, client.SubscriptionURLLogin, cli.ExpiredAccountMessage)
-		case internal.CodeDedicatedIPRenewError:
-			ti.notifyServiceExpired(client.SubscriptionDedicatedIPURL, client.SubscriptionDedicatedIPURLLogin, cli.NoDedicatedIPMessage)
-		case internal.CodeDisconnected:
-			ti.notify(NoForce, client.ConnectCanceled, internal.StringsToInterfaces(out.Data)...)
-		case internal.CodeTagNonexisting:
-			ti.notify(NoForce, internal.TagNonexistentErrorMessage)
-		case internal.CodeGroupNonexisting:
-			ti.notify(NoForce, internal.GroupNonexistentErrorMessage)
-		case internal.CodeServerUnavailable:
-			ti.notify(NoForce, internal.ServerUnavailableErrorMessage)
-		case internal.CodeVirtualLocationDisabled:
-			ti.notify(NoForce, internal.ServerUnavailableErrorMessage)
-		case internal.CodeDoubleGroupError:
-			ti.notify(NoForce, internal.DoubleGroupErrorMessage)
-		case internal.CodeVPNRunning:
-			ti.notify(NoForce, client.ConnectConnected)
-		case internal.CodeNothingToDo:
-			ti.notify(NoForce, client.ConnectConnecting)
-		case internal.CodeUFWDisabled:
-			ti.notify(NoForce, client.UFWDisabledMessage)
-		case internal.CodeDedicatedServersRenewError:
-			ti.notifyServiceExpired(client.DedicatedServersUpselURL, client.DedicatedServersUpselURLLogin, cli.DedicatedServersNoServiceMessage)
-		case internal.CodeDedicatedServersServiceButNoServers:
-			ti.notifyServiceExpired(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin, cli.DedicatedServersNoServersAvailable)
-		case internal.CodeDedicatedServersServerNotSetUp:
-			ti.notifyServiceExpired(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin, cli.DedicatedServersNoServersAvailable)
-		case internal.CodeDedicatedServersNotReady:
-			ti.notify(Force, cli.DedicatedServersServerNotReadyMessage)
-		case internal.CodeDedicatedServersNoNordlynx:
-			ti.notify(Force, cli.DedicatedServersNoNordlynxMessage)
-		case internal.CodeDedicatedServersCanNotConnect:
-			ti.notify(Force, cli.DedicatedServersCanNotConnectMessage)
-		case internal.CodeDedicatedServersSessionMaxLimitReached:
-			ti.notify(Force, cli.DedicatedServersConnectionLimitReached)
-		case internal.CodeDedicatedServersPq:
-			ti.notify(Force, internal.ServerUnavailableErrorMessage)
-		case internal.CodeConnecting:
-		case internal.CodeConnected:
+		}
+
+		if out.Type == internal.CodeConnected {
 			return true
 		}
 	}
@@ -444,7 +393,7 @@ func (ti *Instance) disconnect(itemName pb.UIEvent_ItemName, itemValue pb.UIEven
 	})
 	resp, err := ti.client.Disconnect(context.Background(), &pb.Empty{})
 	if err != nil {
-		ti.notify(NoForce, "Disconnect error: %s", err)
+		ti.n.Alert(fmt.Sprintf("Disconnect error: %s", err)).Show()
 		return false
 	}
 
@@ -454,13 +403,13 @@ func (ti *Instance) disconnect(itemName pb.UIEvent_ItemName, itemValue pb.UIEven
 			if err == io.EOF {
 				break
 			}
-			ti.notify(NoForce, "Disconnect error: %s", err)
+			ti.n.Alert(fmt.Sprintf("Disconnect error: %s", err)).Show()
 			return false
 		}
 
 		switch out.Type {
 		case internal.CodeVPNNotRunning:
-			ti.notify(NoForce, cli.DisconnectNotConnected)
+			ti.n.Alert(cli.DisconnectNotConnected).Show()
 		case internal.CodeDisconnected:
 		}
 	}
@@ -477,18 +426,18 @@ func (ti *Instance) pause(pauseLength pauseLength) bool {
 	})
 	resp, err := ti.client.PauseConnection(context.Background(), &pb.PauseRequest{Seconds: pauseLength.DurationSeconds})
 	if err != nil {
-		ti.notify(NoForce, "Pause failed. Please try again.")
+		ti.n.Alert("Pause failed. Please try again.").Show()
 		return false
 	}
 
 	switch resp.Type {
 	case internal.CodePauseAttemptWhenConnectedToMeshPeer:
 		log.Error("Pause attempt when connected to meshnet peer")
-		ti.notify(NoForce, "Pause is not available while connected to a Meshnet device.")
+		ti.n.Alert("Pause is not available while connected to a Meshnet device.").Show()
 		return false
 	case internal.CodeFailure:
 		log.Error("Pause attempt failed")
-		ti.notify(NoForce, "Pause failed. Please try again.")
+		ti.n.Alert("Pause failed. Please try again.").Show()
 		return false
 	}
 	return true
@@ -501,14 +450,14 @@ func (ti *Instance) setNotify(flag bool) bool {
 	})
 	if err != nil {
 		log.Errorf("Setting notifications %s error: %s", flagText, err)
-		ti.notify(NoForce, "Setting notifications %s error: %s", flagText, err)
+		ti.n.Alert(fmt.Sprintf("Setting notifications %s error: %s", flagText, err)).Show()
 		return false
 	}
 
 	switch resp.Type {
 	case internal.CodeConfigError:
 		log.Errorf("Setting notifications %s error: %s", flagText, "Config file error")
-		ti.notify(NoForce, "Setting notifications %s error: %s", flagText, "Config file error")
+		ti.n.Alert(fmt.Sprintf("Setting notifications %s error: %s", flagText, "Config file error")).Show()
 		return false
 	case internal.CodeNothingToDo:
 	case internal.CodeSuccess:
@@ -517,7 +466,7 @@ func (ti *Instance) setNotify(flag bool) bool {
 	ti.fileshare.SetNotifications(flag)
 
 	if resp.Type == internal.CodeNothingToDo {
-		ti.notify(NoForce, "Notifications already %s", flagText)
+		ti.n.Alert(fmt.Sprintf("Notifications already %s", flagText)).Show()
 	}
 
 	return true
@@ -528,7 +477,7 @@ func (ti *Instance) setTray(flag bool) bool {
 
 	if !flag {
 		log.Info("Tray icon disabled. To enable it again, run the \"nordvpn set tray on\" command.")
-		ti.notify(Force, "Tray icon disabled. To enable it again, run the \"nordvpn set tray on\" command.")
+		ti.n.Alert("Tray icon disabled. To enable it again, run the \"nordvpn set tray on\" command.").Urgent().Show()
 	}
 
 	resp, err := ti.client.SetTray(context.Background(), &pb.SetTrayRequest{
@@ -536,17 +485,17 @@ func (ti *Instance) setTray(flag bool) bool {
 	})
 	if err != nil {
 		log.Errorf("Setting tray %s error: %s", flagText, err)
-		ti.notify(NoForce, "Setting tray %s error: %s", flagText, err)
+		ti.n.Alert(fmt.Sprintf("Setting tray %s error: %s", flagText, err)).Show()
 		return false
 	}
 
 	switch resp.Type {
 	case internal.CodeConfigError:
 		log.Errorf("Setting tray %s error: %s", flagText, "Config file error")
-		ti.notify(NoForce, "Setting tray %s error: %s", flagText, "Config file error")
+		ti.n.Alert(fmt.Sprintf("Setting tray %s error: %s", flagText, "Config file error")).Show()
 		return false
 	case internal.CodeNothingToDo:
-		ti.notify(NoForce, "Tray already %s", flagText)
+		ti.n.Alert(fmt.Sprintf("Tray already %s", flagText)).Show()
 	case internal.CodeSuccess:
 	}
 

--- a/tray/actions_test.go
+++ b/tray/actions_test.go
@@ -12,27 +12,12 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock/alert"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
-
-type capturedNotification struct {
-	summary string
-	body    string
-}
-
-type fakeNotifier struct {
-	notifications []capturedNotification
-}
-
-func (f *fakeNotifier) start() {}
-
-func (f *fakeNotifier) sendNotification(summary, body string) error {
-	f.notifications = append(f.notifications, capturedNotification{summary: summary, body: body})
-	return nil
-}
 
 type fakeConnectStream struct {
 	grpc.ServerStreamingClient[pb.Payload]
@@ -86,25 +71,29 @@ func (c *trayDaemonClient) TokenInfo(
 
 type trayFixture struct {
 	instance *Instance
-	notifier *fakeNotifier
+	n        *alert.NotifierMock
 	client   *trayDaemonClient
 }
 
 func newTrayFixture(t *testing.T, payloads ...*pb.Payload) *trayFixture {
 	t.Helper()
 
-	notifier := &fakeNotifier{}
+	notifier := &alert.NotifierMock{
+		Alerts:   []alert.Alert{},
+		NextID:   0,
+		UpdateCh: make(chan struct{}, 1),
+	}
 	client := &trayDaemonClient{
 		connectStream: &fakeConnectStream{payloads: payloads},
 	}
 	ti := &Instance{
-		client:   client,
-		notifier: notifier,
+		client: client,
+		n:      notifier,
 	}
 	ti.state.initialSyncCompleted = true
 	ti.state.notificationsStatus = Enabled
 
-	return &trayFixture{instance: ti, notifier: notifier, client: client}
+	return &trayFixture{instance: ti, n: notifier, client: client}
 }
 
 func TestConnect_DedicatedServersErrorPaths(t *testing.T) {
@@ -178,9 +167,9 @@ func TestConnect_DedicatedServersErrorPaths(t *testing.T) {
 			)
 
 			assert.False(t, ok, "connect should fail on dedicated-servers error code")
-			require.Len(t, f.notifier.notifications, 1, "exactly one notification expected")
-			assert.Equal(t, "NordVPN", f.notifier.notifications[0].summary)
-			assert.Equal(t, tc.wantBody, f.notifier.notifications[0].body)
+			require.Len(t, f.n.Alerts, 1, "exactly one notification expected")
+			assert.Equal(t, "NordVPN", f.n.Alerts[0].Summary)
+			assert.Equal(t, tc.wantBody, f.n.Alerts[0].Body)
 		})
 	}
 }

--- a/tray/menu.go
+++ b/tray/menu.go
@@ -173,7 +173,7 @@ func buildQuitButton(ti *Instance) {
 			return
 		}
 		log.Info(msgShutdownNotification)
-		ti.notify(Force, msgShutdownNotification)
+		ti.n.Alert(msgShutdownNotification).Urgent().Show()
 		select {
 		case ti.quitChan <- norduser.StopRequest{}:
 		default:

--- a/tray/monitor.go
+++ b/tray/monitor.go
@@ -171,7 +171,7 @@ func (ti *Instance) updateLoginStatus() bool {
 	}()
 
 	if notificationText != "" {
-		ti.notify(NoForce, notificationText)
+		ti.n.Alert(notificationText).Show()
 	}
 	return changed
 }
@@ -260,8 +260,10 @@ func (ti *Instance) setSettings(settings *pb.Settings) bool {
 		var newNotificationsStatus Status
 		if userSettings.Notify {
 			newNotificationsStatus = Enabled
+			ti.n.Unmute()
 		} else {
 			newNotificationsStatus = Disabled
+			ti.n.Mute()
 		}
 
 		if ti.state.notificationsStatus == Invalid {
@@ -309,18 +311,18 @@ func (ti *Instance) setSettings(settings *pb.Settings) bool {
 	}()
 
 	if notificationsText != "" {
-		notificationType := NoForce
+		b := ti.n.Alert(notificationsText)
 		if forceNotifications {
-			notificationType = Force
+			b = b.Urgent()
 		}
-		ti.notify(notificationType, notificationsText)
+		b.Show()
 	}
 	if trayText != "" {
-		notificationType := NoForce
+		b := ti.n.Alert(trayText)
 		if forceTray {
-			notificationType = Force
+			b = b.Urgent()
 		}
-		ti.notify(notificationType, trayText)
+		b.Show()
 	}
 
 	return changed
@@ -470,7 +472,7 @@ func (ti *Instance) updateDaemonConnectionStatus(errorMessage string) bool {
 	ti.state.mu.Unlock()
 
 	if ti.state.initialSyncCompleted && notificationText != "" {
-		ti.notify(NoForce, notificationText)
+		ti.n.Alert(notificationText).Show()
 	}
 	return changed
 }
@@ -540,7 +542,7 @@ func (ti *Instance) setVpnStatus(
 	}()
 
 	if notificationText != "" {
-		ti.notify(NoForce, notificationText, notificationArg)
+		ti.n.Alert(fmt.Sprintf(notificationText, notificationArg)).Show()
 	}
 
 	return changed
@@ -549,7 +551,7 @@ func (ti *Instance) setVpnStatus(
 func (ti *Instance) handlePauseEvent(event *pb.PauseEvent) bool {
 	switch event.Type {
 	case pb.PauseEventType_RECONNECT_FAILED:
-		ti.notify(NoForce, "Connect error: %s", client.ConnectCantConnect)
+		ti.n.Alert(fmt.Sprintf("Connect error: %s", client.ConnectCantConnect)).Show()
 		log.Error("Reconnect failed after pause expired")
 	default:
 		log.Warn("Unexpected pause event received ", event.Type)

--- a/tray/notifications.go
+++ b/tray/notifications.go
@@ -16,15 +16,11 @@ import (
 // until the tray has completed its sync with the daemon.
 type gatedNotifier struct {
 	alert.Notifier
-	state *trayState
+	isReady func() bool
 }
 
 func (g *gatedNotifier) Alert(body string) *alert.AlertBuilder {
-	g.state.mu.RLock()
-	ready := g.state.initialSyncCompleted
-	g.state.mu.RUnlock()
-
-	if !ready {
+	if !g.isReady() {
 		log.Systray.Infof("Notification suppressed (initial sync not completed): %s", body)
 		return alert.NewAlertBuilder(func(alert.Alert) {}, body)
 	}

--- a/tray/notifications.go
+++ b/tray/notifications.go
@@ -1,126 +1,102 @@
 package tray
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"sync"
 
-	"github.com/esiqveland/notify"
-	"github.com/godbus/dbus/v5"
-
+	"github.com/NordSecurity/nordvpn-linux/alert"
+	"github.com/NordSecurity/nordvpn-linux/cli"
+	"github.com/NordSecurity/nordvpn-linux/client"
+	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
-	inotify "github.com/NordSecurity/nordvpn-linux/notify"
 )
 
-var errDbusNotifierNotConnected = errors.New("dbus notifier not connected")
-
-func (ti *Instance) notify(ntype NotificationType, text string, a ...any) {
-	ti.state.mu.RLock()
-	notificationsStatus := ti.state.notificationsStatus
-	ti.state.mu.RUnlock()
-
-	if ti.state.initialSyncCompleted && (notificationsStatus == Enabled || ntype == Force) {
-		text = fmt.Sprintf(text, a...)
-		log.Systray.Infof("Sending notification: %s", text)
-		if err := ti.notifier.sendNotification("NordVPN", text); err != nil {
-			if !errors.Is(err, errDbusNotifierNotConnected) {
-				log.Error("Failed to send notification:", err)
-			}
-		}
-	} else {
-		log.Systray.Infof("Notification suppressed: %s (status: %d, force: %v)",
-			fmt.Sprintf(text, a...),
-			notificationsStatus,
-			ntype == Force)
-	}
+// gatedNotifier suppresses every alert, even Urgent ones,
+// until the tray has completed its sync with the daemon.
+type gatedNotifier struct {
+	alert.Notifier
+	state *trayState
 }
 
-// dbusNotifier wraps github.com/esiqveland/notify notifier implementation
-type dbusNotifier struct {
-	mu       sync.Mutex
-	notifier notify.Notifier
+func (g *gatedNotifier) Alert(body string) *alert.AlertBuilder {
+	g.state.mu.RLock()
+	ready := g.state.initialSyncCompleted
+	g.state.mu.RUnlock()
+
+	if !ready {
+		log.Systray.Infof("Notification suppressed (initial sync not completed): %s", body)
+		return alert.NewAlertBuilder(func(alert.Alert) {}, body)
+	}
+
+	return g.Notifier.Alert(body)
 }
 
-func (n *dbusNotifier) start() {
-	ntf, err := newNotifier()
-	if err == nil {
-		log.Info("Started dbus notifier")
-		n.mu.Lock()
-		n.notifier = ntf
-		n.mu.Unlock()
-	} else {
-		log.Error("Failed to start dbus notifier:", err)
+func (ti *Instance) connectionResultAlert(out *pb.Payload) *alert.AlertBuilder {
+	switch out.Type {
+	case internal.CodeFailure:
+		return ti.n.Alert(fmt.Sprintf("Connect error: %s", client.ConnectCantConnect))
+	case internal.CodeExpiredRenewToken:
+		return ti.n.Alert(client.RelogRequest)
+	case internal.CodeTokenRenewError:
+		return ti.n.Alert(client.AccountTokenRenewError)
+	case internal.CodeAccountExpired:
+		link := ti.trustedPassURLOrDefault(client.SubscriptionURL, client.SubscriptionURLLogin)
+		return ti.n.Alert(fmt.Sprintf(cli.ExpiredAccountMessage, link)).Urgent()
+	case internal.CodeDedicatedIPRenewError:
+		link := ti.trustedPassURLOrDefault(client.SubscriptionDedicatedIPURL, client.SubscriptionDedicatedIPURLLogin)
+		return ti.n.Alert(fmt.Sprintf(cli.NoDedicatedIPMessage, link)).Urgent()
+	case internal.CodeDisconnected:
+		return ti.n.Alert(fmt.Sprintf(client.ConnectCanceled, internal.StringsToInterfaces(out.Data)...))
+	case internal.CodeTagNonexisting:
+		return ti.n.Alert(internal.TagNonexistentErrorMessage)
+	case internal.CodeGroupNonexisting:
+		return ti.n.Alert(internal.GroupNonexistentErrorMessage)
+	case internal.CodeServerUnavailable:
+		return ti.n.Alert(internal.ServerUnavailableErrorMessage)
+	case internal.CodeVirtualLocationDisabled:
+		return ti.n.Alert(internal.SpecifiedServerIsVirtualLocation)
+	case internal.CodeDoubleGroupError:
+		return ti.n.Alert(internal.DoubleGroupErrorMessage)
+	case internal.CodeVPNRunning:
+		return ti.n.Alert(client.ConnectConnected)
+	case internal.CodeNothingToDo:
+		return ti.n.Alert(client.ConnectConnecting)
+	case internal.CodeUFWDisabled:
+		return ti.n.Alert(client.UFWDisabledMessage)
+	case internal.CodeDedicatedServersRenewError:
+		link := ti.trustedPassURLOrDefault(client.DedicatedServersUpselURL, client.DedicatedServersUpselURLLogin)
+		return ti.n.Alert(fmt.Sprintf(cli.DedicatedServersNoServiceMessage, link)).Urgent()
+	case internal.CodeDedicatedServersServiceButNoServers:
+		link := ti.trustedPassURLOrDefault(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin)
+		return ti.n.Alert(fmt.Sprintf(cli.DedicatedServersNoServersAvailable, link)).Urgent()
+	case internal.CodeDedicatedServersServerNotSetUp:
+		link := ti.trustedPassURLOrDefault(client.DedicatedServersSetupURL, client.DedicatedServersSetupURLLogin)
+		return ti.n.Alert(fmt.Sprintf(cli.DedicatedServersNoServersAvailable, link)).Urgent()
+	case internal.CodeDedicatedServersNotReady:
+		return ti.n.Alert(cli.DedicatedServersServerNotReadyMessage).Urgent()
+	case internal.CodeDedicatedServersNoNordlynx:
+		return ti.n.Alert(cli.DedicatedServersNoNordlynxMessage).Urgent()
+	case internal.CodeDedicatedServersCanNotConnect:
+		return ti.n.Alert(cli.DedicatedServersCanNotConnectMessage).Urgent()
+	case internal.CodeDedicatedServersSessionMaxLimitReached:
+		return ti.n.Alert(cli.DedicatedServersConnectionLimitReached).Urgent()
+	case internal.CodeDedicatedServersPq:
+		return ti.n.Alert(internal.ServerUnavailableErrorMessage).Urgent()
+	case internal.CodeConnecting: // no notification
+	case internal.CodeConnected:
+		// NOTE: connection success is not handled here on purpose
 	}
+	return nil
 }
 
-// sendNotification sends notification via dbus. Thread safe.
-func (n *dbusNotifier) sendNotification(summary string, body string) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
+func (ti *Instance) trustedPassURLOrDefault(defaultURL string, trustedPassURL string) string {
+	resp, err := ti.client.TokenInfo(context.Background(), &pb.Empty{})
 
-	if n.notifier != nil {
-		notification := notify.Notification{
-			AppName:       "NordVPN",
-			Summary:       summary,
-			AppIcon:       inotify.GetIconPath("nordvpn"),
-			Body:          body,
-			ExpireTimeout: notify.ExpireTimeoutSetByNotificationServer,
-			Hints: map[string]dbus.Variant{
-				"transient": dbus.MakeVariant(1),
-			},
-		}
-		if _, err := n.notifier.SendNotification(notification); err != nil {
-			return err
-		}
-		return nil
-	} else {
-		return errDbusNotifierNotConnected
+	link := defaultURL
+	if err == nil && (resp.TrustedPassToken != "" && resp.TrustedPassOwnerId != "") {
+		link = fmt.Sprintf(trustedPassURL, resp.TrustedPassToken, resp.TrustedPassOwnerId)
 	}
+
+	return link
 }
-
-func newNotifier() (notify.Notifier, error) {
-	dbusConn, err := dbus.SessionBusPrivate()
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		if err != nil {
-			if err := dbusConn.Close(); err != nil {
-				log.Error("Failed to close dbus connection:", err)
-			}
-		}
-	}()
-
-	if err = dbusConn.Auth(nil); err != nil {
-		return nil, err
-	}
-
-	if err = dbusConn.Hello(); err != nil {
-		return nil, err
-	}
-
-	ntf, err := notify.New(dbusConn)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		if err != nil {
-			if err := ntf.Close(); err != nil {
-				log.Error("Failed to close notifier:", err)
-			}
-		}
-	}()
-
-	return ntf, nil
-}
-
-type NotificationType bool
-
-const (
-	// NoForce indicates that the notification should respect the user's settings.
-	NoForce NotificationType = false
-	// Force indicates that the notification should be shown regardless of the user's settings.
-	Force NotificationType = true
-)

--- a/tray/notifications_test.go
+++ b/tray/notifications_test.go
@@ -1,0 +1,68 @@
+package tray
+
+import (
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	mockalert "github.com/NordSecurity/nordvpn-linux/test/mock/alert"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatedNotifierSuppressesUntilInitialSyncCompleted(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name                 string
+		initialSyncCompleted bool
+		urgent               bool
+		wantDelivered        bool
+	}{
+		{
+			name:                 "normal alert suppressed before initial sync",
+			initialSyncCompleted: false,
+			urgent:               false,
+			wantDelivered:        false,
+		},
+		{
+			name:                 "urgent alert suppressed before initial sync",
+			initialSyncCompleted: false,
+			urgent:               true,
+			wantDelivered:        false,
+		},
+		{
+			name:                 "normal alert delivered after initial sync",
+			initialSyncCompleted: true,
+			urgent:               false,
+			wantDelivered:        true,
+		},
+		{
+			name:                 "urgent alert delivered after initial sync",
+			initialSyncCompleted: true,
+			urgent:               true,
+			wantDelivered:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockalert.NotifierMock{}
+			state := &trayState{initialSyncCompleted: tt.initialSyncCompleted}
+			g := &gatedNotifier{Notifier: mock, state: state}
+
+			b := g.Alert("body")
+			if tt.urgent {
+				b = b.Urgent()
+			}
+			b.Show()
+
+			if tt.wantDelivered {
+				require.Len(t, mock.Alerts, 1)
+				assert.Equal(t, "body", mock.Alerts[0].Body)
+			} else {
+				assert.Empty(t, mock.Alerts)
+			}
+		})
+	}
+}

--- a/tray/notifications_test.go
+++ b/tray/notifications_test.go
@@ -48,8 +48,8 @@ func TestGatedNotifierSuppressesUntilInitialSyncCompleted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockalert.NotifierMock{}
-			state := &trayState{initialSyncCompleted: tt.initialSyncCompleted}
-			g := &gatedNotifier{Notifier: mock, state: state}
+			ready := tt.initialSyncCompleted
+			g := &gatedNotifier{Notifier: mock, isReady: func() bool { return ready }}
 
 			b := g.Alert("body")
 			if tt.urgent {

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -12,10 +12,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/NordSecurity/nordvpn-linux/alert"
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
 	"github.com/NordSecurity/nordvpn-linux/norduser"
-	"github.com/NordSecurity/nordvpn-linux/notify"
 	"github.com/NordSecurity/nordvpn-linux/sysinfo"
 
 	"github.com/NordSecurity/systray"
@@ -115,17 +116,12 @@ func sortedConnections(sgs []*pb.ServerGroup) []Server {
 	return list
 }
 
-type notifier interface {
-	start()
-	sendNotification(summary string, body string) error
-}
-
 type Instance struct {
 	client                pb.DaemonClient
 	fileshare             FileshareManager
 	accountInfo           accountInfo
 	debugMode             bool
-	notifier              notifier
+	n                     alert.Notifier
 	renderChan            chan struct{}
 	initialDataLoadChan   chan struct{}
 	iconConnected         string
@@ -176,16 +172,29 @@ func (state *trayState) serverName() string {
 }
 
 func NewTrayInstance(client pb.DaemonClient, quitChan chan<- norduser.StopRequest) *Instance {
+	var n alert.Notifier
+	notifier, err := alert.NewDbusNotifier(alert.WithTransient())
+	if err != nil {
+		log.Error("Failed to create dbus notifier, notifications will be disabled:", err)
+		n = alert.NoopNotifier{}
+	} else {
+		n = notifier
+	}
+
 	obj := &Instance{
 		client:                client,
 		fileshare:             NewFileshareManager(),
-		notifier:              &dbusNotifier{},
 		quitChan:              quitChan,
 		connSensor:            newConnectionSettingsChangeSensor(),
 		recentConnections:     newRecentConnectionsManager(client),
 		checkboxSync:          NewCheckboxSynchronizer(),
 		stopVisibilityMonitor: make(chan struct{}),
 	}
+	obj.n = &gatedNotifier{Notifier: n, state: &obj.state}
+	// disable notifier until we have up to date settings with
+	// information if notifications are allowed or not
+	obj.n.Mute()
+
 	obj.isVisible.Store(false)
 	obj.stateListener = newStateListener(client, obj.onDaemonStateEvent)
 	return obj
@@ -230,8 +239,8 @@ func selectIcon(desktopEnv string) string {
 
 // updateIconsSelection selects the most appropriate icon based on the desktop environment.
 func (ti *Instance) updateIconsSelection() {
-	ti.iconDisconnected = notify.GetIconPath(selectIcon(sysinfo.GetDisplayDesktopEnvironment()))
-	ti.iconConnected = notify.GetIconPath(IconBlue)
+	ti.iconDisconnected = alert.GetIconPath(selectIcon(sysinfo.GetDisplayDesktopEnvironment()))
+	ti.iconConnected = alert.GetIconPath(IconBlue)
 }
 
 // configureDebugMode configures debug mode based on the environment variable.
@@ -298,13 +307,13 @@ func (ti *Instance) Start() {
 
 func (ti *Instance) OnExit() {
 	ti.stateListener.Stop()
+	_ = ti.n.Close()
 }
 
 func (ti *Instance) OnReady(ctx context.Context) {
-	systray.SetTitle("NordVPN")
-	systray.SetTooltip("NordVPN")
+	systray.SetTitle(internal.AppName)
+	systray.SetTooltip(internal.AppName)
 
-	ti.notifier.start()
 	ti.stateListener.Start()
 
 	go ti.renderLoop(ctx)

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -190,7 +190,14 @@ func NewTrayInstance(client pb.DaemonClient, quitChan chan<- norduser.StopReques
 		checkboxSync:          NewCheckboxSynchronizer(),
 		stopVisibilityMonitor: make(chan struct{}),
 	}
-	obj.n = &gatedNotifier{Notifier: n, state: &obj.state}
+	obj.n = &gatedNotifier{
+		Notifier: n,
+		isReady: func() bool {
+			obj.state.mu.RLock()
+			defer obj.state.mu.RUnlock()
+			return obj.state.initialSyncCompleted
+		},
+	}
 	// disable notifier until we have up to date settings with
 	// information if notifications are allowed or not
 	obj.n.Mute()


### PR DESCRIPTION
Context:

- displaying URLs in OS notifications is not the best UX, especially for long URLs or in DE that don't render URLs as clickable
- fileshare notifications support defining actions displayed as button
- tray notifications code was a duplicate of fileshare notifications, but without button support
- this PR introduces common code for displaying notifications, incluing specifying actions as button

Changes:

- introduce `alert` package that manages notifications and their actions
- migrate tray to `alert`
- migrate fileshare to `alert`