### PR TITLE
Remove duplicate target adding in rustup

### DIFF
--- a/ci/build_libtelio.sh
+++ b/ci/build_libtelio.sh
@@ -13,7 +13,6 @@ rm -rf "${lib_root}/current"
 
 pushd "${WORKDIR}/build/foss/libtelio"
 rustup target add aarch64-unknown-linux-gnu \
-    aarch64-unknown-linux-gnu \
     arm-unknown-linux-gnueabi \
     armv7-unknown-linux-gnueabihf \
     i686-unknown-linux-gnu


### PR DESCRIPTION
Remove our undying love for `aarch64-unknown-linux-gnu` by only downloading it once instead of twice