### PR TITLE
LVPN-11020: Diagnostics improvements

### DIFF
--- a/daemon/rpc_diagnostics.go
+++ b/daemon/rpc_diagnostics.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -64,11 +65,16 @@ func (r *RPC) CollectDiagnostics(
 		})
 	}
 
-	// createDiagnosticsZip uses os.CreateTemp under the hood, so we always
-	// get a fresh file with no chance of collision — no existence check, no
-	// TOCTOU race, no overwrite of an old report, even if two collections
-	// land in the same second.
-	zipFile, err := createDiagnosticsZip(caller.outputDir)
+	outputRoot, err := os.OpenRoot(caller.outputDir)
+	if err != nil {
+		log.Diagnostics.Error("failed to open root output dir:", err)
+		return srv.Send(&pb.DiagnosticsProgress{
+			ErrorCode: pb.DiagnosticsErrorCode_DIAGNOSTICS_ERROR_CODE_FAILED_TO_CREATE_ZIP,
+		})
+	}
+	defer outputRoot.Close()
+
+	zipFile, err := createDiagnosticsFile(outputRoot)
 	if err != nil {
 		log.Diagnostics.Error("failed to create diagnostics zip:", err)
 		return srv.Send(&pb.DiagnosticsProgress{
@@ -78,14 +84,16 @@ func (r *RPC) CollectDiagnostics(
 	zipPath := zipFile.Name()
 
 	if snapconf.IsUnderSnap() {
-		if err := os.Chmod(zipPath, internal.PermUserRWGroupROthersR); err != nil {
+		if err := zipFile.Chmod(internal.PermUserRWGroupROthersR); err != nil {
 			log.Diagnostics.Warn("failed to change file permissions:", err)
 		}
 	} else {
-		if err := os.Chown(zipPath, int(caller.uid), int(caller.gid)); err != nil {
+		if err := zipFile.Chown(int(caller.uid), int(caller.gid)); err != nil {
 			log.Diagnostics.Error("failed to change file ownership:", err)
 			return abortDiagnosticsWithCode(
-				zipFile, srv,
+				zipFile,
+				outputRoot,
+				srv,
 				pb.DiagnosticsErrorCode_DIAGNOSTICS_ERROR_CODE_CHOWN_FAILED,
 			)
 		}
@@ -96,32 +104,38 @@ func (r *RPC) CollectDiagnostics(
 		if errors.Is(err, errZipSizeLimitExceeded) {
 			log.Diagnostics.Error("diagnostics zip exceeded 40 MB limit")
 			return abortDiagnosticsWithCode(
-				zipFile, srv,
+				zipFile,
+				outputRoot,
+				srv,
 				pb.DiagnosticsErrorCode_DIAGNOSTICS_ERROR_CODE_ZIP_TOO_LARGE,
 			)
 		}
 		if errors.Is(err, errNoDaemonLogSource) {
 			log.Diagnostics.Error("no daemon log source available:", err)
 			return abortDiagnosticsWithCode(
-				zipFile, srv,
+				zipFile,
+				outputRoot,
+				srv,
 				pb.DiagnosticsErrorCode_DIAGNOSTICS_ERROR_CODE_NO_DAEMON_LOG_SOURCE,
 			)
 		}
 		log.Diagnostics.Error("failed to collect diagnostics:", err)
 		return abortDiagnosticsWithCode(
-			zipFile, srv,
+			zipFile,
+			outputRoot,
+			srv,
 			pb.DiagnosticsErrorCode_DIAGNOSTICS_ERROR_CODE_COLLECTION_FAILED,
 		)
 	}
 
 	if err := zipFile.Close(); err != nil {
 		log.Diagnostics.Error("failed to close zip file:", err)
-		if removeErr := os.Remove(zipPath); removeErr != nil {
-			log.Diagnostics.Error("failed to delete zip", removeErr)
-		}
-		return srv.Send(&pb.DiagnosticsProgress{
-			ErrorCode: pb.DiagnosticsErrorCode_DIAGNOSTICS_ERROR_CODE_FAILED_TO_CLOSE_ZIP,
-		})
+		return abortDiagnosticsWithCode(
+			zipFile,
+			outputRoot,
+			srv,
+			pb.DiagnosticsErrorCode_DIAGNOSTICS_ERROR_CODE_FAILED_TO_CLOSE_ZIP,
+		)
 	}
 
 	return srv.Send(&pb.DiagnosticsProgress{
@@ -134,26 +148,18 @@ func (r *RPC) CollectDiagnostics(
 // an error code on the stream.
 func abortDiagnosticsWithCode(
 	zipFile *os.File,
+	rootDir *os.Root,
 	srv pb.Daemon_CollectDiagnosticsServer,
 	code pb.DiagnosticsErrorCode,
 ) error {
 	_ = zipFile.Close()
-	if err := os.Remove(zipFile.Name()); err != nil {
+	// f.Name() returns the absolute path. root.Remove needs a relative path
+	if rel, err := filepath.Rel(rootDir.Name(), zipFile.Name()); err != nil {
+		log.Diagnostics.Error("failed to delete zip", err)
+	} else if err := rootDir.Remove(rel); err != nil {
 		log.Diagnostics.Error("failed to delete zip", err)
 	}
 	return srv.Send(&pb.DiagnosticsProgress{ErrorCode: code})
-}
-
-// createDiagnosticsZip atomically creates a uniquely-named diagnostics zip
-// inside outputDir. The filename embeds a second-precision timestamp plus a
-// random suffix from os.CreateTemp's `*` substitution, guaranteeing
-// different paths even for back-to-back calls within the same second.
-func createDiagnosticsZip(outputDir string) (*os.File, error) {
-	pattern := fmt.Sprintf(
-		"nordvpn-diagnostics-%s-*.zip",
-		time.Now().Format("20060102-150405"),
-	)
-	return os.CreateTemp(outputDir, pattern)
 }
 
 // appState bundles the daemon's view of itself for inclusion in
@@ -209,8 +215,7 @@ type diagnosticsCaller struct {
 
 // resolveDiagnosticsCaller extracts the caller's UID/GID from the gRPC
 // context, looks up their user record, and picks the directory where the
-// diagnostics zip will land. The actual filename is generated atomically by
-// os.CreateTemp at write time.
+// diagnostics zip will land.
 func resolveDiagnosticsCaller(ctx context.Context) (*diagnosticsCaller, error) {
 	cred, err := internal.UcredFromContext(ctx)
 	if err != nil {
@@ -1102,4 +1107,34 @@ func resolvectlStatus(logf logFunc) string {
 		return runCommand(logf, "systemd-resolve", "--status")
 	}
 	return runCommand(logf, "resolvectl", "status")
+}
+
+// createDiagnosticsFile - creates a unique file inside the `rootDir` directory
+func createDiagnosticsFile(rootDir *os.Root) (*os.File, error) {
+	prefix := fmt.Sprintf("nordvpn-diagnostics-%s", time.Now().Format("20060102-150405"))
+
+	name := prefix + ".zip"
+	f, err := rootDir.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, internal.PermUserRW)
+	if err == nil {
+		return f, nil
+	}
+
+	for i := 0; i < 1000; i++ {
+		var b [4]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			return nil, err
+		}
+
+		name := fmt.Sprintf("%s-%x.zip", prefix, b)
+
+		f, err := rootDir.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, internal.PermUserRW)
+
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return nil, err
+		}
+	}
+	return nil, errors.New("maximum retries reached")
 }

--- a/daemon/rpc_diagnostics.go
+++ b/daemon/rpc_diagnostics.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"os/user"
@@ -14,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
@@ -22,6 +24,7 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/snapconf"
 	"github.com/godbus/dbus/v5"
 	"github.com/snapcore/snapd/client"
+	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/encoding/prototext"
 )
 
@@ -89,9 +92,7 @@ func (r *RPC) CollectDiagnostics(
 	}
 
 	state := r.collectAppState(srv.Context())
-	if err := collectDiagnosticsData(
-		srv, zipFile, caller.user.HomeDir, state,
-	); err != nil {
+	if err := collectDiagnosticsData(srv, zipFile, caller, state); err != nil {
 		if errors.Is(err, errZipSizeLimitExceeded) {
 			log.Diagnostics.Error("diagnostics zip exceeded 40 MB limit")
 			return abortDiagnosticsWithCode(
@@ -314,7 +315,7 @@ type diagnosticsStep struct {
 func collectDiagnosticsData(
 	srv pb.Daemon_CollectDiagnosticsServer,
 	output io.Writer,
-	homeDir string,
+	caller *diagnosticsCaller,
 	state appState,
 ) error {
 	limited := &sizeLimitedWriter{w: output, limit: maxZipFileSize}
@@ -345,8 +346,13 @@ func collectDiagnosticsData(
 				// We are skipping it for now.
 				return nil
 			}
-			cliLog := filepath.Join(homeDir, ".config", "nordvpn", "cli.log")
-			return addFileToZip(zipWriter, cliLog, "cli.log")
+			homeRoot, err := os.OpenRoot(caller.user.HomeDir)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = homeRoot.Close() }()
+			cliLog := filepath.Join(".config", "nordvpn", "cli.log")
+			return addUserFileToZip(zipWriter, homeRoot, cliLog, "cli.log", caller.uid)
 		}, false},
 		{"Collecting user logs...", func() error {
 			if snapconf.IsUnderSnap() {
@@ -356,12 +362,17 @@ func collectDiagnosticsData(
 				// We are skipping it for now.
 				return nil
 			}
-			cacheDir := filepath.Join(homeDir, ".cache", "nordvpn")
-			if _, err := os.Stat(cacheDir); err != nil {
+			homeRoot, err := os.OpenRoot(caller.user.HomeDir)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = homeRoot.Close() }()
+			cacheDir := filepath.Join(".cache", "nordvpn")
+			if _, err := homeRoot.Stat(cacheDir); err != nil {
 				logf("%s: %v", cacheDir, err)
 				return nil
 			}
-			count, err := addDirectoryToZip(zipWriter, cacheDir, "cache")
+			count, err := addUserDirectoryToZip(zipWriter, homeRoot, cacheDir, "cache", caller.uid, logf)
 			if err != nil {
 				return err
 			}
@@ -716,6 +727,10 @@ func addFileToZip(zipWriter *zip.Writer, filePath, zipPath string) error {
 	}
 	defer file.Close() // nolint:errcheck
 
+	return writeOpenFileToZip(zipWriter, file, zipPath)
+}
+
+func writeOpenFileToZip(zipWriter *zip.Writer, file *os.File, zipPath string) error {
 	info, err := file.Stat()
 	if err != nil {
 		return err
@@ -735,6 +750,106 @@ func addFileToZip(zipWriter *zip.Writer, filePath, zipPath string) error {
 
 	_, err = io.Copy(writer, file)
 	return err
+}
+
+func openVerifiedUserFile(homeRoot *os.Root, relPath string, expectedUID uint32) (*os.File, error) {
+	file, err := homeRoot.OpenFile(relPath, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("%s: not a regular file", relPath)
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(file.Fd()), &stat); err != nil {
+		return nil, err
+	}
+
+	if stat.Uid != expectedUID {
+		_ = file.Close()
+		return nil, fmt.Errorf("%s: not owned by the requesting user", relPath)
+	}
+
+	return file, nil
+}
+
+func addUserFileToZip(
+	zipWriter *zip.Writer,
+	homeRoot *os.Root,
+	relPath, zipPath string,
+	expectedUID uint32,
+) error {
+	file, err := openVerifiedUserFile(homeRoot, relPath, expectedUID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	return writeOpenFileToZip(zipWriter, file, zipPath)
+}
+
+func addUserDirectoryToZip(
+	zipWriter *zip.Writer,
+	homeRoot *os.Root,
+	relDir, zipPrefix string,
+	expectedUID uint32,
+	logf logFunc,
+) (int, error) {
+	var count int
+	err := fs.WalkDir(homeRoot.FS(), relDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			logf("%s: %v", path, err)
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if d.Type()&fs.ModeSymlink != 0 {
+			logf("%s: skipping symlink", path)
+			return nil
+		}
+
+		relPath, err := filepath.Rel(relDir, path)
+		if err != nil {
+			logf("%s: %v", path, err)
+			return nil
+		}
+
+		zipPath := filepath.Join(zipPrefix, relPath)
+
+		file, err := openVerifiedUserFile(homeRoot, path, expectedUID)
+		if err != nil {
+			logf("%s: %v", path, err)
+			return nil
+		}
+		defer func() { _ = file.Close() }()
+
+		if err := writeOpenFileToZip(zipWriter, file, zipPath); err != nil {
+			if errors.Is(err, errZipSizeLimitExceeded) {
+				return err
+			}
+			logf("%s: %v", path, err)
+			return nil
+		}
+		count++
+
+		return nil
+	})
+	return count, err
 }
 
 // writeBlock appends a titled section to w in the form:

--- a/daemon/rpc_diagnostics_test.go
+++ b/daemon/rpc_diagnostics_test.go
@@ -982,20 +982,18 @@ func TestFailToExtractDaemonLogs(t *testing.T) {
 	assert.Contains(t, err.Error(), "support team")
 }
 
-// TestCreateDiagnosticsZip_UniqueFilename verifies that back-to-back calls
-// produce distinct paths even when they share the same second-precision
-// timestamp — the random suffix injected by os.CreateTemp's `*` is what
-// guarantees uniqueness, so two collections in the same second cannot
-// clobber each other's output.
-func TestCreateDiagnosticsZip_UniqueFilename(t *testing.T) {
+func TestCreateDiagnosticsFile_UniqueFilename(t *testing.T) {
 	category.Set(t, category.Unit)
 
 	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	require.NotNil(t, root)
 
 	const N = 5
 	seen := make(map[string]bool, N)
 	for i := range N {
-		f, err := createDiagnosticsZip(dir)
+		f, err := createDiagnosticsFile(root)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 

--- a/daemon/rpc_diagnostics_test.go
+++ b/daemon/rpc_diagnostics_test.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/test/category"
@@ -360,6 +362,418 @@ func TestAddDirectoryToZip_SymlinksSkipped(t *testing.T) {
 	assert.Len(t, entries, 1)
 }
 
+func TestOpenVerifiedUserFile(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	uid := uint32(os.Getuid())
+
+	tests := []struct {
+		name string
+		// setup prepares a home directory and returns the *os.Root anchored
+		// at it, the relative path to open, and the uid to require
+		setup         func(t *testing.T) (root *os.Root, relPath string, expectedUID uint32)
+		expectErr     bool
+		expectContent string
+	}{
+		{
+			name: "regular file owned by the expected uid succeeds",
+			setup: func(t *testing.T) (*os.Root, string, uint32) {
+				home := t.TempDir()
+				dir := filepath.Join(home, ".config", "nordvpn")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "cli.log"), []byte("hello"), 0o600))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "nordvpn", "cli.log"), uid
+			},
+			expectContent: "hello",
+		},
+		{
+			// Mirrors the reported PoC: cli.log replaced with a symlink to
+			// a file the caller cannot read directly.
+			name: "rejects a symlink to a file outside home",
+			setup: func(t *testing.T) (*os.Root, string, uint32) {
+				home := t.TempDir()
+				outside := t.TempDir()
+				secret := filepath.Join(outside, "root-only-secret")
+				require.NoError(t, os.WriteFile(secret, []byte("ROOT-ONLY-SENTINEL"), 0o600))
+
+				dir := filepath.Join(home, ".config", "nordvpn")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.Symlink(secret, filepath.Join(dir, "cli.log")))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "nordvpn", "cli.log"), uid
+			},
+			expectErr: true,
+		},
+		{
+			name: "rejects a symlink even to a file inside home",
+			setup: func(t *testing.T) (*os.Root, string, uint32) {
+				home := t.TempDir()
+				other := filepath.Join(home, "other.txt")
+				require.NoError(t, os.WriteFile(other, []byte("other"), 0o600))
+
+				dir := filepath.Join(home, ".config", "nordvpn")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.Symlink(other, filepath.Join(dir, "cli.log")))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "nordvpn", "cli.log"), uid
+			},
+			expectErr: true,
+		},
+		{
+			// Attacker replaces ~/.config itself with a symlink pointing
+			// outside home.
+			name: "rejects an intermediate path component that symlinks out of home",
+			setup: func(t *testing.T) (*os.Root, string, uint32) {
+				home := t.TempDir()
+				outside := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(outside, "cli.log"), []byte("x"), 0o600))
+				require.NoError(t, os.Symlink(outside, filepath.Join(home, ".config")))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "cli.log"), uid
+			},
+			expectErr: true,
+		},
+		{
+			name: "rejects a file not owned by the expected uid",
+			setup: func(t *testing.T) (*os.Root, string, uint32) {
+				home := t.TempDir()
+				dir := filepath.Join(home, ".config", "nordvpn")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "cli.log"), []byte("hello"), 0o600))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "nordvpn", "cli.log"), uid + 12345
+			},
+			expectErr: true,
+		},
+		{
+			name: "rejects a directory",
+			setup: func(t *testing.T) (*os.Root, string, uint32) {
+				home := t.TempDir()
+				dir := filepath.Join(home, ".config", "nordvpn")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "nordvpn"), uid
+			},
+			expectErr: true,
+		},
+		{
+			name: "rejects a FIFO without blocking",
+			setup: func(t *testing.T) (*os.Root, string, uint32) {
+				home := t.TempDir()
+				require.NoError(t, syscall.Mkfifo(filepath.Join(home, "cli.log"), 0o600))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, "cli.log", uid
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, relPath, expectedUID := tc.setup(t)
+
+			type result struct {
+				file *os.File
+				err  error
+			}
+			done := make(chan result, 1)
+			go func() {
+				f, err := openVerifiedUserFile(root, relPath, expectedUID)
+				done <- result{f, err}
+			}()
+
+			var res result
+			select {
+			case res = <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatal("openVerifiedUserFile did not return in time (blocking open?)")
+			}
+
+			if tc.expectErr {
+				assert.Error(t, res.err)
+				return
+			}
+			require.NoError(t, res.err)
+			defer func() { _ = res.file.Close() }()
+
+			data, err := io.ReadAll(res.file)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectContent, string(data))
+		})
+	}
+}
+
+func TestAddUserFileToZip_RegressionRootFileDisclosure(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	uid := uint32(os.Getuid())
+	home := t.TempDir()
+	rootOnlyDir := t.TempDir()
+	sentinel := filepath.Join(rootOnlyDir, "root-only-sentinel")
+	require.NoError(t, os.WriteFile(sentinel, []byte("ROOT-ONLY-SENTINEL"), 0o600))
+
+	dir := filepath.Join(home, ".config", "nordvpn")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.Symlink(sentinel, filepath.Join(dir, "cli.log")))
+
+	root, err := os.OpenRoot(home)
+	require.NoError(t, err)
+	defer func() { _ = root.Close() }()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	err = addUserFileToZip(zw, root, filepath.Join(".config", "nordvpn", "cli.log"), "cli.log", uid)
+	assert.Error(t, err, "the daemon must refuse to follow a symlinked cli.log")
+	require.NoError(t, zw.Close())
+
+	entries := readZipEntries(t, buf.Bytes())
+	assert.NotContains(t, entries, "cli.log")
+	for _, content := range entries {
+		assert.NotContains(t, content, "ROOT-ONLY-SENTINEL")
+	}
+}
+
+func TestAddUserFileToZip(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	uid := uint32(os.Getuid())
+
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T) (root *os.Root, relPath string)
+		expectErr   bool
+		expectEntry string
+	}{
+		{
+			name: "adds a genuine file",
+			setup: func(t *testing.T) (*os.Root, string) {
+				home := t.TempDir()
+				dir := filepath.Join(home, ".config", "nordvpn")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "cli.log"), []byte("log-content"), 0o600))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "nordvpn", "cli.log")
+			},
+			expectEntry: "log-content",
+		},
+		{
+			name: "missing file returns error",
+			setup: func(t *testing.T) (*os.Root, string) {
+				root, err := os.OpenRoot(t.TempDir())
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".config", "nordvpn", "cli.log")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, relPath := tc.setup(t)
+			var buf bytes.Buffer
+			zw := zip.NewWriter(&buf)
+			err := addUserFileToZip(zw, root, relPath, "cli.log", uid)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, zw.Close())
+
+			entries := readZipEntries(t, buf.Bytes())
+			assert.Equal(t, tc.expectEntry, entries["cli.log"])
+		})
+	}
+}
+
+func TestAddUserDirectoryToZip(t *testing.T) {
+	category.Set(t, category.Unit)
+
+	uid := uint32(os.Getuid())
+
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T) (root *os.Root, relDir string)
+		expectErr     bool
+		expectCount   int
+		expectEntries map[string]string // zip entry name -> expected content
+		expectAbsent  []string
+		expectLogged  string
+	}{
+		{
+			name: "copies regular files and skips symlinks",
+			setup: func(t *testing.T) (*os.Root, string) {
+				home := t.TempDir()
+				cacheDir := filepath.Join(home, ".cache", "nordvpn")
+				require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "real.txt"), []byte("real"), 0o600))
+
+				outside := t.TempDir()
+				secret := filepath.Join(outside, "secret")
+				require.NoError(t, os.WriteFile(secret, []byte("secret"), 0o600))
+				require.NoError(t, os.Symlink(secret, filepath.Join(cacheDir, "link.txt")))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".cache", "nordvpn")
+			},
+			expectCount:   1,
+			expectEntries: map[string]string{"cache/real.txt": "real"},
+			expectAbsent:  []string{"cache/link.txt"},
+			expectLogged:  "link.txt",
+		},
+		{
+			name: "logs and collects nothing when the directory itself escapes home, without erroring",
+			setup: func(t *testing.T) (*os.Root, string) {
+				home := t.TempDir()
+				outside := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(outside, "leaked.txt"), []byte("leaked"), 0o600))
+				require.NoError(t, os.Symlink(outside, filepath.Join(home, ".cache")))
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".cache", "nordvpn")
+			},
+			expectCount:  0,
+			expectAbsent: []string{"cache/leaked.txt"},
+			expectLogged: "escapes",
+		},
+		{
+			name: "skips a non-regular file but keeps collecting siblings",
+			setup: func(t *testing.T) (*os.Root, string) {
+				home := t.TempDir()
+				cacheDir := filepath.Join(home, ".cache", "nordvpn")
+				require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "a.txt"), []byte("a"), 0o600))
+				require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "z.txt"), []byte("z"), 0o600))
+
+				l, err := net.Listen("unix", filepath.Join(cacheDir, "m.sock"))
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = l.Close() })
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".cache", "nordvpn")
+			},
+			expectCount: 2,
+			expectEntries: map[string]string{
+				"cache/a.txt": "a",
+				"cache/z.txt": "z",
+			},
+			expectAbsent: []string{"cache/m.sock"},
+			expectLogged: "m.sock",
+		},
+		{
+			name: "skips an unreadable subdirectory but keeps collecting siblings",
+			setup: func(t *testing.T) (*os.Root, string) {
+				if os.Getuid() == 0 {
+					t.Skip("permission checks don't apply when running as root")
+				}
+				home := t.TempDir()
+				cacheDir := filepath.Join(home, ".cache", "nordvpn")
+				require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "a.txt"), []byte("a"), 0o600))
+				require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "z.txt"), []byte("z"), 0o600))
+
+				badDir := filepath.Join(cacheDir, "n_bad")
+				require.NoError(t, os.MkdirAll(badDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(badDir, "hidden.txt"), []byte("hidden"), 0o600))
+				require.NoError(t, os.Chmod(badDir, 0o000))
+				t.Cleanup(func() { _ = os.Chmod(badDir, 0o755) }) // let TempDir cleanup remove it
+
+				root, err := os.OpenRoot(home)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = root.Close() })
+
+				return root, filepath.Join(".cache", "nordvpn")
+			},
+			expectCount: 2,
+			expectEntries: map[string]string{
+				"cache/a.txt": "a",
+				"cache/z.txt": "z",
+			},
+			expectAbsent: []string{"cache/n_bad/hidden.txt"},
+			expectLogged: "n_bad",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, relDir := tc.setup(t)
+			var buf bytes.Buffer
+			zw := zip.NewWriter(&buf)
+			logf, lines := capturingLogf()
+			count, err := addUserDirectoryToZip(zw, root, relDir, "cache", uid, logf)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectCount, count)
+			}
+			require.NoError(t, zw.Close())
+
+			entries := readZipEntries(t, buf.Bytes())
+			for name, content := range tc.expectEntries {
+				assert.Equal(t, content, entries[name])
+			}
+			for _, name := range tc.expectAbsent {
+				assert.NotContains(t, entries, name)
+			}
+			if tc.expectLogged != "" {
+				found := false
+				for _, line := range *lines {
+					if strings.Contains(line, tc.expectLogged) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected a log line containing %q, got %v", tc.expectLogged, *lines)
+			}
+		})
+	}
+}
+
 func TestWriteLogExtractionReport(t *testing.T) {
 	category.Set(t, category.Unit)
 
@@ -463,14 +877,14 @@ func TestStreamFileToWriter_RespectsDaemonLogCap(t *testing.T) {
 	path := filepath.Join(t.TempDir(), uuid.NewString()+".log")
 	// 1 KiB of recognisable lines: 100 lines × ~10 bytes each.
 	var content bytes.Buffer
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		fmt.Fprintf(&content, "line %03d\n", i) // 9 bytes/line incl. newline
 	}
 	require.NoError(t, os.WriteFile(path, content.Bytes(), 0o600))
 
 	f, err := os.Open(path)
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	info, err := f.Stat()
 	require.NoError(t, err)
 
@@ -531,7 +945,7 @@ func TestAddDaemonLogs_StdoutAsRegularFile(t *testing.T) {
 
 	logFile, err := os.OpenFile(logPath, os.O_RDWR, 0o600)
 	require.NoError(t, err)
-	t.Cleanup(func() { logFile.Close() })
+	t.Cleanup(func() { _ = logFile.Close() })
 
 	// Save fd 1 so we can restore it; point fd 1 at logFile so
 	// /proc/self/fd/1 symlinks to logPath for the duration of this test.
@@ -542,7 +956,7 @@ func TestAddDaemonLogs_StdoutAsRegularFile(t *testing.T) {
 		if err := syscall.Dup3(savedFD, 1, 0); err != nil {
 			t.Errorf("failed to restore fd 1: %v", err)
 		}
-		syscall.Close(savedFD)
+		_ = syscall.Close(savedFD)
 	})
 
 	var zbuf bytes.Buffer
@@ -580,7 +994,7 @@ func TestCreateDiagnosticsZip_UniqueFilename(t *testing.T) {
 
 	const N = 5
 	seen := make(map[string]bool, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		f, err := createDiagnosticsZip(dir)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
@@ -622,7 +1036,7 @@ func readZipEntries(t *testing.T, data []byte) map[string]string {
 		rc, err := f.Open()
 		require.NoError(t, err)
 		content, err := io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		require.NoError(t, err)
 		out[f.Name] = string(content)
 	}


### PR DESCRIPTION
Changes:

- `openVerifiedUserFile()` opens only files relative to user home dir root, which is opened based on UID, this function does not follow symlinks and double checks if the file UID matches the expected one
- `addUserFileToZip()` uses func above to add file to zip
- `addUserDirectoryToZip()` walks FS rooted at verified home user dir, adds only non-symlink files relative to the root 
- the funcs above are used for accessing cli and norduserd logs
- tests
- cleanup