### PR TITLE
LVPN-11033: Remove virtual location from CLI

### DIFF
--- a/cli/cli_cities.go
+++ b/cli/cli_cities.go
@@ -44,18 +44,16 @@ func (c *cmd) Cities(ctx *cli.Context) error {
 		return formatError(errors.New(CitiesNotFoundError))
 	}
 
-	footer := footerForServerGroupsList(resp.Servers)
 	formattedList, err := columns(resp.Servers,
 		serverNameLen,
 		formatServerName,
-		footer,
 	)
 	if err == nil {
 		fmt.Println(formattedList)
 	} else {
 		log.Error(err)
 
-		columns, _ := formatTable(resp.Servers, serverNameLen, formatServerName, 1, footer)
+		columns, _ := formatTable(resp.Servers, serverNameLen, formatServerName, 1)
 		fmt.Println(columns)
 	}
 	return nil

--- a/cli/cli_countries.go
+++ b/cli/cli_countries.go
@@ -24,15 +24,13 @@ func (c *cmd) Countries(ctx *cli.Context) error {
 		return formatError(err)
 	}
 
-	footer := footerForServerGroupsList(resp.Servers)
 	countryList, err := columns(resp.Servers,
 		serverNameLen,
 		formatServerName,
-		footer,
 	)
 	if err != nil {
 		log.Error(err)
-		countries, _ := formatTable(resp.Servers, serverNameLen, formatServerName, 1, footer)
+		countries, _ := formatTable(resp.Servers, serverNameLen, formatServerName, 1)
 		fmt.Println(countries)
 	} else {
 		fmt.Println(countryList)

--- a/cli/cli_groups.go
+++ b/cli/cli_groups.go
@@ -24,17 +24,15 @@ func (c *cmd) Groups(ctx *cli.Context) error {
 		return formatError(fmt.Errorf(MsgListIsEmpty, "server groups"))
 	}
 
-	footer := footerForServerGroupsList(resp.Servers)
 	groupList, err := columns(
 		resp.Servers,
 		serverNameLen,
 		formatServerName,
-		footer,
 	)
 
 	if err != nil {
 		log.Error(err)
-		countries, _ := formatTable(resp.Servers, serverNameLen, formatServerName, 1, footer)
+		countries, _ := formatTable(resp.Servers, serverNameLen, formatServerName, 1)
 		fmt.Println(countries)
 	} else {
 		fmt.Println(groupList)

--- a/cli/cli_status.go
+++ b/cli/cli_status.go
@@ -59,11 +59,7 @@ func Status(resp *pb.StatusResponse) string {
 	}
 
 	if resp.Name != "" {
-		serverName := resp.Name
-		if resp.VirtualLocation {
-			serverName += " - Virtual"
-		}
-		b.WriteString(fmt.Sprintf("Server: %s\n", serverName))
+		b.WriteString(fmt.Sprintf("Server: %s\n", resp.Name))
 	}
 
 	if resp.Hostname != "" {

--- a/cli/messages.go
+++ b/cli/messages.go
@@ -362,9 +362,8 @@ Provide a [transfer_id] argument to list files in the specified transfer.`
 
 	MsgSetVirtualLocationUsageText   = "Enables or disables access to virtual locations. Virtual location servers let you access more locations worldwide."
 	MsgSetVirtualLocationDescription = "Enables or disables access to virtual locations."
-	MsgFooterVirtualLocationNote     = "* Virtual location servers"
 
-	MsgShowListOfServers = "Shows a list of %s where servers are available.\n\nLocations marked with a different color in the list are virtual. Virtual location servers let you connect to more places worldwide. They run on dedicated physical servers, which are placed outside the intended location but configured to use its IP address."
+	MsgShowListOfServers = "Shows a list of %s where servers are available."
 
 	SetPqUnavailable       = "Post-quantum encryption is not compatible with %s. Switch to NordLynx to use this encryption."
 	SetTechnologyDisablePQ = "This setting is not compatible with post-quantum encryption. To use %s, turn off post-quantum encryption first."

--- a/cli/terminal.go
+++ b/cli/terminal.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NordSecurity/nordvpn-linux/daemon/pb"
 	"github.com/NordSecurity/nordvpn-linux/internal"
 	"github.com/NordSecurity/nordvpn-linux/log"
-	"github.com/fatih/color"
 	"golang.org/x/term"
 )
 
@@ -68,23 +67,7 @@ func serverNameLen(server *pb.ServerGroup) int {
 }
 
 func formatServerName(server *pb.ServerGroup) string {
-	if server.VirtualLocation && isStdoutTerminal() {
-		return color.HiBlueString(server.Name)
-	}
 	return server.Name
-}
-
-func footerForServerGroupsList(servers []*pb.ServerGroup) string {
-	if !isStdoutTerminal() {
-		return ""
-	}
-
-	for _, server := range servers {
-		if server.VirtualLocation {
-			return color.HiBlueString(MsgFooterVirtualLocationNote)
-		}
-	}
-	return ""
 }
 
 func checkUsernamePasswordIsEmpty(username, password string) error {
@@ -104,14 +87,13 @@ func columns[T any](
 	data []T,
 	length func(T) int,
 	display func(T) string,
-	footer string,
 ) (string, error) {
 	width, _, err := cliDimensions()
 	if err != nil {
 		return "", err
 	}
 
-	return formatTable(data, length, display, width, footer)
+	return formatTable(data, length, display, width)
 }
 
 func formatTable[T any](
@@ -119,7 +101,6 @@ func formatTable[T any](
 	length func(T) int,
 	display func(T) string,
 	width int,
-	footer string,
 ) (string, error) {
 	if width <= 0 {
 		return "", fmt.Errorf("invalid width size")
@@ -165,10 +146,6 @@ func formatTable[T any](
 			// add new line for rows, except last one
 			builder.WriteString("\n")
 		}
-	}
-
-	if len(footer) > 0 {
-		builder.WriteString("\n\n" + footer)
 	}
 
 	return builder.String(), nil

--- a/cli/terminal_test.go
+++ b/cli/terminal_test.go
@@ -172,7 +172,6 @@ func TestSplitDataInColumns(t *testing.T) {
 				func(item string) int { return len(item) },
 				func(item string) string { return item },
 				test.width,
-				"",
 			)
 			if test.expectsError {
 				assert.Error(t, err)

--- a/cmd/daemon/events_linux.go
+++ b/cmd/daemon/events_linux.go
@@ -47,7 +47,6 @@ func (*dummyAnalytics) NotifyDedicatedServerStatus(
 	return nil
 }
 func (*dummyAnalytics) NotifyLANDiscovery(bool) error                    { return nil }
-func (*dummyAnalytics) NotifyVirtualLocation(bool) error                 { return nil }
 func (*dummyAnalytics) NotifyPostquantumVpn(bool) error                  { return nil }
 func (*dummyAnalytics) NotifyAppStartTime(int64) error                   { return nil }
 func (*dummyAnalytics) OnPauseCancelled(events.DataPauseCancelled) error { return nil }

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -147,7 +147,6 @@ type SettingsPublisher interface {
 	NotifyMeshnet(bool) error
 	NotifyDefaults(any) error
 	NotifyLANDiscovery(bool) error
-	NotifyVirtualLocation(bool) error
 	NotifyPostquantumVpn(bool) error
 }
 
@@ -185,7 +184,6 @@ func (s *SettingsEvents) Subscribe(to SettingsPublisher) {
 	s.Meshnet.Subscribe(to.NotifyMeshnet)
 	s.Defaults.Subscribe(to.NotifyDefaults)
 	s.LANDiscovery.Subscribe(to.NotifyLANDiscovery)
-	s.VirtualLocation.Subscribe(to.NotifyVirtualLocation)
 	s.PostquantumVPN.Subscribe(to.NotifyPostquantumVpn)
 }
 

--- a/events/logger/settings.go
+++ b/events/logger/settings.go
@@ -85,11 +85,6 @@ func (l *DaemonSettingsSubscriber) NotifyLANDiscovery(data bool) error {
 	return nil
 }
 
-func (l *DaemonSettingsSubscriber) NotifyVirtualLocation(data bool) error {
-	printSettingsChange("Virtual location", boolToString(data))
-	return nil
-}
-
 func (l *DaemonSettingsSubscriber) NotifyPostquantumVpn(data bool) error {
 	printSettingsChange("PostquantumVpn", boolToString(data))
 	return nil

--- a/events/moose/moose.go
+++ b/events/moose/moose.go
@@ -520,13 +520,6 @@ func (s *Subscriber) NotifyLANDiscovery(data bool) error {
 	return nil
 }
 
-func (s *Subscriber) NotifyVirtualLocation(data bool) error {
-	if err := s.response(moose.NordvpnappSetContextApplicationNordvpnappConfigUserPreferencesVirtualServerEnabledValue(data)); err != nil {
-		return fmt.Errorf("setting virtual location preference (enabled=%v): %w", data, err)
-	}
-	return nil
-}
-
 func (s *Subscriber) NotifyPostquantumVpn(data bool) error {
 	if err := s.response(moose.NordvpnappSetContextApplicationNordvpnappConfigUserPreferencesPostQuantumEnabledValue(data)); err != nil {
 		return fmt.Errorf("setting post-quantum VPN preference (enabled=%v): %w", data, err)

--- a/test/qa/lib/server.py
+++ b/test/qa/lib/server.py
@@ -90,6 +90,49 @@ def _exclude_dedicated_ip_servers(servers: list[dict]) -> list[dict]:
     return non_dip_servers
 
 
+def _server_is_virtual(server: dict) -> bool:
+    """
+    Returns True if the server is a virtual-location server.
+
+    The Core API exposes this as a "virtual_location" entry inside the
+    server's "specifications" list. The value is a *string* ("True"/"False")
+    nested under "values". Physical servers omit the spec entirely, so an
+    absent spec is treated as non-virtual.
+    """
+    for spec in server.get("specifications", []):
+        if spec.get("identifier") != "virtual_location":
+            continue
+
+        values = spec.get("values", [])
+        if not values:
+            return False
+
+        value = values[0].get("value")
+        # value is normally the string "True"/"False", but guard against a bool too
+        if isinstance(value, str):
+            return value.strip().lower() == "true"
+        return bool(value)
+
+    return False
+
+
+def _exclude_non_virtual_servers(servers: list[dict]) -> list[dict]:
+    """
+    Returns the input list with any non virtual servers removed.
+
+    The API returns both physical and virtual servers. This helps
+    us remove all the physical ones from the list.
+
+    Example:
+        _exclude_non_virtual_servers([ph_server, v_server])  # -> [v_server]
+    """
+    virtual_servers: list[dict] = []
+    for server in servers:
+        if _server_is_virtual(server):
+            virtual_servers.append(server)
+    return virtual_servers
+
+
 def get_hostname_by(technology="", protocol="", obfuscated="", group_name="", exclude_dip=False):
     """
     Returns server name and hostname from core API.
@@ -131,6 +174,49 @@ def get_hostname_by(technology="", protocol="", obfuscated="", group_name="", ex
         response = _exclude_dedicated_ip_servers(response)
         if not response:
             return None
+
+    server = random.choice(response)
+    validate_server(server_json=str(server), tech_id=tech_id, group_id=group_id)
+    return ServerInfo(server_info=server)
+
+
+def get_random_virtual_server(technology="", protocol="", obfuscated="", group_name=""):
+    """Returns a virtual server's name and hostname from core API."""
+
+    (tech_id, group_id) = get_request_parameters(technology, protocol, obfuscated, group_name)
+
+    # api limits
+    time.sleep(2)
+
+    limit = 3000
+
+    url = f"https://api.nordvpn.com/v1/servers?limit={limit}&filters[servers.status]=online&filters[servers_technologies][id]={tech_id}&filters[servers_groups][id]={group_id}"
+    logging.debug(url)
+
+    response = requests.get(url, timeout=5)
+    content_type = response.headers.get("Content-Type", "")
+
+    assert response.ok, (
+        f"Core API HTTP {response.status_code}, ct={content_type}, "
+        f"body={response.text[:300]!r}"
+    )
+    assert "json" in content_type.lower(), (
+        f"Core API returned non-JSON response, ct={content_type}, "
+        f"body={response.text[:300]!r}"
+    )
+
+    response = response.json()
+
+    assert len(response) > 0, "Core API returned an empty servers list"
+    logging.debug("Core API response (truncated): %s", str(response)[:300])
+
+    response = _exclude_dedicated_ip_servers(response)
+    if not response:
+        return None
+
+    response = _exclude_non_virtual_servers(response)
+    if not response:
+        return None
 
     server = random.choice(response)
     validate_server(server_json=str(server), tech_id=tech_id, group_id=group_id)

--- a/test/qa/test_autoconnect.py
+++ b/test/qa/test_autoconnect.py
@@ -1,4 +1,3 @@
-import random
 import warnings
 
 import pytest
@@ -147,41 +146,6 @@ def test_autoconnect_to_obfuscated_group(tech, proto, obfuscated, group):
 
     lib.set_technology_and_protocol(tech, proto, obfuscated)
     autoconnect_base_test(group)
-
-
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
-def test_autoconnect_virtual_country(tech, proto, obfuscated):
-    """Manual TC: LVPN-8549"""
-
-    lib.set_technology_and_protocol(tech, proto, obfuscated)
-    sh.nordvpn.set("virtual-location", "on")
-
-    virtual_countries = lib.get_virtual_countries()
-    assert len(virtual_countries) > 0, "Virtual countries should be available"
-    country = random.choice(virtual_countries)
-
-    autoconnect_base_test(country)
-
-
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
-def test_autoconnect_virtual_country_disabled(tech, proto, obfuscated):
-    """Manual TC: LVPN-8548"""
-
-    lib.set_technology_and_protocol(tech, proto, obfuscated)
-
-    # fix in LVPN-8449
-    # sh.nordvpn.set("virtual-location", "on")
-    # virtual_countries = lib.get_virtual_countries()
-    # assert len(virtual_countries) > 0
-    # country = random.choice(virtual_countries)
-    # until then chose a country that has only virtual server locations
-    country = "AF"
-
-    sh.nordvpn.set("virtual-location", "off")
-
-    with pytest.raises(sh.ErrorReturnCode_1) as _:
-        output = sh_no_tty.nordvpn.set.autoconnect.on(country)
-        assert "Please enable virtual location access to connect to this server." in output, "Should show virtual location access error"
 
 
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES)

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -599,3 +599,13 @@ def test_ens_connection_limit(reconnect: bool, pause: bool):
 
         assert "Disconnected" in sh.nordvpn.status(), "Wrong status"
         assert network.is_available(), "Network should be available"
+
+
+@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
+def test_connect_to_virtual_server(tech, proto, obfuscated):
+    lib.set_technology_and_protocol(tech, proto, obfuscated)
+
+    server_info = server.get_random_virtual_server(tech, proto, obfuscated)
+    connect_base_test((tech, proto, obfuscated), server_info.hostname.split(".")[0], server_info.name, server_info.hostname)
+
+    disconnect_base_test()

--- a/test/qa/test_connect.py
+++ b/test/qa/test_connect.py
@@ -487,21 +487,6 @@ def test_status_connected(tech, proto, obfuscated):
     disconnect_base_test()
 
 
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
-def test_connect_to_virtual_server(tech, proto, obfuscated):
-    """Manual TC: LVPN-5316"""
-
-    lib.set_technology_and_protocol(tech, proto, obfuscated)
-    sh.nordvpn.set("virtual-location", "on")
-    virtual_countries = lib.get_virtual_countries()
-
-    assert len(virtual_countries) > 0, "Virtual countries should be available"
-    country = random.choice(virtual_countries)
-
-    connect_base_test((tech, proto, obfuscated), country)
-    disconnect_base_test()
-
-
 @pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.TECHNOLOGIES_BASIC1)
 def test_connect_to_post_quantum_server(tech, proto, obfuscated):
     """Manual TC: LVPN-5794"""
@@ -571,36 +556,6 @@ def test_connect_to_dedicated_ip(tech, proto, obfuscated):
 
     assert network.is_disconnected(), "Network should be disconnected after disconnect"
     assert "nordlynx" not in sh.ip.a() and "nordtun" not in sh.ip.a(), "VPN interfaces should be removed"
-
-
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.STANDARD_TECHNOLOGIES)
-def test_connect_fails_virtual_location_disabled(tech, proto, obfuscated):
-    """Manual TC: LVPN-8533"""
-
-    lib.set_technology_and_protocol(tech, proto, obfuscated)
-
-    virtual_country = lib.get_random_virtual_country()
-
-    sh.nordvpn.set("virtual-location", "off")
-
-    with pytest.raises(sh.ErrorReturnCode_1) as ex:
-        sh.nordvpn(get_alias(), virtual_country)
-
-    assert "Please enable virtual location access to connect to this server." in ex.value.stdout.decode(), "Should show virtual location disabled error"
-
-
-@pytest.mark.parametrize(("tech", "proto", "obfuscated"), lib.OBFUSCATED_TECHNOLOGIES)
-def test_obfuscation_prevents_virtual_location_connection(tech, proto, obfuscated):
-    """Manual TC: LVPN-5771"""
-
-    virtual_country = lib.get_random_virtual_country()
-
-    lib.set_technology_and_protocol(tech, proto, obfuscated)
-
-    with pytest.raises(sh.ErrorReturnCode_1) as ex:
-        sh.nordvpn(get_alias(), virtual_country)
-
-    assert "The specified server is not available at the moment or does not support your connection settings." in ex.value.stdout.decode(), "Should show server unavailable error"
 
 
 @pytest.mark.parametrize(("reconnect", "pause"), [(True, True), (True, False), (False, False)])


### PR DESCRIPTION
This should remove everything related to virtual location from the CLI, except the set command.
This should also remove the virtual_server_enabled metric from the moose.