### PR TITLE
LVPN-11045: remove URL links from popups announcements

### DIFF
--- a/gui/lib/i18n/en/a11y.i18n.json
+++ b/gui/lib/i18n/en/a11y.i18n.json
@@ -13,5 +13,6 @@
   "expandibleEntryExpanded": "Expanded",
   "expandibleEntryCollapsed": "Collapsed",
   "clear": "Clear",
-  "popupWithContent": "$title. $message"
+  "popupWithContent": "$title. $message",
+  "linkWithinPopup": "Link $name"
 }

--- a/gui/lib/i18n/strings.g.dart
+++ b/gui/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 711
+/// Strings: 712
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/gui/lib/i18n/strings_en.g.dart
+++ b/gui/lib/i18n/strings_en.g.dart
@@ -99,6 +99,9 @@ class Translations$a11y$en {
 
 	/// en: '$title. $message'
 	String popupWithContent({required Object title, required Object message}) => '${title}. ${message}';
+
+	/// en: 'Link $name'
+	String linkWithinPopup({required Object name}) => 'Link ${name}';
 }
 
 // Path: cities
@@ -2248,6 +2251,7 @@ extension on Translations {
 			'a11y.expandibleEntryCollapsed' => 'Collapsed',
 			'a11y.clear' => 'Clear',
 			'a11y.popupWithContent' => ({required Object title, required Object message}) => '${title}. ${message}',
+			'a11y.linkWithinPopup' => ({required Object name}) => 'Link ${name}',
 			'cities.tirana' => 'Tirana',
 			'cities.algiers' => 'Algiers',
 			'cities.addis_ababa' => 'Addis Ababa',
@@ -2744,9 +2748,9 @@ extension on Translations {
 			'ui.searchServersHint' => 'Search countries, cities, or servers',
 			'ui.citiesAvailable' => ({required Object n}) => '${n} cities available',
 			'ui.virtual' => 'Virtual',
-			'ui.dedicatedIp' => 'Dedicated IP',
 			_ => null,
 		} ?? switch (path) {
+			'ui.dedicatedIp' => 'Dedicated IP',
 			'ui.dedicatedServer' => 'Dedicated Server',
 			'ui.doubleVpn' => 'Double VPN',
 			'ui.onionOverVpn' => 'Onion over VPN',

--- a/gui/lib/widgets/popups/popup.dart
+++ b/gui/lib/widgets/popups/popup.dart
@@ -8,6 +8,7 @@ import 'package:nordvpn/i18n/strings.g.dart';
 import 'package:nordvpn/internal/scaler_responsive_box.dart';
 import 'package:nordvpn/theme/popup_theme.dart';
 import 'package:nordvpn/widgets/dynamic_theme_image.dart';
+import 'package:nordvpn/widgets/rich_text_markdown_links.dart';
 
 // Base class providing "template" for popups.
 abstract class Popup extends ConsumerWidget {
@@ -114,7 +115,10 @@ abstract class Popup extends ConsumerWidget {
   @protected
   String joinSemanticLabel(String heading, String body) => body.isEmpty
       ? heading
-      : t.a11y.popupWithContent(title: heading, message: body);
+      : t.a11y.popupWithContent(
+          title: heading,
+          message: dropURLLinkFromPopupMessage(body),
+        );
 
   Widget? get leadingIcon => null;
   Widget buildContent(BuildContext context, WidgetRef ref);

--- a/gui/lib/widgets/rich_text_markdown_links.dart
+++ b/gui/lib/widgets/rich_text_markdown_links.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:nordvpn/i18n/strings.g.dart';
 import 'package:nordvpn/logger.dart';
 import 'package:nordvpn/theme/support_link_theme.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -26,13 +27,20 @@ class RichTextMarkdownLinks extends StatefulWidget {
   State<RichTextMarkdownLinks> createState() => _RichTextMarkdownLinksState();
 }
 
-class _RichTextMarkdownLinksState extends State<RichTextMarkdownLinks> {
-  // Matches [label](url)
-  final _linkPattern = RegExp(
-    r'\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)',
-    caseSensitive: false,
-  );
+// Matches [label](url)
+final _linkPattern = RegExp(
+  r'\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)',
+  caseSensitive: false,
+);
 
+// drop the URL, if present in text arg, and keep only the label for the sake of
+// screen reader announcements clarity
+String dropURLLinkFromPopupMessage(String text) => text.replaceAllMapped(
+  _linkPattern,
+  (match) => t.a11y.linkWithinPopup(name: match.group(1)!),
+);
+
+class _RichTextMarkdownLinksState extends State<RichTextMarkdownLinks> {
   // keep a list with all the TapGestureRecognizer because they need to be disposed manually
   final List<TapGestureRecognizer> _tapGestureRecognizers = [];
 

--- a/gui/test/widgets/popup_announcements_test.dart
+++ b/gui/test/widgets/popup_announcements_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nordvpn/data/models/popup_metadata.dart';
 import 'package:nordvpn/i18n/strings.g.dart';
@@ -112,6 +113,27 @@ void main() {
         t.a11y.popupWithContent(title: header, message: message),
       );
       expect(announced, isNot(contains(t.ui.nordVpn)));
+    });
+
+    // If a Popup comes with an URL, then TTS engine must not read out the whole URL, only its name
+    testWidgets('announcement reads link, without its URL', (tester) async {
+      await tester.setupWidgetTest(
+        infoPopup(
+          text:
+              "Check the [test name URL](https://example.com/help?utm_source=app).",
+        ),
+      );
+
+      final announced = tester.takeAnnouncements().single.message;
+      expect(
+        announced,
+        t.a11y.popupWithContent(
+          title: title,
+          message: "Check the ${t.a11y.linkWithinPopup(name: "test name URL")}.",
+        ),
+      );
+      expect(announced, isNot(contains("example.com")));
+      expect(announced, isNot(contains("](")));
     });
 
     testWidgets('popup with an empty message announces its title alone', (


### PR DESCRIPTION
Recently new bracket of popups has been added, ones coming with an URL inside the popup's message. This caused screen reader announce the whole body message, along the URL.

This PR fixes TTS announcements, so now only URL label is announced.