### PR TITLE
LVPN-10994: Test if peer is unreachable, after removing it

### DIFF
--- a/test/qa/lib/meshnet.py
+++ b/test/qa/lib/meshnet.py
@@ -50,7 +50,7 @@ class TestUtils:
     def teardown_module(ssh_client: ssh.Ssh):
         # Preserve other peer log
         dest_logs_path = f"{os.environ['WORKDIR']}/dist/logs"
-        ssh_client.download_file("/var/log/nordvpn/daemon.log", f"{dest_logs_path}/other-peer-daemon.log")
+        download_remote_peer_logs(ssh_client, dest_logs_path)
         daemon.uninstall_peer(ssh_client)
         ssh_client.disconnect()
 

--- a/test/qa/lib/meshnet.py
+++ b/test/qa/lib/meshnet.py
@@ -293,13 +293,6 @@ class PeerList:
     def clear_external_peer_list(self):
         self.external_peers = []
 
-    def find_peer(self, peer: str) -> Peer:
-        for peer_info in self.external_peers + self.internal_peers:
-            if peer_info.ip == peer or peer_info.hostname == peer or peer_info.nickname == peer:
-                return peer_info
-        raise Exception("peer not found")
-
-
     def parse_peer_list(self, filter_list: str | None = None) -> list[str]:
         """Builds expected Meshnet peer list string according to passed list of filters."""
 

--- a/test/qa/lib/meshnet.py
+++ b/test/qa/lib/meshnet.py
@@ -612,7 +612,7 @@ def get_lines_with_keywords(lines: list[str], keywords: list[str]) -> list:
     """Returns list with elements, that contain specified `keywords`."""
     return [line.strip() for line in lines if all(keyword in line for keyword in keywords)]
 
-def are_peers_connected(ssh_client: ssh.Ssh = None, retry: int = 15) -> None:
+def wait_for_peers_connection(ssh_client: ssh.Ssh = None, retry: int = 15) -> None:
     """
     Verifies if local and remote NordVPN mesh peers see each other as connected in peer list.
 

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -56,12 +56,7 @@ def setup_module(module):  # noqa: ARG001
     sh.nordvpn.mesh.peer.refresh()
     ssh_client.exec_command("nordvpn mesh peer refresh")
 
-    while True:
-        local_peer_list = sh_no_tty.nordvpn.mesh.peer.list()
-        remote_peer_list = ssh_client.exec_command("nordvpn mesh peer list")
-        if all("Status: connected" in peer_list for peer_list in (local_peer_list, remote_peer_list)):
-            break
-        time.sleep(1)
+    meshnet.are_peers_connected(ssh_client)
 
     if not os.path.exists(workdir):
         os.makedirs(workdir)

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import random
 import re
@@ -1553,11 +1552,7 @@ def test_all_permissions_denied_send_file(background_send: bool, background_acce
     local_peer_list = meshnet.PeerList.from_str(sh.nordvpn.mesh.peer.list())
     local_address = local_peer_list.get_this_device().hostname
 
-    permissions = ["incoming", "routing", "local"]
-
-    for permission in permissions:
-        with contextlib.suppress(RuntimeError):
-            ssh_client.exec_command(f"nordvpn mesh peer {permission} deny {local_address}")
+    ssh_client.meshnet.set_permissions(local_address, routing=False, local=False, incoming=False)
 
     wdir = fileshare.create_directory(1)
     peer_address = local_peer_list.get_internal_peer().hostname
@@ -1593,8 +1588,6 @@ def test_all_permissions_denied_send_file(background_send: bool, background_acce
     assert fileshare.files_from_transfer_exist_in_filesystem(remote_transfer_id, [wdir], ssh_client), "Files should be transferred to filesystem"
     ssh_client.exec_command(f"rm -rf {peer_filepath}/{wdir.filenames[0]}")
 
-    for permission in permissions:
-        with contextlib.suppress(RuntimeError):
-            ssh_client.exec_command(f"nordvpn mesh peer {permission} allow {local_address}")
+    ssh_client.meshnet.set_permissions(local_address, routing=True, local=True, incoming=True)
 
     shutil.rmtree(wdir.dir_path)

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -71,9 +71,7 @@ def setup_module(module):  # noqa: ARG001
 
 def teardown_module(module):  # noqa: ARG001
     dest_logs_path = f"{os.environ['WORKDIR']}/dist/logs"
-    ssh_client.download_file("/var/log/nordvpn/daemon.log", f"{dest_logs_path}/daemon-qapeer.log")
-    ssh_client.download_file("/root/.cache/nordvpn/nordfileshare.log", f"{dest_logs_path}/nordfileshare-qapeer.log")
-    ssh_client.download_file("/root/.cache/nordvpn/norduserd.log", f"{dest_logs_path}/norduserd-qapeer.log")
+    meshnet.download_remote_peer_logs(ssh_client, dest_logs_path)
     shutil.copy("/home/qa/.cache/nordvpn/norduserd.log", dest_logs_path)
     shutil.copy("/home/qa/.cache/nordvpn/nordfileshare.log", dest_logs_path)
     shutil.copy("/home/qa/.config/nordvpn/fileshare_history.db", dest_logs_path)

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -55,7 +55,7 @@ def setup_module(module):  # noqa: ARG001
     sh.nordvpn.mesh.peer.refresh()
     ssh_client.exec_command("nordvpn mesh peer refresh")
 
-    meshnet.are_peers_connected(ssh_client)
+    meshnet.wait_for_peers_connection(ssh_client)
 
     if not os.path.exists(workdir):
         os.makedirs(workdir)

--- a/test/qa/test_fileshare.py
+++ b/test/qa/test_fileshare.py
@@ -704,7 +704,7 @@ def test_fileshare_graceful_cancel_transfer_ongoing(sender_cancels: bool, transf
     transfer_accept_thread = PeerTransferAcceptThread(transfer_id)
     transfer_accept_thread.start()
 
-    for transfer_in_progress in poll(lambda: "downloading" in fileshare.get_transfer(transfer_id, ssh_client)):
+    for transfer_in_progress in poll(lambda: fileshare.TransferState.DOWNLOADING in fileshare.get_transfer(transfer_id, ssh_client)):
         if transfer_in_progress:
             break
 

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -77,10 +77,6 @@ def test_mesh_removed_machine_by_other():
             mymachineid = itm['identifier']
 
     # remove myself using api call
-    headers = {
-        'Accept': 'application/json',
-        'Authorization': 'Bearer token:' + mytoken,
-    }
     requests.delete('https://api.nordvpn.com/v1/meshnet/machines/' + mymachineid, headers=headers, timeout=5)
 
     # machine not found error should be handled by disabling meshnet

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime
 
 import pytest
@@ -163,27 +162,15 @@ def test_exitnode_permissions():
     assert "This peer does not allow file transfers from you." in str(ex.value), "qa-peer should not be able to send file to tester"
 
 
-@pytest.mark.xfail(condition=meshnet.is_meshnet_test_disabled_from_run(), reason="Run only in nightly")
-def test_remove_peer_firewall_update():
-    peer_ip = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().ip
-    meshnet.set_permissions(peer_ip, True, True, True, True)
+@pytest.mark.core_meshnet
+def test_peer_unreachable_after_remove():
+    peer = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer()
+    meshnet.set_permissions(peer.ip, True, True, True, True)
 
-    sh_no_tty.nordvpn.mesh.peer.remove(peer_ip)
+    sh_no_tty.nordvpn.mesh.peer.remove(peer.ip)
     sh_no_tty.nordvpn.mesh.peer.refresh()
 
-    def all_peer_permissions_removed() -> (bool, str):
-        #rules = sh.sudo.iptables("-S")
-        rules = os.popen("sudo iptables -S").read()
-        if peer_ip not in rules:
-            return True, ""
-        return False, f"Rules for peer were not removed from firewall\nPeer IP: {peer_ip}\nrules:\n{rules}"
-
-    result, message = None, None
-    for (result, message) in lib.poll(all_peer_permissions_removed):  # noqa: B007
-        if result:
-            break
-
-    assert result, message
+    assert not meshnet.is_peer_reachable(peer, meshnet.PeerName.Ip)
 
 
 @pytest.mark.xfail(condition=meshnet.is_meshnet_test_disabled_from_run(), reason="Run only in nightly")

--- a/test/qa/test_meshnet.py
+++ b/test/qa/test_meshnet.py
@@ -314,7 +314,7 @@ def test_direct_connection_rtt_and_loss():
 def test_incoming_connections():
     """Manual TC: LVPN-1259"""
 
-    meshnet.are_peers_connected(ssh_client)
+    meshnet.wait_for_peers_connection(ssh_client)
 
     peer_list = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list())
     local_hostname = peer_list.get_this_device().hostname

--- a/test/qa/test_meshnet_routing.py
+++ b/test/qa/test_meshnet_routing.py
@@ -156,13 +156,14 @@ def test_routing_access_LAN():
     peer_hostname = peer_list.get_external_peer().hostname
     this_device = peer_list.get_this_device()
     sh_no_tty.nordvpn.mesh.peer.local.deny(peer_hostname)
-
+    ssh_client.exec_command("nordvpn mesh peer refresh")
     output = ssh_client.exec_command("nordvpn mesh peer connect " + this_device.ip)
     assert meshnet.is_connect_successful(output, this_device.hostname), "Remote peer connect should be successful"
     default_gateway = network.get_default_gateway()
 
     assert not ssh_client.network.ping(default_gateway, retry=3)
     sh_no_tty.nordvpn.mesh.peer.local.allow(peer_hostname)
+    ssh_client.exec_command("nordvpn mesh peer refresh")
     cap = capture_utils.BackgroundCapture("any", display_filter=f"ip.addr == {default_gateway}")
     cap.start()
     time.sleep(2)

--- a/test/qa/test_meshnet_vpn.py
+++ b/test/qa/test_meshnet_vpn.py
@@ -32,21 +32,8 @@ def test_killswitch_exitnode_vpn(lan_discovery: bool, local: bool):
     my_ip = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_this_device().ip
     peer_ip = meshnet.PeerList.from_str(sh_no_tty.nordvpn.mesh.peer.list()).get_external_peer().ip
 
-    try:
-        ssh_client.exec_command(f"nordvpn mesh peer incoming allow {my_ip}")
-    except RuntimeError as err:
-        if "already allowed" not in err.args[0]:
-            raise
-    try:
-        ssh_client.exec_command(f"nordvpn mesh peer routing allow {my_ip}")
-    except RuntimeError as err:
-        if "already allowed" not in err.args[0]:
-            raise
-    try:
-        ssh_client.exec_command(f"nordvpn mesh peer local {'allow' if local else 'deny'} {my_ip}")
-    except RuntimeError as err:
-        if "already allowed" not in err.args[0]:
-            raise
+    ssh_client.meshnet.set_permissions(my_ip, routing=True, local=local, incoming=True)
+
     try:
         ssh_client.exec_command(f"nordvpn set lan-discovery {'on' if lan_discovery else 'off'}")
     except RuntimeError as err:

--- a/test/qa/test_update.py
+++ b/test/qa/test_update.py
@@ -82,7 +82,7 @@ def setup_function(function):  # noqa: ARG001
         ssh_client.exec_command("nordvpn set mesh on")
         sh.nordvpn.mesh.peer.refresh()
 
-        meshnet.are_peers_connected(ssh_client)
+        meshnet.wait_for_peers_connection(ssh_client)
 
 
 def teardown_function(function):  # noqa: ARG001


### PR DESCRIPTION
Refactor old test, which relies on checking `iptables`.

Goal is to have a test among `core_meshnet` tests, which would verify, that peer cannot be reached anymore, if we remove it from our Meshnet.