### PR TITLE
LVPN-11019: Add analytics for out of tree DCO usage

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -452,6 +452,8 @@ func main() {
 	connectionInfo.SubscribeToInternalStateChanges(statePublisher)
 	connectionInfo.SubscribeToPauseCancelled(analytics)
 	daemonEvents.Service.Connect.Subscribe(connectionInfo.ConnectionStatusNotifyConnect)
+	daemonEvents.Service.Connect.Subscribe(
+		openvpn.NewDCOAnalytics(daemonEvents.Debugger.DebuggerEvents).NotifyConnect)
 	daemonEvents.Service.Disconnect.Subscribe(connectionInfo.ConnectionStatusNotifyDisconnect)
 	daemonEvents.User.Subscribe(statePublisher)
 	configEvents.Subscribe(statePublisher)

--- a/daemon/vpn/openvpn/analytics.go
+++ b/daemon/vpn/openvpn/analytics.go
@@ -2,6 +2,7 @@ package openvpn
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +32,10 @@ var dcoLinkKinds = map[string]bool{
 	"ovpn":     true,
 }
 
-// dcoModuleSysfsDir exists while the ovpn-dco kernel module is loaded.
+// dcoModuleSysfsDir exists while the out-of-tree ovpn-dco kernel module is
+// loaded, whether or not the tunnel uses it.
+// We don't check the built-in ovpn module because OpenVPN 2.6.x can't use it.
+// Revisit this when OpenVPN 2.7 is available.
 const dcoModuleSysfsDir = "/sys/module/ovpn_dco_v2"
 
 // dcoStatusEvent is the debugger-event payload describing whether a successful
@@ -44,7 +48,8 @@ type dcoStatusEvent struct {
 	DCOActive bool `json:"dco_active"`
 	// LinkKind is the tunnel interface's link kind.
 	LinkKind string `json:"link_kind"`
-	// ModuleAvailable reports whether a DCO kernel module is loaded, regardless of use.
+	// ModuleAvailable reports whether the out-of-tree DCO kernel module is
+	// loaded, regardless of use.
 	ModuleAvailable bool `json:"module_available"`
 	// ModuleVersion is the loaded module's version.
 	ModuleVersion string `json:"module_version,omitempty"`
@@ -101,8 +106,15 @@ func (a *DCOAnalytics) NotifyConnect(e events.DataConnect) error {
 
 // ToDebuggerEvent converts the event to a DebuggerEvent for publishing.
 func (e *dcoStatusEvent) ToDebuggerEvent() *events.DebuggerEvent {
-	// cannot fail: the struct holds only strings and bools
-	jsonData, _ := json.Marshal(e)
+	jsonData, err := json.Marshal(e)
+	if err != nil {
+		log.Error("failed to marshal dco status event:", err)
+		// Fallback
+		jsonData = fmt.Appendf(nil,
+			`{"namespace":"%s","subscope":"%s","event":"%s","dco_active":%t,"module_available":%t,"error":"marshal_error"}`,
+			ovpnNamespace, ovpnSubscope, dcoStatusEventName, e.DCOActive, e.ModuleAvailable,
+		)
+	}
 	return events.NewDebuggerEvent(string(jsonData)).
 		WithKeyBasedContextPaths(
 			events.ContextValue{Path: ovpnContextPathPrefix + ".namespace", Value: e.Namespace},

--- a/daemon/vpn/openvpn/analytics.go
+++ b/daemon/vpn/openvpn/analytics.go
@@ -1,0 +1,116 @@
+package openvpn
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/internal"
+	"github.com/NordSecurity/nordvpn-linux/internal/analytics"
+	"github.com/NordSecurity/nordvpn-linux/log"
+)
+
+const (
+	ovpnNamespace         = internal.DebugEventMessageNamespace
+	ovpnSubscope          = "openvpn"
+	dcoStatusEventName    = ovpnSubscope + "_dco_status"
+	ovpnContextPathPrefix = ovpnSubscope
+
+	// linkKindUnknown is reported when the tunnel interface kind could not be read.
+	linkKindUnknown = "unknown"
+)
+
+// dcoLinkKinds lists link types used by OpenVPN DCO tunnel interfaces.
+var dcoLinkKinds = map[string]bool{
+	"ovpn-dco": true,
+	"ovpn":     true,
+}
+
+// dcoModuleSysfsDir exists while the ovpn-dco kernel module is loaded.
+const dcoModuleSysfsDir = "/sys/module/ovpn_dco_v2"
+
+// dcoStatusEvent is the debugger-event payload describing whether a successful
+// OpenVPN connection runs with kernel data channel offload (DCO).
+type dcoStatusEvent struct {
+	Namespace string `json:"namespace"`
+	Subscope  string `json:"subscope"`
+	Event     string `json:"event"`
+	// DCOActive reports whether a DCO kernel module is in use.
+	DCOActive bool `json:"dco_active"`
+	// LinkKind is the tunnel interface's link kind.
+	LinkKind string `json:"link_kind"`
+	// ModuleAvailable reports whether a DCO kernel module is loaded, regardless of use.
+	ModuleAvailable bool `json:"module_available"`
+	// ModuleVersion is the loaded module's version.
+	ModuleVersion string `json:"module_version,omitempty"`
+}
+
+func getLinkKind() (string, error) {
+	link, err := netlink.LinkByName(InterfaceName)
+	if err != nil {
+		return "", err
+	}
+	return link.Type(), nil
+}
+
+// newDCOStatusEvent inspects the established tunnel and the kernel.
+func newDCOStatusEvent() *dcoStatusEvent {
+	linkKind, err := getLinkKind()
+	if err != nil {
+		log.Error("reading tunnel interface link kind:", err)
+		linkKind = linkKindUnknown
+	}
+
+	event := &dcoStatusEvent{
+		Namespace: ovpnNamespace,
+		Subscope:  ovpnSubscope,
+		Event:     dcoStatusEventName,
+		DCOActive: dcoLinkKinds[linkKind],
+		LinkKind:  linkKind,
+	}
+
+	if internal.FileExists(dcoModuleSysfsDir) {
+		event.ModuleAvailable = true
+		if version, err := os.ReadFile(filepath.Join(dcoModuleSysfsDir, "version")); err == nil {
+			event.ModuleVersion = strings.TrimSpace(string(version))
+		}
+	}
+	return event
+}
+
+type DCOAnalytics struct {
+	publisher events.Publisher[events.DebuggerEvent]
+}
+
+func NewDCOAnalytics(publisher events.Publisher[events.DebuggerEvent]) *DCOAnalytics {
+	return &DCOAnalytics{publisher: publisher}
+}
+
+// NotifyConnect emits the DCO status event once per successful OpenVPN connection
+func (a *DCOAnalytics) NotifyConnect(e events.DataConnect) error {
+	if e.EventStatus == events.StatusSuccess && e.Technology == config.Technology_OPENVPN {
+		a.publisher.Publish(*newDCOStatusEvent().ToDebuggerEvent())
+	}
+	return nil
+}
+
+// ToDebuggerEvent converts the event to a DebuggerEvent for publishing.
+func (e *dcoStatusEvent) ToDebuggerEvent() *events.DebuggerEvent {
+	// cannot fail: the struct holds only strings and bools
+	jsonData, _ := json.Marshal(e)
+	return events.NewDebuggerEvent(string(jsonData)).
+		WithKeyBasedContextPaths(
+			events.ContextValue{Path: ovpnContextPathPrefix + ".namespace", Value: e.Namespace},
+			events.ContextValue{Path: ovpnContextPathPrefix + ".subscope", Value: e.Subscope},
+			events.ContextValue{Path: ovpnContextPathPrefix + ".event", Value: e.Event},
+			events.ContextValue{Path: ovpnContextPathPrefix + ".dco_active", Value: e.DCOActive},
+			events.ContextValue{Path: ovpnContextPathPrefix + ".link_kind", Value: e.LinkKind},
+			events.ContextValue{Path: ovpnContextPathPrefix + ".module_available", Value: e.ModuleAvailable},
+		).
+		WithGlobalContextPaths(analytics.MergeContextPaths()...)
+}

--- a/daemon/vpn/openvpn/analytics.go
+++ b/daemon/vpn/openvpn/analytics.go
@@ -28,8 +28,8 @@ const (
 
 // dcoLinkKinds lists link types used by OpenVPN DCO tunnel interfaces.
 var dcoLinkKinds = map[string]bool{
-	"ovpn-dco": true,
-	"ovpn":     true,
+	"ovpn-dco": true, // out-of-tree DKMS module, used by OpenVPN 2.6.x
+	"ovpn":     true, // in-tree module (kernel >= 6.16), used by OpenVPN 2.7+
 }
 
 // dcoModuleSysfsDir exists while the out-of-tree ovpn-dco kernel module is

--- a/daemon/vpn/openvpn/analytics_test.go
+++ b/daemon/vpn/openvpn/analytics_test.go
@@ -1,0 +1,113 @@
+package openvpn
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NordSecurity/nordvpn-linux/config"
+	"github.com/NordSecurity/nordvpn-linux/events"
+	"github.com/NordSecurity/nordvpn-linux/test/category"
+	mockevents "github.com/NordSecurity/nordvpn-linux/test/mock/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func contextValueByPath(paths []events.ContextValue, path string) any {
+	for _, cv := range paths {
+		if cv.Path == path {
+			return cv.Value
+		}
+	}
+	return nil
+}
+
+func TestDCOStatusEvent_ToDebuggerEvent(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	event := &dcoStatusEvent{
+		Namespace:       ovpnNamespace,
+		Subscope:        ovpnSubscope,
+		Event:           dcoStatusEventName,
+		DCOActive:       true,
+		LinkKind:        "ovpn-dco",
+		ModuleAvailable: true,
+		ModuleVersion:   "0.2.20260519",
+	}
+	debuggerEvent := event.ToDebuggerEvent()
+
+	require.NotNil(t, debuggerEvent)
+	require.NotEmpty(t, debuggerEvent.JsonData)
+
+	var decoded dcoStatusEvent
+	require.NoError(t, json.Unmarshal([]byte(debuggerEvent.JsonData), &decoded))
+	assert.Equal(t, *event, decoded)
+
+	assert.Equal(t, "nordvpn-linux", decoded.Namespace)
+	assert.Equal(t, "openvpn", decoded.Subscope)
+	assert.Equal(t, "openvpn_dco_status", decoded.Event)
+
+	assert.Equal(t, true, contextValueByPath(debuggerEvent.KeyBasedContextPaths, "openvpn.dco_active"))
+	assert.Equal(t, "ovpn-dco", contextValueByPath(debuggerEvent.KeyBasedContextPaths, "openvpn.link_kind"))
+	assert.Equal(t, true, contextValueByPath(debuggerEvent.KeyBasedContextPaths, "openvpn.module_available"))
+	assert.NotEmpty(t, debuggerEvent.GeneralContextPaths)
+}
+
+func TestNewDCOStatusEvent(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	event := newDCOStatusEvent()
+
+	assert.Equal(t, "nordvpn-linux", event.Namespace)
+	assert.Equal(t, "openvpn", event.Subscope)
+	assert.Equal(t, "openvpn_dco_status", event.Event)
+	assert.NotEmpty(t, event.LinkKind)
+}
+
+func TestDCOAnalytics_NotifyConnect(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	tests := []struct {
+		name          string
+		event         events.DataConnect
+		wantPublished bool
+	}{
+		{
+			name: "successful openvpn connect publishes DCO status",
+			event: events.DataConnect{
+				EventStatus: events.StatusSuccess,
+				Technology:  config.Technology_OPENVPN,
+			},
+			wantPublished: true,
+		},
+		{
+			name: "successful nordlynx connect publishes nothing",
+			event: events.DataConnect{
+				EventStatus: events.StatusSuccess,
+				Technology:  config.Technology_NORDLYNX,
+			},
+			wantPublished: false,
+		},
+		{
+			name: "openvpn connect attempt publishes nothing",
+			event: events.DataConnect{
+				EventStatus: events.StatusAttempt,
+				Technology:  config.Technology_OPENVPN,
+			},
+			wantPublished: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			publisher := &mockevents.MockPublisherSubscriber[events.DebuggerEvent]{}
+
+			err := NewDCOAnalytics(publisher).NotifyConnect(tt.event)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPublished, publisher.EventPublished)
+			if tt.wantPublished {
+				assert.Contains(t, publisher.Event.JsonData, `"event":"openvpn_dco_status"`)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added analytics to track out-of-tree OpenVPN DCO usage through a debugger event.