### PR TITLE
LVPN-10889: Add OVPN DCO support

### DIFF
--- a/ci/nfpm/template.yaml
+++ b/ci/nfpm/template.yaml
@@ -152,10 +152,14 @@ contents:
     # like rpm-ostree.
     file_info:
       mode: 0755
-    
+
 # All fields above marked as `overridable` can be overridden for a given package format in this section.
 overrides:
   deb:
+    # Package provides the out-of-tree kernel module the bundled OpenVPN 2.6.x needs for
+    # data channel offload.
+    suggests:
+      - openvpn-dco-dkms
     # Deb specific scripts.
     scripts:
       preinstall: ${WORKDIR}/contrib/scriptlets/deb/preinst
@@ -173,6 +177,10 @@ overrides:
       - glibc >= 2.35
       - (libsqlite3-0 or sqlite-libs)
       - (xsltproc or libxslt)
+    # Package provides the out-of-tree kernel module the bundled OpenVPN 2.6.x needs for
+    # data channel offload.
+    suggests:
+      - (kmod-ovpn-dco or ovpn-dco-kmp-default)
     recommends:
       - iptables
       - nordvpn-gui

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -887,7 +887,7 @@ func buildTpServersAndResolver(
 	cdn := core.NewCDNAPI(userAgent, cdnUrl, httpClientSimple, validator)
 	tpServers := dns.NewNameServers()
 	// fetch async the TP servers, because FetchTPServers will retry until is successful
-	go tpServers.FetchTPServers(cdn.ThreatProtectionLite, timeoutFn)
+	go tpServers.FetchTPServers(cdn.FetchThreatProtectionLite, timeoutFn)
 
 	resolver := network.NewResolver(tpServers, fwmark, serviceEvents)
 	return tpServers, resolver

--- a/core/cdn.go
+++ b/core/cdn.go
@@ -12,10 +12,20 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/request"
 )
 
+// OvpnTemplateVariant identifies which OpenVPN config template to fetch.
+type OvpnTemplateVariant int
+
+const (
+	// OvpnTemplateStandard is used when the data channel is not offloaded to the kernel.
+	OvpnTemplateStandard OvpnTemplateVariant = iota
+	// OvpnTemplateObfuscated is used for XOR obfuscated connections.
+	OvpnTemplateObfuscated
+)
+
 // CDN provides methods to interact with Nord's Content Delivery Network
 type CDN interface {
-	ThreatProtectionLite() (*NameServers, error)
-	ConfigTemplate(isObfuscated bool, method string) (http.Header, []byte, error)
+	FetchThreatProtectionLite() (*NameServers, error)
+	FetchConfigTemplate(variant OvpnTemplateVariant, method string) (http.Header, []byte, error)
 	RemoteStorage
 }
 
@@ -109,13 +119,20 @@ func mandatoryHeadersExist(headers http.Header) bool {
 	return okAuth && okDigest && okAccept && okSign
 }
 
-func (api *CDNAPI) ConfigTemplate(isObfuscated bool, method string) (http.Header, []byte, error) {
+func (api *CDNAPI) FetchConfigTemplate(
+	variant OvpnTemplateVariant,
+	method string,
+) (http.Header, []byte, error) {
 	var path string
-	if isObfuscated {
-		path = ovpnObfsTemplateURL
-	} else {
+	switch variant {
+	case OvpnTemplateStandard:
 		path = ovpnTemplateURL
+	case OvpnTemplateObfuscated:
+		path = ovpnObfsTemplateURL
+	default:
+		return nil, nil, fmt.Errorf("unknown OpenVPN config template variant: %d", variant)
 	}
+
 	resp, err := api.request(path, method)
 	if err != nil {
 		return nil, nil, err
@@ -128,7 +145,7 @@ func (api *CDNAPI) ConfigTemplate(isObfuscated bool, method string) (http.Header
 	return resp.Headers, body, nil
 }
 
-func (api *CDNAPI) ThreatProtectionLite() (*NameServers, error) {
+func (api *CDNAPI) FetchThreatProtectionLite() (*NameServers, error) {
 	resp, err := api.request(ThreatProtectionLiteURL, http.MethodGet)
 	if err != nil {
 		return nil, err

--- a/core/cdn_test.go
+++ b/core/cdn_test.go
@@ -27,11 +27,11 @@ func TestCdnApi(t *testing.T) {
 	cdnApi, cancel := setupCdnApi()
 	assert.NotNil(t, cdnApi)
 
-	nameservers, err := cdnApi.ThreatProtectionLite()
+	nameservers, err := cdnApi.FetchThreatProtectionLite()
 	assert.NoError(t, err)
 	assert.NotNil(t, nameservers)
 
-	_, fileBytes, err := cdnApi.ConfigTemplate(false, http.MethodGet)
+	_, fileBytes, err := cdnApi.FetchConfigTemplate(OvpnTemplateStandard, http.MethodGet)
 	assert.NoError(t, err)
 	assert.NotZero(t, len(fileBytes))
 
@@ -250,7 +250,7 @@ func TestCDNAPI_Request_HeadMissingHeaders(t *testing.T) {
 	defer server.Close()
 
 	api := NewCDNAPI("test-agent", server.URL, &http.Client{}, response.NoopValidator{})
-	_, _, err := api.ConfigTemplate(false, http.MethodHead)
+	_, _, err := api.FetchConfigTemplate(OvpnTemplateStandard, http.MethodHead)
 
 	assert.ErrorContains(t, err, "mandatory response headers")
 }
@@ -268,11 +268,50 @@ func TestCDNAPI_Request_HeadWithMandatoryHeaders(t *testing.T) {
 	defer server.Close()
 
 	api := NewCDNAPI("test-agent", server.URL, &http.Client{}, response.NoopValidator{})
-	headers, body, err := api.ConfigTemplate(false, http.MethodHead)
+	headers, body, err := api.FetchConfigTemplate(OvpnTemplateStandard, http.MethodHead)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, headers)
 	assert.Empty(t, body)
+}
+
+func TestCDNAPI_FetchConfigTemplate_PathByVariant(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name     string
+		variant  OvpnTemplateVariant
+		wantPath string
+	}{
+		{"standard", OvpnTemplateStandard, ovpnTemplateURL},
+		{"obfuscated", OvpnTemplateObfuscated, ovpnObfsTemplateURL},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			api := NewCDNAPI("test-agent", server.URL, &http.Client{}, response.NoopValidator{})
+			_, _, err := api.FetchConfigTemplate(test.variant, http.MethodGet)
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantPath, gotPath)
+		})
+	}
+}
+
+func TestCDNAPI_FetchConfigTemplate_UnknownVariant(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	api := NewCDNAPI("test-agent", "http://localhost", &http.Client{}, response.NoopValidator{})
+	_, _, err := api.FetchConfigTemplate(OvpnTemplateVariant(99), http.MethodGet)
+
+	assert.ErrorContains(t, err, "unknown OpenVPN config template variant")
 }
 
 func TestCDNAPI_Request_NetworkError(t *testing.T) {

--- a/daemon/firewall/nft/nft_snapshot_test.go
+++ b/daemon/firewall/nft/nft_snapshot_test.go
@@ -24,6 +24,10 @@ func TestVPNRuleset(t *testing.T) {
 		config *helpers.FirewallConfigBuilder
 	}{
 		{
+			name:   "pre connect nothing set",
+			config: helpers.NewFWConfig(),
+		},
+		{
 			name:   "kill switch only",
 			config: helpers.NewFWConfig().KillSwitch(),
 		},

--- a/daemon/firewall/nft/testdata/TestVPNRuleset/pre_connect_nothing_set.golden
+++ b/daemon/firewall/nft/testdata/TestVPNRuleset/pre_connect_nothing_set.golden
@@ -1,0 +1,25 @@
+table inet nordvpn {
+	set lan_ranges {
+		type ipv4_addr
+		flags constant,interval
+		elements = { 10.0.0.0/8, 169.254.0.0/16,
+			     172.16.0.0/12, 192.168.0.0/16 }
+	}
+
+	chain input {
+		type filter hook input priority filter; policy accept;
+		iifname "lo" accept comment "local to local"
+		ct mark 0x0000e1f1 accept comment "response for sockets with SO_MARK"
+	}
+
+	chain output {
+		type route hook output priority mangle; policy accept;
+		oifname "lo" accept comment "local to loopback"
+		ct mark 0x0000e1f1 accept comment "VPN transport continuation"
+		meta mark 0x0000e1f1 ct mark set meta mark accept comment "mark connection for socket with SO_MARK"
+	}
+
+	chain forward {
+		type filter hook forward priority filter; policy accept;
+	}
+}

--- a/daemon/job_templates.go
+++ b/daemon/job_templates.go
@@ -9,40 +9,44 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/log"
 )
 
+// ovpnTemplates maps every OpenVPN config template variant to the file it is cached in.
+var ovpnTemplates = map[core.OvpnTemplateVariant]string{
+	core.OvpnTemplateStandard:   internal.OvpnTemplatePath,
+	core.OvpnTemplateObfuscated: internal.OvpnObfsTemplatePath,
+}
+
 func JobTemplates(cdn core.CDN) func() {
 	return func() {
-		getTemplate := func(isObfuscated bool) {
+		getTemplate := func(variant core.OvpnTemplateVariant, cachePath string) {
 			var digest string
-			filepath := internal.OvpnTemplatePath
-			if isObfuscated {
-				filepath = internal.OvpnObfsTemplatePath
-			}
-			if internal.FileExists(filepath) {
-				if hash, err := internal.FileSha256(filepath); err == nil {
+			if internal.FileExists(cachePath) {
+				if hash, err := internal.FileSha256(cachePath); err == nil {
 					digest = hex.EncodeToString(hash)
 				}
 			}
 
-			headers, _, err := cdn.ConfigTemplate(isObfuscated, http.MethodHead)
+			headers, _, err := cdn.FetchConfigTemplate(variant, http.MethodHead)
 			if err != nil {
 				log.Warn("downloading (MethodHead) config template:", err)
 				return
 			}
 
 			if digest != headers.Get(core.HeaderDigest) {
-				_, body, err := cdn.ConfigTemplate(isObfuscated, http.MethodGet)
+				_, body, err := cdn.FetchConfigTemplate(variant, http.MethodGet)
 				if err != nil {
 					log.Warn("downloading (MethodGet) config template:", err)
 					return
 				}
-				err = internal.FileWrite(filepath, body, internal.PermUserRW)
+				err = internal.FileWrite(cachePath, body, internal.PermUserRW)
 				if err != nil {
-					log.Warn("writing doanloded config template:", err)
+					log.Warn("writing downloaded config template:", err)
 					return
 				}
 			}
 		}
-		go getTemplate(false)
-		go getTemplate(true)
+
+		for variant, cachePath := range ovpnTemplates {
+			go getTemplate(variant, cachePath)
+		}
 	}
 }

--- a/daemon/job_templates.go
+++ b/daemon/job_templates.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net/http"
 
 	"github.com/NordSecurity/nordvpn-linux/core"
@@ -9,44 +10,49 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/log"
 )
 
-// ovpnTemplates maps every OpenVPN config template variant to the file it is cached in.
-var ovpnTemplates = map[core.OvpnTemplateVariant]string{
-	core.OvpnTemplateStandard:   internal.OvpnTemplatePath,
-	core.OvpnTemplateObfuscated: internal.OvpnObfsTemplatePath,
+// updateTemplateCache downloads the config template to cachePath unless the cached copy matches
+// the CDN digest.
+func updateTemplateCache(cdn core.CDN, variant core.OvpnTemplateVariant, cachePath string) error {
+	var digest string
+	if internal.FileExists(cachePath) {
+		if hash, err := internal.FileSha256(cachePath); err == nil {
+			digest = hex.EncodeToString(hash)
+		}
+	}
+
+	headers, _, err := cdn.FetchConfigTemplate(variant, http.MethodHead)
+	if err != nil {
+		return fmt.Errorf("downloading (MethodHead) config template: %w", err)
+	}
+
+	if digest == headers.Get(core.HeaderDigest) {
+		return nil
+	}
+
+	_, body, err := cdn.FetchConfigTemplate(variant, http.MethodGet)
+	if err != nil {
+		return fmt.Errorf("downloading (MethodGet) config template: %w", err)
+	}
+	if err := internal.FileWrite(cachePath, body, internal.PermUserRW); err != nil {
+		return fmt.Errorf("writing downloaded config template: %w", err)
+	}
+	return nil
 }
 
 func JobTemplates(cdn core.CDN) func() {
+	// ovpnTemplates maps every OpenVPN config template variant to the file it is cached in.
+	var ovpnTemplates = map[core.OvpnTemplateVariant]string{
+		core.OvpnTemplateStandard:   internal.OvpnTemplatePath,
+		core.OvpnTemplateObfuscated: internal.OvpnObfsTemplatePath,
+	}
+
 	return func() {
-		getTemplate := func(variant core.OvpnTemplateVariant, cachePath string) {
-			var digest string
-			if internal.FileExists(cachePath) {
-				if hash, err := internal.FileSha256(cachePath); err == nil {
-					digest = hex.EncodeToString(hash)
-				}
-			}
-
-			headers, _, err := cdn.FetchConfigTemplate(variant, http.MethodHead)
-			if err != nil {
-				log.Warn("downloading (MethodHead) config template:", err)
-				return
-			}
-
-			if digest != headers.Get(core.HeaderDigest) {
-				_, body, err := cdn.FetchConfigTemplate(variant, http.MethodGet)
-				if err != nil {
-					log.Warn("downloading (MethodGet) config template:", err)
-					return
-				}
-				err = internal.FileWrite(cachePath, body, internal.PermUserRW)
-				if err != nil {
-					log.Warn("writing downloaded config template:", err)
-					return
-				}
-			}
-		}
-
 		for variant, cachePath := range ovpnTemplates {
-			go getTemplate(variant, cachePath)
+			go func() {
+				if err := updateTemplateCache(cdn, variant, cachePath); err != nil {
+					log.Warn("updating config template cache:", err)
+				}
+			}()
 		}
 	}
 }

--- a/daemon/job_templates_test.go
+++ b/daemon/job_templates_test.go
@@ -1,0 +1,157 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/core"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockTemplateCDN implements core.CDN for exercising updateTemplateCache.
+type mockTemplateCDN struct {
+	digest   string
+	body     []byte
+	headErr  error
+	getErr   error
+	getCalls int
+}
+
+func (*mockTemplateCDN) FetchThreatProtectionLite() (*core.NameServers, error) { return nil, nil }
+
+func (*mockTemplateCDN) GetRemoteFile(string) ([]byte, error) { return nil, nil }
+
+func (m *mockTemplateCDN) FetchConfigTemplate(
+	_ core.OvpnTemplateVariant, method string,
+) (http.Header, []byte, error) {
+	switch method {
+	case http.MethodHead:
+		if m.headErr != nil {
+			return nil, nil, m.headErr
+		}
+		headers := http.Header{}
+		headers.Set(core.HeaderDigest, m.digest)
+		return headers, nil, nil
+	case http.MethodGet:
+		m.getCalls++
+		if m.getErr != nil {
+			return nil, nil, m.getErr
+		}
+		return nil, m.body, nil
+	default:
+		return nil, nil, fmt.Errorf("unexpected method %s", method)
+	}
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestUpdateTemplateCache(t *testing.T) {
+	category.Set(t, category.File)
+
+	template := []byte("remote template")
+
+	tests := []struct {
+		name        string
+		cached      []byte
+		cdn         *mockTemplateCDN
+		wantErr     bool
+		wantContent []byte
+		wantGets    int
+	}{
+		{
+			name:        "downloads template when cache is missing",
+			cdn:         &mockTemplateCDN{digest: sha256Hex(template), body: template},
+			wantContent: template,
+			wantGets:    1,
+		},
+		{
+			name:        "skips download when cached digest matches",
+			cached:      template,
+			cdn:         &mockTemplateCDN{digest: sha256Hex(template)},
+			wantContent: template,
+			wantGets:    0,
+		},
+		{
+			name:        "replaces cache when digest differs",
+			cached:      []byte("stale template"),
+			cdn:         &mockTemplateCDN{digest: sha256Hex(template), body: template},
+			wantContent: template,
+			wantGets:    1,
+		},
+		{
+			name:    "returns error when HEAD fails",
+			cdn:     &mockTemplateCDN{headErr: errors.New("head failed")},
+			wantErr: true,
+		},
+		{
+			name:        "keeps existing cache when HEAD fails",
+			cached:      template,
+			cdn:         &mockTemplateCDN{headErr: errors.New("head failed")},
+			wantErr:     true,
+			wantContent: template,
+		},
+		{
+			name:     "returns error when GET fails",
+			cdn:      &mockTemplateCDN{digest: sha256Hex(template), getErr: errors.New("get failed")},
+			wantErr:  true,
+			wantGets: 1,
+		},
+		{
+			name:        "keeps stale cache when GET fails",
+			cached:      []byte("stale template"),
+			cdn:         &mockTemplateCDN{digest: sha256Hex(template), getErr: errors.New("get failed")},
+			wantErr:     true,
+			wantGets:    1,
+			wantContent: []byte("stale template"),
+		},
+		{
+			name:     "skips download when cache and digest header are both missing",
+			cdn:      &mockTemplateCDN{},
+			wantGets: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cachePath := filepath.Join(t.TempDir(), "template.xslt")
+			if test.cached != nil {
+				assert.NoError(t, os.WriteFile(cachePath, test.cached, internal.PermUserRW))
+			}
+
+			err := updateTemplateCache(test.cdn, core.OvpnTemplateStandard, cachePath)
+
+			if test.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.wantGets, test.cdn.getCalls)
+
+			if test.wantContent != nil {
+				content, err := os.ReadFile(cachePath)
+				assert.NoError(t, err)
+				assert.Equal(t, test.wantContent, content)
+			} else if test.cached == nil {
+				assert.False(t, internal.FileExists(cachePath))
+			}
+
+			if test.wantGets > 0 && !test.wantErr {
+				info, err := os.Stat(cachePath)
+				assert.NoError(t, err)
+				assert.Equal(t, os.FileMode(internal.PermUserRW), info.Mode().Perm())
+			}
+		})
+	}
+}

--- a/daemon/vpn/openvpn/config_test.go
+++ b/daemon/vpn/openvpn/config_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSetOpenVPNConfigRequiresServerVersion(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	err := setOpenVPNConfig(config.Protocol_UDP, netip.MustParseAddr("192.0.2.1"), false, "")
+
+	assert.ErrorIs(t, err, ErrServerVersion)
+}
+
 func TestGetConfigIdentifier(t *testing.T) {
 	category.Set(t, category.Unit)
 

--- a/daemon/vpn/openvpn/config_testdata_test.go
+++ b/daemon/vpn/openvpn/config_testdata_test.go
@@ -5,25 +5,20 @@ const (
 	configV1 = `client
 dev tun
 
-remote 1.1.1.1 1194 udp
+remote 1.1.1.1 53 udp
+fast-io
+mssfix 1450
     
 resolv-retry infinite
-remote-random
 nobind
-tun-mtu 1500
-tun-mtu-extra 32
-mssfix 1450
-persist-key
-persist-tun
+ping-timer-rem
 reneg-sec 0
 server-poll-timeout 5
 remote-cert-tls server
 auth-user-pass
 verb 3
 pull
-fast-io
-cipher AES-256-CBC
-auth SHA512
+tls-version-min 1.2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFCjCCAvKgAwIBAgIBATANBgkqhkiG9w0BAQ0FADA5MQswCQYDVQQGEwJQQTEQ
@@ -56,7 +51,7 @@ PApL8PytggYKeQmRhl499+6jLxcZ2IegLfqq41dzIjwHwTMplg+1pKIOVojpWA==
 -----END CERTIFICATE-----
 </ca>
 key-direction 1
-<tls-auth>
+<tls-crypt>
 #
 # 2048 bit OpenVPN static key
 #
@@ -78,7 +73,7 @@ a196c9de96012090e333519ae18d3509
 9427e7b372d348d352dc4c85e18cd4b9
 3f8a56ddb2e64eb67adfc9b337157ff4
 -----END OpenVPN Static key V1-----
-</tls-auth>
+</tls-crypt>
 `
 	configXORV1 = `client
 dev tun
@@ -102,6 +97,7 @@ persist-tun
 reneg-sec 0
 server-poll-timeout 5
 scramble obfuscate tiecohbeengik9eiGheeshidohtai8hiegeelai3Am9Cee8eePhohRa
+hand-window 10
 remote-cert-tls server
 auth-user-pass
 verb 3
@@ -291,6 +287,11 @@ remote <xsl:value-of select="./@address"/> 80 tcp
     </xsl:otherwise>
   </xsl:choose>
 </xsl:for-each>
+<xsl:choose>
+    <xsl:when test="/config/hostname != ''">
+verify-x509-name CN=<xsl:value-of select="/config/hostname"/>
+    </xsl:when>
+</xsl:choose>
 resolv-retry infinite
 remote-random
 nobind

--- a/daemon/vpn/openvpn/openvpn.go
+++ b/daemon/vpn/openvpn/openvpn.go
@@ -112,9 +112,7 @@ func (ovpn *OpenVPN) Start(
 	defer close(mErrCh)
 
 	ovpn.active = true
-	// #nosec G204 -- input is properly sanitized
-	process := exec.Command(
-		openVPNExec,
+	args := []string{
 		"--config", openVPNConfigFileName, // path to openVpnConfig to be used
 		"--management-client",
 		"--management", openvpnManagementSocket, "unix", // enable openvpn management
@@ -127,10 +125,17 @@ func (ovpn *OpenVPN) Start(
 		"--mark", strconv.Itoa(int(ovpn.fwmark)),
 		"--dev-type", interfaceType,
 		"--dev", InterfaceName,
-		// DCO cannot be used because currently servers are pushing `comp-lzo no`
-		"--disable-dco",
 		"--auth-nocache",
-	)
+	}
+
+	// Kernel DCO is attempted by default and OpenVPN drops it by itself whenever it cannot work,
+	// e.g. no kernel module, an unsupported cipher, compression -> back to the userspace.
+	if serverData.Obfuscated {
+		args = append(args, "--disable-dco")
+	}
+
+	// #nosec G204 -- input is properly sanitized
+	process := exec.Command(openVPNExec, args...)
 	err = startOpenVPN(process)
 
 	ovpn.stopCh = make(chan error, 1)

--- a/networker/firewall_order_test.go
+++ b/networker/firewall_order_test.go
@@ -1,0 +1,95 @@
+package networker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/daemon/firewall"
+	"github.com/NordSecurity/nordvpn-linux/daemon/vpn"
+	"github.com/NordSecurity/nordvpn-linux/events/subs"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	"github.com/NordSecurity/nordvpn-linux/test/mock"
+	firewallmock "github.com/NordSecurity/nordvpn-linux/test/mock/firewall"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callOrder records the sequence in which the firewall and the VPN are driven.
+type callOrder struct {
+	events []string
+}
+
+type recordingFirewall struct {
+	firewall.Service
+	order *callOrder
+}
+
+func (f *recordingFirewall) Configure(cfg firewall.Config) error {
+	f.order.events = append(f.order.events, "firewall")
+	return f.Service.Configure(cfg)
+}
+
+type recordingVPN struct {
+	vpn.VPN
+	order *callOrder
+}
+
+func (v *recordingVPN) Start(ctx context.Context, creds vpn.Credentials, server vpn.ServerData) error {
+	v.order.events = append(v.order.events, "vpn")
+	return v.VPN.Start(ctx, creds, server)
+}
+
+// The firewall's output chain marks the VPN transport connection with
+// "meta mark -> ct mark set", a rule that only matches packets carrying
+// skb->mark, i.e. packets sent by the VPN process itself. With OpenVPN DCO the
+// kernel module owns the socket once the handshake completes and never sets
+// skb->mark again, so the handshake is the only chance to mark the connection.
+// Configuring the firewall after the handshake leaves the conntrack entry
+// unmarked and the post-connect drop policy then blackholes the data channel
+// for the rest of the session.
+func TestCombined_Start_ConfiguresFirewallBeforeVPNStarts(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	order := &callOrder{}
+
+	netw := NewCombined(
+		&recordingVPN{VPN: &mock.WorkingVPN{}, order: order},
+		nil,
+		workingGateway{},
+		&subs.Subject[string]{},
+		workingRouter{},
+		&workingDNS{},
+		&recordingFirewall{Service: firewallmock.NewFirewall(), order: order},
+		nil,
+		&workingRoutingSetup{},
+		nil,
+		workingRouter{},
+		nil,
+		0,
+		false,
+		&workingIpv6{},
+		false,
+		&mock.SysctlSetterMock{},
+		config.Allowlist{},
+		&mock.SysctlSetterMock{},
+	)
+
+	err := netw.Start(
+		context.Background(),
+		vpn.Credentials{},
+		vpn.ServerData{},
+		config.NewAllowlist(nil, nil, nil),
+		[]string{"1.1.1.1"},
+		true,
+		func(time.Time, error) {},
+	)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, order.events, "neither the firewall nor the VPN was driven")
+	assert.Equal(t, "firewall", order.events[0],
+		"the firewall must be configured before the VPN handshake, otherwise the "+
+			"transport connection (OVPN) is never marked and DCO traffic is dropped")
+	assert.Contains(t, order.events, "vpn", "the VPN was never started")
+}

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -294,6 +294,15 @@ func (netw *Combined) start(
 	if serverData.IP == (netip.Addr{}) {
 		serverData = netw.lastServer
 	}
+
+	// Apply the firewall before the VPN starts so "meta mark -> ct mark set" exists
+	// during the handshake. That is the only chance to mark the transport connection,
+	// since nothing sets the mark once DCO hands the socket to the kernel module.
+	// Re-applying the current config changes no filtering.
+	if err = netw.fw.Configure(netw.fwConfig); err != nil {
+		return fmt.Errorf("configuring firewall before vpn start: %w", err)
+	}
+
 	if err = netw.vpnet.Start(ctx, creds, serverData); err != nil {
 		if err := netw.vpnet.Stop(); err != nil {
 			log.Error(err)


### PR DESCRIPTION
### Turns on OpenVPN kernel data channel offload (DCO).
We were passing `--disable-dco` always, because servers used `comp-lzo no`. Template stopped pinning a cipher in #1687.
Now we only pass this flag when offload actually can't work — obfuscated connection lives in userspace


### Firewall is now set up before the VPN starts.
The `meta mark -> ct mark set` rule needs to be there during the handshake — that's the one and only time a marked packet comes out of userspace. After that DCO (handed socket to kernel module) never sends one. Miss it and the output of offloaded traffic is gone.

### New 'suggest'
Adding additional suggestion to install (out-of-tree) kernel module: `openvpn-dco-dkms`