### PR TITLE
LVPN-10661: fix wrong status after reconnect failure

### DIFF
--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -77,12 +77,24 @@ func (r *RPC) executeConnect(srv pb.Daemon_ConnectServer, fn func(context.Contex
 		return srv.Send(&pb.Payload{Type: internal.CodeNothingToDo})
 	}
 
-	// set connection status to "Disconnected"
+	// reconcile connection status after a failed attempt
 	if didFail || err != nil {
-		r.events.Service.Disconnect.Publish(events.DataDisconnect{})
+		r.reconcileStatusAfterFailedConnect()
 	}
 
 	return err
+}
+
+// reconcileStatusAfterFailedConnect fixes up the reported connection status after a connection
+// attempt failed. If the attempt aborted before the existing tunnel was touched, the VPN is still
+// up (netw.IsVPNActive()==true) and we restore the previous status instead of falsely reporting a
+// disconnect. Only when there is genuinely no active tunnel do we publish a Disconnect.
+func (r *RPC) reconcileStatusAfterFailedConnect() {
+	if r.netw.IsVPNActive() {
+		r.connectionInfo.RestorePreviousStatus()
+		return
+	}
+	r.events.Service.Disconnect.Publish(events.DataDisconnect{})
 }
 
 func (r *RPC) reconnectOnServerMaintenance(

--- a/daemon/rpc_connect.go
+++ b/daemon/rpc_connect.go
@@ -61,7 +61,6 @@ func (r *RPC) ReconnectOnServerMaintenanceEvent(endpointFromEvent string) (exitE
 // executeConnect - ensures that no two connect functions are executed in the same time
 func (r *RPC) executeConnect(srv pb.Daemon_ConnectServer, fn func(context.Context) (bool, error)) error {
 	var err error
-	var didFail bool
 	// TODO: Currently this only listens to a given context in `netw.Start()`, therefore gets
 	// stopped on `ctx.Done()` only if it happens while `netw.Start()` is being executed.
 	// Otherwise:
@@ -72,14 +71,13 @@ func (r *RPC) executeConnect(srv pb.Daemon_ConnectServer, fn func(context.Contex
 	// In order to fix this, all of expensive operations should implement `ctx.Done()` handling
 	// and have context bypassed to them.
 	if !r.connectContext.TryExecuteWith(func(ctx context.Context) {
+		var didFail bool
 		didFail, err = fn(ctx)
+		if didFail || err != nil {
+			r.reconcileStatusAfterFailedConnect()
+		}
 	}) {
 		return srv.Send(&pb.Payload{Type: internal.CodeNothingToDo})
-	}
-
-	// reconcile connection status after a failed attempt
-	if didFail || err != nil {
-		r.reconcileStatusAfterFailedConnect()
 	}
 
 	return err

--- a/daemon/rpc_connect_reconcile_test.go
+++ b/daemon/rpc_connect_reconcile_test.go
@@ -26,7 +26,7 @@ func (n *hookedNetworker) IsVPNActive() bool {
 	if n.onIsVPNActive != nil {
 		n.onIsVPNActive()
 	}
-	return n.Mock.VpnActive
+	return n.VpnActive
 }
 
 // suspendOnReconcile returns a networker whose IsVPNActive call (the first thing

--- a/daemon/rpc_connect_reconcile_test.go
+++ b/daemon/rpc_connect_reconcile_test.go
@@ -1,0 +1,205 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
+	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	testnetworker "github.com/NordSecurity/nordvpn-linux/test/mock/networker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hookedNetworker lets a test observe (and suspend) the moment
+// reconcileStatusAfterFailedConnect inspects the tunnel state.
+type hookedNetworker struct {
+	*testnetworker.Mock
+	onIsVPNActive func()
+}
+
+func (n *hookedNetworker) IsVPNActive() bool {
+	if n.onIsVPNActive != nil {
+		n.onIsVPNActive()
+	}
+	return n.Mock.VpnActive
+}
+
+// suspendOnReconcile returns a networker whose IsVPNActive call (the first thing
+// reconcileStatusAfterFailedConnect does) signals `entered` and then blocks until `release` is
+// closed, plus the resulting *RPC.
+func suspendOnReconcile(t *testing.T, vpnActive bool) (rpc *RPC, entered <-chan struct{}, release func()) {
+	t.Helper()
+
+	rpc = testRPC()
+	enteredCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+	var once sync.Once
+
+	rpc.netw = &hookedNetworker{
+		Mock: &testnetworker.Mock{VpnActive: vpnActive},
+		onIsVPNActive: func() {
+			once.Do(func() { close(enteredCh) })
+			<-releaseCh
+		},
+	}
+
+	var releaseOnce sync.Once
+	return rpc, enteredCh, func() { releaseOnce.Do(func() { close(releaseCh) }) }
+}
+
+// failingConnect emulates a connection attempt that gave up without touching the existing tunnel.
+func failingConnect(context.Context) (bool, error) { return true, nil }
+
+// TestExecuteConnect_ReconcileRunsOutsideCriticalSection reproduces the defect: because
+// sharedctx.Context.TryExecuteWith releases its mutex before returning,
+// reconcileStatusAfterFailedConnect runs unprotected and another connect attempt (a second
+// `nordvpn connect`, an ENS reconnect, autoconnect or a meshnet exit node connect - they all share
+// the same sharedctx.Context) can already be running while the failed attempt is still fixing up
+// the reported status.
+func TestExecuteConnect_ReconcileRunsOutsideCriticalSection(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	rpc, reconcileEntered, releaseReconcile := suspendOnReconcile(t, true)
+	defer releaseReconcile()
+
+	connectDone := make(chan error, 1)
+	go func() {
+		connectDone <- rpc.executeConnect(&mockRPCServer{}, failingConnect)
+	}()
+
+	select {
+	case <-reconcileEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the failed attempt to start reconciling the status")
+	}
+
+	// The failed attempt is in the middle of reconcileStatusAfterFailedConnect. No other connect
+	// may be admitted until that cleanup is done, otherwise its status is overwritten by ours.
+	admitted := rpc.connectContext.TryExecuteWith(func(context.Context) {})
+
+	releaseReconcile()
+	require.NoError(t, <-connectDone)
+
+	assert.False(t, admitted,
+		"another connect attempt was admitted while the failed attempt was still reconciling "+
+			"the connection status")
+}
+
+// TestExecuteConnect_FailedAttemptClobbersNextAttemptStatus shows the user visible consequence of
+// the race above: the failed attempt publishes a Disconnect event on top of the status of an
+// attempt that is already running, so the daemon reports DISCONNECTED in the middle of a connect.
+func TestExecuteConnect_FailedAttemptClobbersNextAttemptStatus(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	// no tunnel left behind, so the reconcile takes the "publish Disconnect" branch
+	rpc, reconcileEntered, releaseReconcile := suspendOnReconcile(t, false)
+	defer releaseReconcile()
+	// wire the status up to the event bus the same way cmd/daemon/main.go does
+	rpc.events.Service.Disconnect.Subscribe(rpc.connectionInfo.ConnectionStatusNotifyDisconnect)
+
+	connectDone := make(chan error, 1)
+	go func() {
+		connectDone <- rpc.executeConnect(&mockRPCServer{}, failingConnect)
+	}()
+
+	select {
+	case <-reconcileEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the failed attempt to start reconciling the status")
+	}
+
+	// A second connect attempt starts. It is admitted as soon as the guard lets it in - today that
+	// happens while the first attempt is still reconciling, once the reconcile is inside the
+	// critical section it happens after the first attempt is fully done. Either way the status it
+	// sets must survive.
+	secondAttempted := make(chan struct{})
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		var once sync.Once
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			admitted := rpc.connectContext.TryExecuteWith(func(context.Context) {
+				rpc.connectionInfo.SetInitialConnecting()
+			})
+			once.Do(func() { close(secondAttempted) })
+			if admitted || time.Now().After(deadline) {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	select {
+	case <-secondAttempted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the second connect attempt")
+	}
+
+	releaseReconcile()
+	require.NoError(t, <-connectDone)
+	<-secondDone
+
+	assert.Equal(t, pb.ConnectionState_CONNECTING, rpc.connectionInfo.Status().State,
+		"the status of the running connect attempt was overwritten by the cleanup of the "+
+			"previous failed attempt")
+}
+
+// stateChangeRecorder records the internal connection status notifications.
+type stateChangeRecorder struct {
+	mu     sync.Mutex
+	events []events.DataConnectChangeNotif
+}
+
+func (r *stateChangeRecorder) OnStateChange(e events.DataConnectChangeNotif) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, e)
+	return nil
+}
+
+func (r *stateChangeRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.events)
+}
+
+// TestExecuteConnect_FailureBeforeSetInitialConnecting_LeavesStatusUntouched covers the secondary
+// defect: reconcileStatusAfterFailedConnect also runs for attempts that bail out before
+// SetInitialConnecting is reached (not logged in, config load error, maintenance bail-out). Such an
+// attempt never changed the reported status, so the cleanup must not restore a snapshot captured by
+// an earlier attempt and drop the live connection to a stale status.
+func TestExecuteConnect_FailureBeforeSetInitialConnecting_LeavesStatusUntouched(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	rpc := testRPC()
+	// the tunnel is up, so the reconcile takes the "restore previous status" branch
+	rpc.netw = &testnetworker.Mock{VpnActive: true}
+
+	// an earlier attempt captured a snapshot while disconnected and then connected successfully
+	rpc.connectionInfo.SetInitialConnecting()
+	require.NoError(t, rpc.connectionInfo.ConnectionStatusNotifyConnect(
+		events.DataConnect{EventStatus: events.StatusSuccess, TargetServerName: "server1"}))
+	require.Equal(t, pb.ConnectionState_CONNECTED, rpc.connectionInfo.Status().State)
+
+	recorder := &stateChangeRecorder{}
+	rpc.connectionInfo.SubscribeToInternalStateChanges(recorder)
+
+	// a new attempt fails before it ever reports CONNECTING
+	err := rpc.executeConnect(&mockRPCServer{}, func(context.Context) (bool, error) {
+		return true, internal.ErrNotLoggedIn
+	})
+	assert.ErrorIs(t, err, internal.ErrNotLoggedIn)
+
+	status := rpc.connectionInfo.Status()
+	assert.Equal(t, pb.ConnectionState_CONNECTED, status.State,
+		"an attempt that failed before reporting CONNECTING must not change the reported status")
+	assert.Equal(t, "server1", status.Name)
+	assert.Zero(t, recorder.count(),
+		"no status change notification should be emitted for an attempt that never changed the status")
+}

--- a/daemon/state/connection_info.go
+++ b/daemon/state/connection_info.go
@@ -45,7 +45,12 @@ type serverSelectionData struct {
 type ConnectionInfo struct {
 	status         types.ConnectionStatus
 	fullyConnected bool
-	pauseData      *pauseData
+	// statusBeforeConnecting is a snapshot of status captured by SetInitialConnecting,
+	// used to roll back the reported status when a connection attempt aborts without
+	// touching the existing tunnel (see RestorePreviousStatus).
+	statusBeforeConnecting types.ConnectionStatus
+	fullyConnectedBefore   bool
+	pauseData              *pauseData
 	// serverSelectionData stores data used to build PauseCancelled events
 	serverSelectionData   serverSelectionData
 	remainingDurationFunc remainingDurationFunc
@@ -105,11 +110,30 @@ func (cs *ConnectionInfo) setStatus(s types.ConnectionStatus, fullyConnected boo
 }
 
 // SetInitialConnecting should be executed as soon as connection started, even when no target server
-// is known yet.
+// is known yet. It snapshots the current status so it can be restored if the attempt aborts before
+// the existing tunnel is touched (see RestorePreviousStatus).
 func (c *ConnectionInfo) SetInitialConnecting() {
+	c.mu.Lock()
+	c.statusBeforeConnecting = c.status
+	c.fullyConnectedBefore = c.fullyConnected
+	c.mu.Unlock()
+
 	status := types.ConnectionStatus{State: pb.ConnectionState_CONNECTING}
 	c.setStatus(status, false)
 	c.internalNotif.Publish(events.DataConnectChangeNotif{Status: status})
+}
+
+// RestorePreviousStatus reverts the reported status to the snapshot captured by the most recent
+// SetInitialConnecting call. Use it when a connection attempt fails but the existing tunnel was
+// left intact, so the reported state must not falsely become DISCONNECTED.
+func (c *ConnectionInfo) RestorePreviousStatus() {
+	c.mu.RLock()
+	prev := c.statusBeforeConnecting
+	fully := c.fullyConnectedBefore
+	c.mu.RUnlock()
+
+	c.setStatus(prev, fully)
+	c.internalNotif.Publish(events.DataConnectChangeNotif{Status: prev})
 }
 
 func (c *ConnectionInfo) ConnectionStatusNotifyConnect(e events.DataConnect) error {

--- a/daemon/state/connection_info.go
+++ b/daemon/state/connection_info.go
@@ -50,6 +50,7 @@ type ConnectionInfo struct {
 	// touching the existing tunnel (see RestorePreviousStatus).
 	statusBeforeConnecting types.ConnectionStatus
 	fullyConnectedBefore   bool
+	hasStatusSnapshot      bool
 	pauseData              *pauseData
 	// serverSelectionData stores data used to build PauseCancelled events
 	serverSelectionData   serverSelectionData
@@ -116,6 +117,7 @@ func (c *ConnectionInfo) SetInitialConnecting() {
 	c.mu.Lock()
 	c.statusBeforeConnecting = c.status
 	c.fullyConnectedBefore = c.fullyConnected
+	c.hasStatusSnapshot = true
 	c.mu.Unlock()
 
 	status := types.ConnectionStatus{State: pb.ConnectionState_CONNECTING}
@@ -123,14 +125,20 @@ func (c *ConnectionInfo) SetInitialConnecting() {
 	c.internalNotif.Publish(events.DataConnectChangeNotif{Status: status})
 }
 
-// RestorePreviousStatus reverts the reported status to the snapshot captured by the most recent
-// SetInitialConnecting call. Use it when a connection attempt fails but the existing tunnel was
-// left intact, so the reported state must not falsely become DISCONNECTED.
+// RestorePreviousStatus reverts the reported status to the snapshot captured by
+// SetInitialConnecting within the current connection attempt. Use it when a connection attempt
+// fails but the existing tunnel was left intact, so the reported state must not falsely become
+// DISCONNECTED.
 func (c *ConnectionInfo) RestorePreviousStatus() {
-	c.mu.RLock()
+	c.mu.Lock()
+	if !c.hasStatusSnapshot {
+		c.mu.Unlock()
+		return
+	}
 	prev := c.statusBeforeConnecting
 	fully := c.fullyConnectedBefore
-	c.mu.RUnlock()
+	c.hasStatusSnapshot = false
+	c.mu.Unlock()
 
 	c.setStatus(prev, fully)
 	c.internalNotif.Publish(events.DataConnectChangeNotif{Status: prev})
@@ -151,6 +159,7 @@ func (c *ConnectionInfo) ConnectionStatusNotifyConnect(e events.DataConnect) err
 		start := time.Now()
 		startTime = &start
 		fullyConnected = true
+		c.discardStatusSnapshot()
 	}
 
 	status := types.ConnectionStatus{
@@ -175,6 +184,12 @@ func (c *ConnectionInfo) ConnectionStatusNotifyConnect(e events.DataConnect) err
 	c.setStatus(status, fullyConnected)
 	c.internalNotif.Publish(events.DataConnectChangeNotif{Status: status})
 	return nil
+}
+
+func (c *ConnectionInfo) discardStatusSnapshot() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hasStatusSnapshot = false
 }
 
 func (c *ConnectionInfo) ConnectionStatusNotifyDisconnect(e events.DataDisconnect) error {

--- a/daemon/state/connection_info_test.go
+++ b/daemon/state/connection_info_test.go
@@ -448,6 +448,87 @@ func TestConnectionInfo_RefreshDisconnectEventsAreIgnored(t *testing.T) {
 	}
 }
 
+func TestConnectionInfo_RestorePreviousStatus(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	t.Run("restores connected status after a failed attempt", func(t *testing.T) {
+		tf := newTestFixture(t)
+		// two events from the initial connect (attempt would be one, but here we
+		// go straight to success), one from SetInitialConnecting, one from restore
+		tf.notificationSubscriber.stateChangeHandler.ExpectEvents(3)
+
+		connected := events.DataConnect{
+			EventStatus:        events.StatusSuccess,
+			Technology:         config.Technology_NORDLYNX,
+			Protocol:           config.Protocol_UDP,
+			TargetServerName:   "server1",
+			TargetServerDomain: "server1.example.com",
+			TargetServerIP:     netip.MustParseAddr("10.0.0.1"),
+		}
+		tf.sut.ConnectionStatusNotifyConnect(connected)
+		assert.Equal(t, pb.ConnectionState_CONNECTED, tf.sut.Status().State)
+		assert.True(t, tf.sut.fullyConnected)
+
+		// a new connection attempt starts and flips the status to CONNECTING
+		tf.sut.SetInitialConnecting()
+		assert.Equal(t, pb.ConnectionState_CONNECTING, tf.sut.Status().State)
+		assert.False(t, tf.sut.fullyConnected)
+
+		// the attempt fails without touching the tunnel; restore the prior status
+		tf.sut.RestorePreviousStatus()
+
+		status := tf.sut.Status()
+		assert.Equal(t, pb.ConnectionState_CONNECTED, status.State,
+			"status should be restored to CONNECTED when the attempt failed without a teardown")
+		assert.True(t, tf.sut.fullyConnected)
+		assert.Equal(t, connected.TargetServerName, status.Name)
+		assert.Equal(t, connected.TargetServerDomain, status.Hostname)
+		assert.Equal(t, connected.TargetServerIP, status.IP)
+		assert.Equal(t, connected.Technology, status.Technology)
+		assert.Equal(t, connected.Protocol, status.Protocol)
+	})
+
+	t.Run("restores disconnected status when the prior state was disconnected", func(t *testing.T) {
+		tf := newTestFixture(t)
+		// one from the disconnect, one from SetInitialConnecting, one from restore
+		tf.notificationSubscriber.stateChangeHandler.ExpectEvents(3)
+
+		tf.sut.ConnectionStatusNotifyDisconnect(events.DataDisconnect{})
+		assert.Equal(t, pb.ConnectionState_DISCONNECTED, tf.sut.Status().State)
+
+		tf.sut.SetInitialConnecting()
+		assert.Equal(t, pb.ConnectionState_CONNECTING, tf.sut.Status().State)
+
+		tf.sut.RestorePreviousStatus()
+		assert.Equal(t, pb.ConnectionState_DISCONNECTED, tf.sut.Status().State,
+			"restoring with a disconnected prior state should yield DISCONNECTED")
+		assert.False(t, tf.sut.fullyConnected)
+	})
+
+	t.Run("restored connected status keeps pause info", func(t *testing.T) {
+		tf := newTestFixture(t)
+		// one from the connect, one from SetInitialConnecting, one from restore
+		tf.notificationSubscriber.stateChangeHandler.ExpectEvents(3)
+		tf.sut.ConnectionStatusNotifyConnect(events.DataConnect{EventStatus: events.StatusSuccess})
+
+		tf.sut.SetInitialConnecting()
+
+		var remainingTimeSec uint32 = 7
+		duration := 10 * time.Second
+		pauseTime := time.Unix(1774276303, 0)
+		tf.sut.Pause(pauseTime, duration)
+		tf.sut.remainingDurationFunc = func(time.Time, time.Duration) uint32 { return remainingTimeSec }
+
+		tf.sut.RestorePreviousStatus()
+
+		status := tf.sut.Status()
+		assert.Equal(t, pb.ConnectionState_PAUSED, status.State,
+			"pause info should be re-applied on top of the restored status")
+		assert.Equal(t, pauseTime, status.PausedAt)
+		assert.Equal(t, remainingTimeSec, status.PauseRemainingTimeSec)
+	})
+}
+
 func TestConnectionInfo_PauseHandling(t *testing.T) {
 	category.Set(t, category.Unit)
 

--- a/daemon/state/connection_info_test.go
+++ b/daemon/state/connection_info_test.go
@@ -505,6 +505,61 @@ func TestConnectionInfo_RestorePreviousStatus(t *testing.T) {
 		assert.False(t, tf.sut.fullyConnected)
 	})
 
+	// Reproduces additional defect: reconcileStatusAfterFailedConnect also runs for
+	// attempts that fail before SetInitialConnecting is reached (not logged in, config load
+	// error, ENS bail-out). Such an attempt never changed the reported status, yet the restore
+	// resurrects the snapshot of an earlier attempt and drops a live connection to DISCONNECTED.
+	t.Run("restoring without a snapshot from the current attempt keeps the status", func(t *testing.T) {
+		tf := newTestFixture(t)
+		// one from the initial disconnect, one from SetInitialConnecting, one from the
+		// restore and one from the connect - the stray restore must not emit anything
+		tf.notificationSubscriber.stateChangeHandler.ExpectEvents(4)
+
+		tf.sut.ConnectionStatusNotifyDisconnect(events.DataDisconnect{})
+
+		// first attempt starts while disconnected and fails without touching the tunnel
+		tf.sut.SetInitialConnecting()
+		tf.sut.RestorePreviousStatus()
+		assert.Equal(t, pb.ConnectionState_DISCONNECTED, tf.sut.Status().State)
+
+		// afterwards the user connects successfully
+		tf.sut.ConnectionStatusNotifyConnect(events.DataConnect{EventStatus: events.StatusSuccess})
+		assert.Equal(t, pb.ConnectionState_CONNECTED, tf.sut.Status().State)
+
+		// a later attempt fails before it ever reaches SetInitialConnecting, so the failure
+		// cleanup restores a snapshot that does not belong to it
+		tf.sut.RestorePreviousStatus()
+
+		assert.Equal(t, pb.ConnectionState_CONNECTED, tf.sut.Status().State,
+			"a restore without a snapshot taken by the current attempt must not change the status")
+		assert.True(t, tf.sut.fullyConnected)
+	})
+
+	t.Run("the snapshot is consumed by the first restore", func(t *testing.T) {
+		tf := newTestFixture(t)
+		// one from the connect, one from SetInitialConnecting, one from the first restore
+		tf.notificationSubscriber.stateChangeHandler.ExpectEvents(3)
+
+		tf.sut.ConnectionStatusNotifyConnect(events.DataConnect{EventStatus: events.StatusSuccess})
+		tf.sut.SetInitialConnecting()
+
+		tf.sut.RestorePreviousStatus()
+		assert.Equal(t, pb.ConnectionState_CONNECTED, tf.sut.Status().State)
+		notificationsAfterRestore := tf.notificationSubscriber.stateChangeHandler.GetNotificationsCount()
+
+		// the tunnel is torn down by something else, then a second restore arrives
+		tf.notificationSubscriber.stateChangeHandler.ExpectEvents(1)
+		tf.sut.ConnectionStatusNotifyDisconnect(events.DataDisconnect{})
+		tf.sut.RestorePreviousStatus()
+
+		assert.Equal(t, pb.ConnectionState_DISCONNECTED, tf.sut.Status().State,
+			"a second restore must not re-apply an already consumed snapshot")
+		assert.False(t, tf.sut.fullyConnected)
+		assert.Equal(t, notificationsAfterRestore+1,
+			tf.notificationSubscriber.stateChangeHandler.GetNotificationsCount(),
+			"only the disconnect should have been notified, not the second restore")
+	})
+
 	t.Run("restored connected status keeps pause info", func(t *testing.T) {
 		tf := newTestFixture(t)
 		// one from the connect, one from SetInitialConnecting, one from restore


### PR DESCRIPTION
LVPN-10661: fix wrong status after reconnect failure - in GUI have Nordlynx VPN connect to Double VPN then go to settings and try to switch protocol to Nordwhisper, dialog will ask to reconnect but proper server cannot be found, then stay connected to the same location and show GUI/Tray proper status.