### PR TITLE
LVPN-9987: Keep killswitch on during daemon restart

### DIFF
--- a/contrib/initd/nordvpn
+++ b/contrib/initd/nordvpn
@@ -60,7 +60,7 @@ stop() {
   return "$RETVAL"
 }
 
-upgrade-stop() {
+usr1-stop() {
   # Return
   #   0 if daemon has been stopped
   #   1 if daemon was already stopped
@@ -80,7 +80,7 @@ restart() {
   # 'force-reload' alias
   #
   log_daemon_msg "Restarting $DAEMON" "$NAME"
-  stop
+  usr1-stop
   case "$?" in
     0|1)
       start
@@ -105,7 +105,7 @@ case "$1" in
     stop
     ;;
   upgrade-stop)
-    upgrade-stop
+    usr1-stop
     ;;
   restart)
     restart

--- a/contrib/systemd/system/nordvpnd.service
+++ b/contrib/systemd/system/nordvpnd.service
@@ -10,6 +10,7 @@ NonBlocking=true
 KillMode=process
 Restart=always
 RestartSec=5
+RestartKillSignal=SIGUSR1
 # centos7 RuntimeDirectory ignored
 RuntimeDirectory=nordvpn
 RuntimeDirectoryMode=0750

--- a/test/qa/lib/daemon.py
+++ b/test/qa/lib/daemon.py
@@ -163,6 +163,17 @@ def restart():
         time.sleep(2)
     start()
 
+# restarts the daemon without blocking
+def non_blocking_restart():
+    if is_running():
+        if is_under_snap():
+            os.popen("sudo snap restart nordvpn").read()
+        elif is_init_systemd():
+            os.popen("sudo systemctl restart nordvpn").read()
+        else:
+            sh.sudo("/etc/init.d/nordvpn", "restart")
+
+
 
 # retrieving links inside this function creates a race condition,
 # therefore it is safer to provide them as arguments

--- a/test/qa/test_killswitch.py
+++ b/test/qa/test_killswitch.py
@@ -289,3 +289,17 @@ def test_killswitch_autoconnect_to_fastest():
     # list of closest countries that surround Germany
     allowed_countries = ["Germany", "Poland", "Czech_Republic", "Austria", "Switzerland", "France", "Belgium", "Netherlands", "Denmark"]
     assert status_data["country"] in allowed_countries, "Fastest server should be in the same country"
+    sh.nordvpn.set.killswitch.off()
+    sh.nordvpn.set.autoconnect.off()
+
+
+@pytest.mark.skipif(daemon.is_under_snap(), reason="feature is not supported on snap")
+def test_killswitch_on_during_restart():
+    sh.nordvpn.set.killswitch.on()
+    daemon.non_blocking_restart()
+    for _ in range(5):
+        # doing five consecutive checks, to see if the table is not gone during the stopping and restarting
+        assert firewall.is_active()
+    assert network.is_not_available()
+    sh.nordvpn.set.killswitch.off()
+    assert network.is_available(), "Network should be available"


### PR DESCRIPTION
This PR adds restart kill signal as SIGUSR1, which keeps killswitch on after stopping the daemon, for systemd and initd systems