### PR TITLE
LVPN-11040: fix ruster docker image for open source build

### DIFF
--- a/ci/docker/ruster/Dockerfile
+++ b/ci/docker/ruster/Dockerfile
@@ -19,6 +19,7 @@ RUN set -eux; \
         ca-certificates \
         curl \
         gcc \
+        cmake make clang \
         libc6-dev \
         wget \
         unzip \

--- a/magefiles/mage.go
+++ b/magefiles/mage.go
@@ -30,7 +30,7 @@ const (
 	imageScanner           = registryPrefix + "scanner:1.1.0"
 	imageTester            = registryPrefix + "tester:1.6.5"
 	imageQAPeer            = registryPrefix + "qa-peer:1.0.5"
-	imageRuster            = registryPrefix + "ruster:1.4.1"
+	imageRuster            = registryPrefix + "ruster:1.4.2"
 	imageCodeQL            = registryPrefix + "codeql:1.0.0"
 
 	dockerWorkDir    = "/opt"


### PR DESCRIPTION
LVPN-11040: fix ruster docker image for open source build