### PR TITLE
LVPN-10896: NW reported as obfuscated

### DIFF
--- a/gui/lib/data/providers/vpn_status_controller.dart
+++ b/gui/lib/data/providers/vpn_status_controller.dart
@@ -14,6 +14,7 @@ import 'package:nordvpn/pb/daemon/state.pbenum.dart';
 import 'package:nordvpn/pb/daemon/status.pb.dart';
 import 'package:nordvpn/pb/daemon/uievent.pbenum.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:nordvpn/data/models/vpn_protocol.dart';
 
 part 'vpn_status_controller.g.dart';
 
@@ -131,6 +132,7 @@ class VpnStatusController extends _$VpnStatusController
     }
 
     final vpnStatus = state.value!.copyWith(
+      protocol: convertToVpnProtocol(status.technology, status.protocol),
       ip: status.ip.isNotEmpty ? status.ip : null,
       hostname: status.hostname.isNotEmpty ? status.hostname : null,
       country: status.hasCountry()

--- a/gui/lib/data/providers/vpn_status_controller.g.dart
+++ b/gui/lib/data/providers/vpn_status_controller.g.dart
@@ -37,7 +37,7 @@ final class VpnStatusControllerProvider
 }
 
 String _$vpnStatusControllerHash() =>
-    r'113717b0fa41f410f2e1f32cba69c977eed28ee1';
+    r'cb4471f33d68a8a0f13c49f9381c69e848773851';
 
 /// Handles the VPN connection functionality
 

--- a/gui/lib/vpn/connection_card_label.dart
+++ b/gui/lib/vpn/connection_card_label.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nordvpn/data/models/server_group_extension.dart';
 import 'package:nordvpn/data/models/server_info.dart';
+import 'package:nordvpn/data/models/vpn_protocol.dart';
 import 'package:nordvpn/data/models/vpn_status.dart';
 import 'package:nordvpn/i18n/string_translation_extension.dart';
 import 'package:nordvpn/i18n/strings.g.dart';
@@ -53,7 +54,7 @@ final class ConnectionCardLabel extends StatelessWidget {
     }
 
     var serverType = "";
-    if (vpnStatus.isObfuscated) {
+    if (vpnStatus.protocol == VpnProtocol.nordWhisper) {
       serverType = labelForServerType(ServerType.obfuscated);
     } else {
       final serverGroup = vpnStatus.connectionParameters.group

--- a/gui/test/data/models/vpn_protocol_test.dart
+++ b/gui/test/data/models/vpn_protocol_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nordvpn/data/models/vpn_protocol.dart';
+import 'package:nordvpn/pb/daemon/config/protocol.pbenum.dart';
+import 'package:nordvpn/pb/daemon/config/technology.pbenum.dart';
+
+void main() {
+  // The daemon reports a (technology, protocol) pair, the GUI works with a
+  // single protocol value.
+  final cases = [
+    (
+      name: "NordLynx ignores the protocol field",
+      technology: Technology.NORDLYNX,
+      protocol: Protocol.UDP,
+      expected: VpnProtocol.nordlynx,
+    ),
+    (
+      name: "OpenVPN over UDP",
+      technology: Technology.OPENVPN,
+      protocol: Protocol.UDP,
+      expected: VpnProtocol.openVpnUdp,
+    ),
+    (
+      name: "OpenVPN over TCP",
+      technology: Technology.OPENVPN,
+      protocol: Protocol.TCP,
+      expected: VpnProtocol.openVpnTcp,
+    ),
+    (
+      name: "NordWhisper is reported with the Webtunnel protocol",
+      technology: Technology.NORDWHISPER,
+      protocol: Protocol.Webtunnel,
+      expected: VpnProtocol.nordWhisper,
+    ),
+    (
+      name: "unknown technology maps to unknown",
+      technology: Technology.UNKNOWN_TECHNOLOGY,
+      protocol: Protocol.UNKNOWN_PROTOCOL,
+      expected: VpnProtocol.unknown,
+    ),
+  ];
+
+  for (final testCase in cases) {
+    test(testCase.name, () {
+      expect(
+        convertToVpnProtocol(testCase.technology, testCase.protocol),
+        testCase.expected,
+      );
+    });
+  }
+}

--- a/gui/test/data/providers/vpn_status_controller_test.dart
+++ b/gui/test/data/providers/vpn_status_controller_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nordvpn/data/models/vpn_protocol.dart';
+import 'package:nordvpn/data/providers/app_state_provider.dart';
+import 'package:nordvpn/data/providers/vpn_status_controller.dart';
+import 'package:nordvpn/data/repository/vpn_repository.dart';
+import 'package:nordvpn/i18n/country_names_service.dart';
+import 'package:nordvpn/pb/daemon/config/protocol.pbenum.dart';
+import 'package:nordvpn/pb/daemon/config/technology.pbenum.dart';
+import 'package:nordvpn/pb/daemon/status.pb.dart';
+import 'package:nordvpn/service_locator.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../../utils/fake_shared_preferences.dart';
+
+final class _FakeVpnRepository implements VpnRepository {
+  final StatusResponse status;
+
+  _FakeVpnRepository(this.status);
+
+  @override
+  Future<StatusResponse> fetchStatus() async => status;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _FakeAppStateChange implements AppStateChange {
+  @override
+  void addVpnStatusObserver(VpnStatusObserver observer) {}
+
+  @override
+  void removeVpnStatusObserver(VpnStatusObserver observer) {}
+
+  @override
+  void addPauseEventsObserver(PauseEventsObserver observer) {}
+
+  @override
+  void removePauseEventsObserver(PauseEventsObserver observer) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferencesAsyncPlatform.instance = FakeSharedPreferencesAsync();
+    await initServiceLocator();
+    sl<CountryNamesService>().register(code: "LT", name: "Lithuania");
+  });
+
+  StatusResponse statusResponse({
+    required Technology technology,
+    required Protocol protocol,
+  }) {
+    return StatusResponse(
+      state: ConnectionState.CONNECTED,
+      technology: technology,
+      protocol: protocol,
+      ip: "127.0.0.1",
+      hostname: "lt123.nordvpn.com",
+      country: "Lithuania",
+      city: "Vilnius",
+      parameters: ConnectionParameters(source: ConnectionSource.MANUAL),
+    );
+  }
+
+  final nordLynx = statusResponse(
+    technology: Technology.NORDLYNX,
+    protocol: Protocol.UDP,
+  );
+  final nordWhisper = statusResponse(
+    technology: Technology.NORDWHISPER,
+    protocol: Protocol.Webtunnel,
+  );
+
+  Future<ProviderContainer> buildController() async {
+    final container = ProviderContainer(
+      overrides: [
+        vpnRepositoryProvider.overrideWithValue(_FakeVpnRepository(nordLynx)),
+        appStateProvider.overrideWithValue(_FakeAppStateChange()),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(vpnStatusControllerProvider.future);
+    return container;
+  }
+
+  test("a status change refreshes the protocol", () async {
+    final container = await buildController();
+    expect(
+      container.read(vpnStatusControllerProvider).value!.protocol,
+      VpnProtocol.nordlynx,
+    );
+
+    container
+        .read(vpnStatusControllerProvider.notifier)
+        .onVpnStatusChanged(nordWhisper);
+
+    expect(
+      container.read(vpnStatusControllerProvider).value!.protocol,
+      VpnProtocol.nordWhisper,
+    );
+  });
+
+  test("the state converges so a repeated status is ignored", () async {
+    final container = await buildController();
+
+    container
+        .read(vpnStatusControllerProvider.notifier)
+        .onVpnStatusChanged(nordWhisper);
+
+    final state = container.read(vpnStatusControllerProvider).value!;
+    expect(state.isEqualToStatusResponse(nordWhisper), isTrue);
+  });
+}

--- a/gui/test/data/providers/vpn_status_controller_test.dart
+++ b/gui/test/data/providers/vpn_status_controller_test.dart
@@ -88,23 +88,6 @@ void main() {
     return container;
   }
 
-  test("a status change refreshes the protocol", () async {
-    final container = await buildController();
-    expect(
-      container.read(vpnStatusControllerProvider).value!.protocol,
-      VpnProtocol.nordlynx,
-    );
-
-    container
-        .read(vpnStatusControllerProvider.notifier)
-        .onVpnStatusChanged(nordWhisper);
-
-    expect(
-      container.read(vpnStatusControllerProvider).value!.protocol,
-      VpnProtocol.nordWhisper,
-    );
-  });
-
   test("the state converges so a repeated status is ignored", () async {
     final container = await buildController();
 

--- a/gui/test/vpn/connection_card_label_test.dart
+++ b/gui/test/vpn/connection_card_label_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nordvpn/data/models/vpn_protocol.dart';
+import 'package:nordvpn/data/models/vpn_status.dart';
+import 'package:nordvpn/i18n/strings.g.dart';
+import 'package:nordvpn/pb/daemon/config/group.pbenum.dart';
+import 'package:nordvpn/pb/daemon/status.pb.dart';
+import 'package:nordvpn/service_locator.dart';
+import 'package:nordvpn/vpn/connection_card_label.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+import '../utils/fake_shared_preferences.dart';
+import '../utils/test_helpers.dart';
+
+void main() {
+  setUpAll(() async {
+    SharedPreferencesAsyncPlatform.instance = FakeSharedPreferencesAsync();
+    await initServiceLocator();
+  });
+
+  VpnStatus vpnStatus({
+    required VpnProtocol protocol,
+    ConnectionState state = ConnectionState.CONNECTED,
+    ServerGroup group = ServerGroup.UNDEFINED,
+    bool isObfuscated = false,
+  }) {
+    return VpnStatus(
+      ip: "127.0.0.1",
+      hostname: "lt123.nordvpn.com",
+      city: null,
+      country: null,
+      status: state,
+      protocol: protocol,
+      isVirtualLocation: false,
+      isObfuscated: isObfuscated,
+      connectionParameters: ConnectionParameters(
+        source: ConnectionSource.MANUAL,
+        group: group,
+      ),
+      isMeshnetRouting: false,
+    );
+  }
+
+  List<String> labelTexts(WidgetTester tester) {
+    final row = tester.widget<Row>(find.byKey(ConnectionCardLabel.labelKey));
+    return row.children
+        .whereType<Text>()
+        .map((text) => text.data ?? "")
+        .toList();
+  }
+
+  final cases = [
+    (
+      name: "NordWhisper is labelled as obfuscated",
+      protocol: VpnProtocol.nordWhisper,
+      group: ServerGroup.UNDEFINED,
+      isObfuscated: false,
+      serverType: t.ui.obfuscated,
+    ),
+    (
+      name: "a plain NordLynx connection has no server type",
+      protocol: VpnProtocol.nordlynx,
+      group: ServerGroup.UNDEFINED,
+      isObfuscated: false,
+      serverType: null,
+    ),
+    (
+      name: "a specialty group is labelled with its own name",
+      protocol: VpnProtocol.nordlynx,
+      group: ServerGroup.DOUBLE_VPN,
+      isObfuscated: false,
+      serverType: t.ui.doubleVpn,
+    ),
+    ( // todo: change this later when OVPN drops obfuscation
+      name: "the obfuscated group is still labelled as obfuscated",
+      protocol: VpnProtocol.openVpnTcp,
+      group: ServerGroup.OBFUSCATED,
+      isObfuscated: true,
+      serverType: t.ui.obfuscated,
+    ),
+    ( // todo: change this later when OVPN drops obfuscation
+      name: "the daemon obfuscated flag alone does not add a label",
+      protocol: VpnProtocol.openVpnTcp,
+      group: ServerGroup.UNDEFINED,
+      isObfuscated: true,
+      serverType: null,
+    ),
+  ];
+
+  for (final testCase in cases) {
+    testWidgets(testCase.name, (tester) async {
+      await tester.setupWidgetTest(
+        ConnectionCardLabel(
+          vpnStatus: vpnStatus(
+            protocol: testCase.protocol,
+            group: testCase.group,
+            isObfuscated: testCase.isObfuscated,
+          ),
+        ),
+      );
+
+      expect(labelTexts(tester), [
+        t.ui.secured,
+        if (testCase.serverType != null) testCase.serverType!,
+      ]);
+    });
+  }
+
+  testWidgets("no server type while disconnected", (tester) async {
+    await tester.setupWidgetTest(
+      ConnectionCardLabel(
+        vpnStatus: vpnStatus(
+          protocol: VpnProtocol.nordWhisper,
+          state: ConnectionState.DISCONNECTED,
+        ),
+      ),
+    );
+
+    expect(labelTexts(tester), [t.ui.notSecured]);
+  });
+}


### PR DESCRIPTION
When protocol is set to NordWhisper simple and auto connections are presented as `Obfuscated` in the GUI and no more responds to `Obfuscate=on/off` settings