### PR TITLE
LVPN-10980: add rule to block non vpn source packets

### DIFF
--- a/daemon/firewall/nft/match_expr.go
+++ b/daemon/firewall/nft/match_expr.go
@@ -276,6 +276,42 @@ func checkCtOriginalSrcIP(ip netip.Addr) []expr.Any {
 	}
 }
 
+// ip saddr != 10.3.0.2
+func checkIPIsNotEqual(addr netip.Addr, match matchType) []expr.Any {
+	var offset uint32 = 12
+	if match == matchDest {
+		offset = 16
+	}
+
+	networkAddr := addr.As4()
+
+	return []expr.Any{
+		&expr.Meta{
+			Key:      expr.MetaKeyNFPROTO,
+			Register: 1,
+		},
+		&expr.Cmp{
+			Register: 1,
+			Op:       expr.CmpOpEq,
+			Data:     []byte{unix.NFPROTO_IPV4},
+		},
+
+		// Load IPv4 address
+		&expr.Payload{
+			DestRegister: 1,
+			Base:         expr.PayloadBaseNetworkHeader,
+			Offset:       offset, // IPv4 saddr
+			Len:          4,
+		},
+
+		&expr.Cmp{
+			Register: 1,
+			Op:       expr.CmpOpNeq,
+			Data:     networkAddr[:],
+		},
+	}
+}
+
 // ip saddr 100.64.0.0/10
 func checkIPIsPartOfSubnet(pfx netip.Prefix, match matchType, op expr.CmpOp) []expr.Any {
 	var offset uint32 = 12

--- a/daemon/firewall/nft/nft.go
+++ b/daemon/firewall/nft/nft.go
@@ -314,6 +314,20 @@ func (n *nft) addOutputChain(config firewall.Config, nftCtx *nftContext) {
 		})
 	}
 
+	if config.TunnelIP.IsValid() && len(config.TunnelInterface) > 0 {
+		// oifname <tun interface> ip saddr != <tun ip> drop
+		n.conn.AddRule(&nftables.Rule{
+			Table: nftCtx.table,
+			Chain: outputChain,
+			Exprs: buildRules(
+				&expr.Verdict{Kind: expr.VerdictDrop},
+				checkInterfaceName(config.TunnelInterface, ifNameOutput, expr.CmpOpEq),
+				checkIPIsNotEqual(config.TunnelIP, matchSource),
+			),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, "Drop non tunnel source ip packets that are going through tunnel interface"),
+		})
+	}
+
 	if len(config.TunnelInterface) > 0 {
 		// oif "nordtun" accept
 		n.conn.AddRule(&nftables.Rule{

--- a/daemon/firewall/nft/nft_snapshot_test.go
+++ b/daemon/firewall/nft/nft_snapshot_test.go
@@ -17,6 +17,7 @@ const (
 )
 
 var selfMeshIP = netip.MustParseAddr("100.64.0.1")
+var tunnelIP = netip.MustParseAddr("10.5.0.2")
 
 func TestVPNRuleset(t *testing.T) {
 	tests := []struct {
@@ -33,30 +34,31 @@ func TestVPNRuleset(t *testing.T) {
 		},
 		{
 			name:   "vpn only",
-			config: helpers.NewFWConfig().TunnelInterface(ifName),
+			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP),
 		},
 		{
 			name:   "vpn and kill switch",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).KillSwitch(),
+			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).KillSwitch(),
 		},
 		{
 			name:   "tcp port allowlisted",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).AllowlistTCPPort(1337),
+			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).AllowlistTCPPort(1337),
 		},
 		{
 			name:   "udp port allowlisted",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).AllowlistUDPPort(8080),
+			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).AllowlistUDPPort(8080),
 		},
 		{
 			name: "DNS port allowlisted for both protocols",
 			config: helpers.NewFWConfig().
 				TunnelInterface(ifName).
+				TunnelIP(tunnelIP).
 				AllowlistUDPPort(53).
 				AllowlistTCPPort(53),
 		},
 		{
 			name:   "subnet allowlisted",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).AllowlistSubnet("10.0.0.0/24"),
+			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).AllowlistSubnet("10.0.0.0/24"),
 		},
 	}
 

--- a/daemon/firewall/nft/nft_snapshot_test.go
+++ b/daemon/firewall/nft/nft_snapshot_test.go
@@ -34,31 +34,30 @@ func TestVPNRuleset(t *testing.T) {
 		},
 		{
 			name:   "vpn only",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP),
+			config: helpers.NewFWConfig().TunnelInterface(ifName, tunnelIP),
 		},
 		{
 			name:   "vpn and kill switch",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).KillSwitch(),
+			config: helpers.NewFWConfig().TunnelInterface(ifName, tunnelIP).KillSwitch(),
 		},
 		{
 			name:   "tcp port allowlisted",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).AllowlistTCPPort(1337),
+			config: helpers.NewFWConfig().TunnelInterface(ifName, tunnelIP).AllowlistTCPPort(1337),
 		},
 		{
 			name:   "udp port allowlisted",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).AllowlistUDPPort(8080),
+			config: helpers.NewFWConfig().TunnelInterface(ifName, tunnelIP).AllowlistUDPPort(8080),
 		},
 		{
 			name: "DNS port allowlisted for both protocols",
 			config: helpers.NewFWConfig().
-				TunnelInterface(ifName).
-				TunnelIP(tunnelIP).
+				TunnelInterface(ifName, tunnelIP).
 				AllowlistUDPPort(53).
 				AllowlistTCPPort(53),
 		},
 		{
 			name:   "subnet allowlisted",
-			config: helpers.NewFWConfig().TunnelInterface(ifName).TunnelIP(tunnelIP).AllowlistSubnet("10.0.0.0/24"),
+			config: helpers.NewFWConfig().TunnelInterface(ifName, tunnelIP).AllowlistSubnet("10.0.0.0/24"),
 		},
 	}
 

--- a/daemon/firewall/nft/testdata/TestVPNRuleset/DNS_port_allowlisted_for_both_protocols.golden
+++ b/daemon/firewall/nft/testdata/TestVPNRuleset/DNS_port_allowlisted_for_both_protocols.golden
@@ -38,6 +38,7 @@ table inet nordvpn {
 		meta mark 0x0000e1f1 ct mark set meta mark accept comment "mark connection for socket with SO_MARK"
 		tcp sport @tcp_allowlist meta mark set 0x0000e1f1 accept comment "from allowlist TCP ports"
 		udp sport @udp_allowlist meta mark set 0x0000e1f1 accept comment "from allowlist UDP ports"
+		oifname "nordlynx" ip saddr != 10.5.0.2 drop comment "Drop non tunnel source ip packets that are going through tunnel interface"
 		oifname "nordlynx" accept comment "local to VPN"
 	}
 

--- a/daemon/firewall/nft/testdata/TestVPNRuleset/subnet_allowlisted.golden
+++ b/daemon/firewall/nft/testdata/TestVPNRuleset/subnet_allowlisted.golden
@@ -32,6 +32,7 @@ table inet nordvpn {
 		ip daddr @lan_ranges tcp dport 53 drop comment "block to LAN DNS for TCP"
 		ip daddr @lan_ranges udp dport 53 drop comment "block to LAN DNS for UDP"
 		ip daddr @allowlist_subnets meta mark set 0x0000e1f1 accept comment "local to allowlist IPs"
+		oifname "nordlynx" ip saddr != 10.5.0.2 drop comment "Drop non tunnel source ip packets that are going through tunnel interface"
 		oifname "nordlynx" accept comment "local to VPN"
 	}
 

--- a/daemon/firewall/nft/testdata/TestVPNRuleset/tcp_port_allowlisted.golden
+++ b/daemon/firewall/nft/testdata/TestVPNRuleset/tcp_port_allowlisted.golden
@@ -32,6 +32,7 @@ table inet nordvpn {
 		ip daddr @lan_ranges tcp dport 53 drop comment "block to LAN DNS for TCP"
 		ip daddr @lan_ranges udp dport 53 drop comment "block to LAN DNS for UDP"
 		tcp sport @tcp_allowlist meta mark set 0x0000e1f1 accept comment "from allowlist TCP ports"
+		oifname "nordlynx" ip saddr != 10.5.0.2 drop comment "Drop non tunnel source ip packets that are going through tunnel interface"
 		oifname "nordlynx" accept comment "local to VPN"
 	}
 

--- a/daemon/firewall/nft/testdata/TestVPNRuleset/udp_port_allowlisted.golden
+++ b/daemon/firewall/nft/testdata/TestVPNRuleset/udp_port_allowlisted.golden
@@ -32,6 +32,7 @@ table inet nordvpn {
 		ip daddr @lan_ranges tcp dport 53 drop comment "block to LAN DNS for TCP"
 		ip daddr @lan_ranges udp dport 53 drop comment "block to LAN DNS for UDP"
 		udp sport @udp_allowlist meta mark set 0x0000e1f1 accept comment "from allowlist UDP ports"
+		oifname "nordlynx" ip saddr != 10.5.0.2 drop comment "Drop non tunnel source ip packets that are going through tunnel interface"
 		oifname "nordlynx" accept comment "local to VPN"
 	}
 

--- a/daemon/firewall/nft/testdata/TestVPNRuleset/vpn_and_kill_switch.golden
+++ b/daemon/firewall/nft/testdata/TestVPNRuleset/vpn_and_kill_switch.golden
@@ -20,6 +20,7 @@ table inet nordvpn {
 		meta mark 0x0000e1f1 ct mark set meta mark accept comment "mark connection for socket with SO_MARK"
 		ip daddr @lan_ranges tcp dport 53 drop comment "block to LAN DNS for TCP"
 		ip daddr @lan_ranges udp dport 53 drop comment "block to LAN DNS for UDP"
+		oifname "nordlynx" ip saddr != 10.5.0.2 drop comment "Drop non tunnel source ip packets that are going through tunnel interface"
 		oifname "nordlynx" accept comment "local to VPN"
 	}
 

--- a/daemon/firewall/nft/testdata/TestVPNRuleset/vpn_only.golden
+++ b/daemon/firewall/nft/testdata/TestVPNRuleset/vpn_only.golden
@@ -20,6 +20,7 @@ table inet nordvpn {
 		meta mark 0x0000e1f1 ct mark set meta mark accept comment "mark connection for socket with SO_MARK"
 		ip daddr @lan_ranges tcp dport 53 drop comment "block to LAN DNS for TCP"
 		ip daddr @lan_ranges udp dport 53 drop comment "block to LAN DNS for UDP"
+		oifname "nordlynx" ip saddr != 10.5.0.2 drop comment "Drop non tunnel source ip packets that are going through tunnel interface"
 		oifname "nordlynx" accept comment "local to VPN"
 	}
 

--- a/daemon/firewall/service.go
+++ b/daemon/firewall/service.go
@@ -42,7 +42,8 @@ func NewConfig(opts ...Option) Config {
 func (c *Config) HasSimilarMeshInfo(cfg *Config) bool {
 	return c.MeshnetInfo != nil &&
 		cfg.MeshnetInfo != nil &&
-		c.MeshnetInfo.IsSimilar(cfg.MeshnetInfo)
+		c.MeshnetInfo.IsSimilar(cfg.MeshnetInfo) &&
+		c.TunnelIP == cfg.TunnelIP
 }
 
 type MeshInfo struct {
@@ -120,9 +121,10 @@ func WithAllowlist(allowlist config.Allowlist) Option {
 	}
 }
 
-func WithTunnelInterface(tunnelInterface string) Option {
+func WithTunnelInterface(tunnelInterface string, tunnelIP netip.Addr) Option {
 	return func(c *Config) {
 		c.TunnelInterface = tunnelInterface
+		c.TunnelIP = tunnelIP
 	}
 }
 

--- a/daemon/firewall/service.go
+++ b/daemon/firewall/service.go
@@ -1,6 +1,7 @@
 package firewall
 
 import (
+	"net/netip"
 	"slices"
 
 	"github.com/NordSecurity/nordvpn-linux/config"
@@ -25,6 +26,7 @@ type FirewallBackend interface {
 // Config keeps all the information needed to configure the firewall
 type Config struct {
 	TunnelInterface string
+	TunnelIP        netip.Addr
 	Allowlist       config.Allowlist
 	KillSwitch      bool
 	// is controlled by the fileshare process monitoring
@@ -121,6 +123,12 @@ func WithAllowlist(allowlist config.Allowlist) Option {
 func WithTunnelInterface(tunnelInterface string) Option {
 	return func(c *Config) {
 		c.TunnelInterface = tunnelInterface
+	}
+}
+
+func WithTunnelIP(tunnelIP netip.Addr) Option {
+	return func(c *Config) {
+		c.TunnelIP = tunnelIP
 	}
 }
 

--- a/daemon/firewall/service_test.go
+++ b/daemon/firewall/service_test.go
@@ -19,6 +19,7 @@ func TestConfigOptions(t *testing.T) {
 	meshInfo := NewMeshInfo(mesh.MachineMap{}, "nordlynx")
 	fullConfig := Config{
 		TunnelInterface: "test",
+		TunnelIP:        netip.AddrFrom4([4]byte{10, 5, 0, 2}),
 		KillSwitch:      true,
 		BlockFileshare:  true,
 		Allowlist:       allowlist,
@@ -32,8 +33,8 @@ func TestConfigOptions(t *testing.T) {
 	}{
 		{
 			name:     "tunnel interface changes",
-			options:  []Option{WithTunnelInterface("test")},
-			expected: Config{TunnelInterface: "test"},
+			options:  []Option{WithTunnelInterface("test", netip.MustParseAddr("10.5.0.2"))},
+			expected: Config{TunnelInterface: "test", TunnelIP: netip.AddrFrom4([4]byte{10, 5, 0, 2})},
 		},
 		{
 			name:     "KillSwitch interface changes",
@@ -58,7 +59,7 @@ func TestConfigOptions(t *testing.T) {
 		{
 			name: "combine all members works",
 			options: []Option{
-				WithTunnelInterface("test"),
+				WithTunnelInterface("test", netip.MustParseAddr("10.5.0.2")),
 				WithKillSwitch(true),
 				WithBlockFileshare(true),
 				WithAllowlist(allowlist),

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -257,6 +257,7 @@ func failureRecover(netw *Combined) {
 
 	cfg := netw.fwConfig.CopyWith(
 		firewall.WithTunnelInterface(""),
+		firewall.WithTunnelIP(netip.Addr{}),
 	)
 	if err := netw.configureFirewall(cfg); err != nil {
 		log.Error(err)
@@ -340,12 +341,14 @@ func (netw *Combined) start(
 	}
 
 	tunnelInterface := netw.vpnet.Tun().Interface().Name
+	tunnelIP, _ := netw.vpnet.Tun().IP()
 	// configure firewall
 	// update tunnel name and allowlist
 	// use netw.allowlist because it is populated in setAllowlist and there will be
 	// updated to also contain LAN addresses for LAN discovery enabled
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithTunnelInterface(tunnelInterface),
+		firewall.WithTunnelIP(tunnelIP),
 		firewall.WithAllowlist(netw.allowlist),
 	)
 	if err := netw.configureFirewall(newCfg); err != nil {
@@ -480,8 +483,10 @@ func (netw *Combined) restart(
 
 	// configure firewall
 	// update only the interface name, in case there is a different VPN technology used
+	tunnelIP, _ := netw.vpnet.Tun().IP()
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithTunnelInterface(netw.vpnet.Tun().Interface().Name),
+		firewall.WithTunnelIP(tunnelIP),
 	)
 	if err := netw.configureFirewall(newCfg); err != nil {
 		return fmt.Errorf("configuring firewall: %w", err)
@@ -559,6 +564,7 @@ func (netw *Combined) stop() error {
 	// configure firewall
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithTunnelInterface(""),
+		firewall.WithTunnelIP(netip.Addr{}),
 	)
 	if err := netw.configureFirewall(newCfg); err != nil {
 		return fmt.Errorf("configuring firewall at stop: %w", err)
@@ -1044,6 +1050,7 @@ func (netw *Combined) setMesh(
 	// configure firewall
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithMeshnetInfo(firewall.NewMeshInfo(netw.cfg, netw.mesh.Tun().Interface().Name)),
+		firewall.WithTunnelIP(self),
 	)
 	if !netw.fwConfig.HasSimilarMeshInfo(&newCfg) {
 		if err := netw.configureFirewall(newCfg); err != nil {

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -1041,19 +1041,18 @@ func (netw *Combined) setMesh(
 	if err := netw.ipForwardSetter.Set(); err != nil {
 		return fmt.Errorf("IP forwarding setting: %w", err)
 	}
-	// If nordlynx was used as vpnet, the interface will change IP, we refresh it here
-	var tunnelIP, ok = netip.Addr{}, false
-	if netw.isVpnSet {
-		tunnelIP, ok = netw.vpnet.Tun().IP()
-	}
 	// configure firewall
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithMeshnetInfo(firewall.NewMeshInfo(netw.cfg, netw.mesh.Tun().Interface().Name)),
 	)
-	if ok {
-		newCfg = newCfg.CopyWith(
-			firewall.WithTunnelIP(tunnelIP),
-		)
+	// If nordlynx was used as vpnet, the interface will change IP, we refresh it here
+	var tunnelIP, ok = netip.Addr{}, false
+	if netw.isVpnSet {
+		if tunnelIP, ok = netw.vpnet.Tun().IP(); ok {
+			newCfg = newCfg.CopyWith(
+				firewall.WithTunnelIP(tunnelIP),
+			)
+		}
 	}
 
 	if !netw.fwConfig.HasSimilarMeshInfo(&newCfg) {

--- a/networker/networker.go
+++ b/networker/networker.go
@@ -256,8 +256,7 @@ func failureRecover(netw *Combined) {
 	}
 
 	cfg := netw.fwConfig.CopyWith(
-		firewall.WithTunnelInterface(""),
-		firewall.WithTunnelIP(netip.Addr{}),
+		firewall.WithTunnelInterface("", netip.Addr{}),
 	)
 	if err := netw.configureFirewall(cfg); err != nil {
 		log.Error(err)
@@ -347,8 +346,7 @@ func (netw *Combined) start(
 	// use netw.allowlist because it is populated in setAllowlist and there will be
 	// updated to also contain LAN addresses for LAN discovery enabled
 	newCfg := netw.fwConfig.CopyWith(
-		firewall.WithTunnelInterface(tunnelInterface),
-		firewall.WithTunnelIP(tunnelIP),
+		firewall.WithTunnelInterface(tunnelInterface, tunnelIP),
 		firewall.WithAllowlist(netw.allowlist),
 	)
 	if err := netw.configureFirewall(newCfg); err != nil {
@@ -485,8 +483,7 @@ func (netw *Combined) restart(
 	// update only the interface name, in case there is a different VPN technology used
 	tunnelIP, _ := netw.vpnet.Tun().IP()
 	newCfg := netw.fwConfig.CopyWith(
-		firewall.WithTunnelInterface(netw.vpnet.Tun().Interface().Name),
-		firewall.WithTunnelIP(tunnelIP),
+		firewall.WithTunnelInterface(netw.vpnet.Tun().Interface().Name, tunnelIP),
 	)
 	if err := netw.configureFirewall(newCfg); err != nil {
 		return fmt.Errorf("configuring firewall: %w", err)
@@ -563,8 +560,7 @@ func (netw *Combined) stop() error {
 
 	// configure firewall
 	newCfg := netw.fwConfig.CopyWith(
-		firewall.WithTunnelInterface(""),
-		firewall.WithTunnelIP(netip.Addr{}),
+		firewall.WithTunnelInterface("", netip.Addr{}),
 	)
 	if err := netw.configureFirewall(newCfg); err != nil {
 		return fmt.Errorf("configuring firewall at stop: %w", err)
@@ -925,7 +921,6 @@ func (netw *Combined) Refresh(c mesh.MachineMap) error {
 		if err := netw.ipForwardSetter.Set(); err != nil {
 			return fmt.Errorf("IP forwarding enabling: %w", err)
 		}
-
 		// configure firewall
 		newCfg := netw.fwConfig.CopyWith(
 			firewall.WithMeshnetInfo(firewall.NewMeshInfo(netw.cfg, netw.mesh.Tun().Interface().Name)),
@@ -1046,12 +1041,21 @@ func (netw *Combined) setMesh(
 	if err := netw.ipForwardSetter.Set(); err != nil {
 		return fmt.Errorf("IP forwarding setting: %w", err)
 	}
-
+	// If nordlynx was used as vpnet, the interface will change IP, we refresh it here
+	var tunnelIP, ok = netip.Addr{}, false
+	if netw.isVpnSet {
+		tunnelIP, ok = netw.vpnet.Tun().IP()
+	}
 	// configure firewall
 	newCfg := netw.fwConfig.CopyWith(
 		firewall.WithMeshnetInfo(firewall.NewMeshInfo(netw.cfg, netw.mesh.Tun().Interface().Name)),
-		firewall.WithTunnelIP(self),
 	)
+	if ok {
+		newCfg = newCfg.CopyWith(
+			firewall.WithTunnelIP(tunnelIP),
+		)
+	}
+
 	if !netw.fwConfig.HasSimilarMeshInfo(&newCfg) {
 		if err := netw.configureFirewall(newCfg); err != nil {
 			return fmt.Errorf("configure firewall for set meshnet: %w", err)

--- a/test/helpers/fw_config_builder.go
+++ b/test/helpers/fw_config_builder.go
@@ -26,6 +26,11 @@ func (b *FirewallConfigBuilder) TunnelInterface(iface string) *FirewallConfigBui
 	return b
 }
 
+func (b *FirewallConfigBuilder) TunnelIP(ip netip.Addr) *FirewallConfigBuilder {
+	b.cfg.TunnelIP = ip
+	return b
+}
+
 func (b *FirewallConfigBuilder) AllowlistTCPPort(port int64) *FirewallConfigBuilder {
 	if b.cfg.Allowlist.Ports.TCP == nil {
 		b.cfg.Allowlist.Ports.TCP = config.PortSet{}

--- a/test/helpers/fw_config_builder.go
+++ b/test/helpers/fw_config_builder.go
@@ -21,8 +21,9 @@ func (b *FirewallConfigBuilder) KillSwitch() *FirewallConfigBuilder {
 	return b
 }
 
-func (b *FirewallConfigBuilder) TunnelInterface(iface string) *FirewallConfigBuilder {
+func (b *FirewallConfigBuilder) TunnelInterface(iface string, ip netip.Addr) *FirewallConfigBuilder {
 	b.cfg.TunnelInterface = iface
+	b.cfg.TunnelIP = ip
 	return b
 }
 


### PR DESCRIPTION
Addresses an issue with some protocols where old living connections established before the VPN tunnel is up can send packets to the server using wrong source address.