### PR TITLE
refactor: migrate deprecated grpc dial calls

### DIFF
--- a/cmd/fileshare/main.go
+++ b/cmd/fileshare/main.go
@@ -117,8 +117,7 @@ func main() {
 		}
 	}()
 
-	//nolint:staticcheck
-	grpcConn, err := grpc.Dial(
+	grpcConn, err := grpc.NewClient(
 		daemonURL,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)

--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -108,8 +108,7 @@ func startTray(quitChan chan<- norduser.StopRequest) {
 func shouldEnableFileshare(uid uint32) (bool, error) {
 	daemonURL := fmt.Sprintf("%s://%s", internal.Proto, internal.DaemonSocket)
 
-	//nolint:staticcheck
-	grpcConn, err := grpc.Dial(
+	grpcConn, err := grpc.NewClient(
 		daemonURL,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)

--- a/norduser/process/norduser_process_manager.go
+++ b/norduser/process/norduser_process_manager.go
@@ -38,8 +38,11 @@ func GetNorduserClientConnection(uid int) (*grpc.ClientConn, error) {
 	}
 
 	url := fmt.Sprintf("%s://%s", internal.Proto, socket)
-	//nolint:staticcheck
-	return grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	return grpc.NewClient(
+		url,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 }
 
 func (n *NorduserProcessClient) Ping(nowait bool) error {


### PR DESCRIPTION
## Problem

`grpc.Dial` is deprecated and the whole codebase already established the usage of `grpc.NewClient`. The holdouts that still do not use the newer format further suppress the linting, as a result, masking the warnings.

## Refactor

Migrate the remaining `grpc.Dial` call sites to use the updated `grpc.NewClient` call. 

Removed the now redundant lint suppression comments to include call site static lint checking.

No behavior change introduced by this commit - none of the `grpc.Dial` call sites include a blocking call, so no difference between lazy and eager grpc connections. Refactor is also already encouraged by grpc-go team: [usage](https://pkg.go.dev/google.golang.org/grpc#Dial), [anti-pattern](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md).