### PR TITLE
LVPN-11038: Fix Snap logging in tests

### DIFF
--- a/ci/install_snap.sh
+++ b/ci/install_snap.sh
@@ -18,6 +18,9 @@ echo "~~~INSTALL new SNAP package"
 find "${WORKDIR}"/ -type f -name "*amd64.snap" \
 	-exec sudo snap install --dangerous "{}" +
 
+echo "~~~REDIRECT logs of SNAP to daemon.log"
+redirect_logs
+
 echo "~~~GRANT permissions - connect snap interfaces"
 snap_connect_interfaces
 

--- a/ci/snap_functions.sh
+++ b/ci/snap_functions.sh
@@ -37,3 +37,22 @@ wait_for_daemon() {
         sleep 1
     done
 }
+
+redirect_logs() {
+    local log_path="${LOGS_FOLDER}"/daemon.log
+
+    mkdir -p "$(dirname "$log_path")"
+    touch "$log_path"
+    chmod 777 "$log_path"
+
+    sudo mkdir -p /etc/systemd/system/snap.nordvpn.nordvpnd.service.d
+
+    cat <<EOF | sudo tee /etc/systemd/system/snap.nordvpn.nordvpnd.service.d/override.conf > /dev/null
+[Service]
+StandardOutput=append:$log_path
+StandardError=append:$log_path
+EOF
+
+    sudo systemctl daemon-reload
+    sudo systemctl restart snap.nordvpn.nordvpnd.service
+}

--- a/ci/test_snap.sh
+++ b/ci/test_snap.sh
@@ -15,19 +15,6 @@ rm -fr "${GOCOVERDIR}"
 ORIG_COVERDIR="$GOCOVERDIR"
 GOCOVERDIR="/tmp/"
 
-add_daemon_logs() {
-    # append the snap daemon logs into the daemon.log file
-    {
-        echo "----------------------------------------- "
-        echo "----------- start daemon log ------------ "
-        echo "----------------------------------------- "
-    } >> "${LOGS_FOLDER}/daemon.log"
-
-    sudo journalctl -b -u snap.nordvpn.nordvpnd.service | tee -a "${LOGS_FOLDER}/daemon.log" > /dev/null
-}
-
-trap add_daemon_logs EXIT INT TERM
-
 "${WORKDIR}/ci/qa_run_tests.sh" "$@"
 
 # restore to original value


### PR DESCRIPTION
Redirect logs from `journalctl` to daemon.log file, in custom location. Quality of life improvement, since otherwise test suite logs appear in top of file, and actual log is being attached to the end of file, which makes reading logs inconvenient.